### PR TITLE
Add back isInstrumented() method

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -283,7 +283,7 @@ public final class NewRelic {
 
             boolean instantApp = InstantApps.isInstantApp(context);
 
-            if (instantApp) {
+            if (instantApp || isInstrumented()) {
                 AndroidAgentImpl.init(context, agentConfiguration);
                 started = true;
 
@@ -320,6 +320,15 @@ public final class NewRelic {
      */
     public static boolean isStarted() {
         return started;
+    }
+
+    /*
+     * This method is used to test if instrumentation was run successfully at
+     * compile time. If successful, this method will simply be re-written to
+     * return true.
+     */
+    private boolean isInstrumented() {
+        return false;
     }
 
     /****** Public APIs ******/


### PR DESCRIPTION
1. isInstrumented method return false and will be rewritten after
/*
 * This method is used to test if instrumentation was run successfully at
 * compile time. If successful, this method will simply be re-written to
 * return true.
 */