### PR TITLE
chore: Update agent start log to emit on DEBUG

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -286,12 +286,12 @@ public final class NewRelic {
                 AndroidAgentImpl.init(context, agentConfiguration);
                 started = true;
 
-                if (log.getLevel() >= AgentLog.AUDIT) {
+                if (log.getLevel() >= AgentLog.DEBUG) {
                     StackTraceElement[] stack = Thread.currentThread().getStackTrace();
                     // the frame we're looking for is 3 levels up from current
                     if (stack.length > 3) {
                         StackTraceElement elem = stack[3];
-                        log.audit("Agent started from " + elem.getClassName() + "." + elem.getMethodName() + ":" + elem.getLineNumber());
+                        log.debug("Agent started from " + elem.getClassName() + "." + elem.getMethodName() + ":" + elem.getLineNumber());
                     }
                 }
 


### PR DESCRIPTION
## What & Why

Changing the agent start location log verbosity to emit on DEBUG so that when customers give us logs in DEBUG mode we won't have to ask for AUDIT level logs.

## Testing

Manually tested on a test app to ensure that log was emitted in both DEBUG and AUDIT verbosity and was not emitted on lower levels. Unit tests require a lengthy refactor using PowerMock or other workaround to mock static/private methods, so no tests written for this for now.