### PR TITLE
feat: Add obfuscated state to hex and crash payloads

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/Agent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/Agent.java
@@ -11,6 +11,7 @@ import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.util.Encoder;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 public class Agent {
@@ -65,6 +66,22 @@ public class Agent {
         }
 
         return buildId;
+    }
+
+    public static boolean getIsObfuscated() {
+
+        boolean isObfuscated = false;
+        try {
+            ClassLoader classLoader = Agent.class.getClassLoader();
+            Class newRelicConfigClass = classLoader.loadClass("com.newrelic.agent.android.NewRelicConfig");
+            Field field = newRelicConfigClass.getDeclaredField("OBFUSCATED");
+            field.setAccessible(true);
+            isObfuscated = (Boolean) field.get(null);
+            field.setAccessible(false);
+        } catch (Exception e) {
+            AgentLogManager.getAgentLog().error("Unable to get obfuscated flag in crash");
+        }
+        return isObfuscated;
     }
 
     public static String getCrossProcessId() {

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataController.java
@@ -82,7 +82,7 @@ public class AgentDataController {
         } else {
             sessionAttributes.put(AnalyticsAttribute.SESSION_TIME_SINCE_LOAD_ATTRIBUTE, sessionDuration / 1000.00f);
         }
-
+        sessionAttributes.put("obfuscated", Agent.getIsObfuscated());
         sessionAttributes.putAll(exceptionAttributes);   // will overwrite any of the above with passed attributes
 
         Set<Map<String, Object>> agentData = new HashSet<>();

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/Crash.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/Crash.java
@@ -31,6 +31,7 @@ import com.newrelic.agent.android.util.SafeJsonPrimitive;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -90,7 +91,7 @@ public class Crash extends HarvestableObject {
         this.exceptionInfo = new ExceptionInfo(cause);
         this.threads = extractThreads(cause);
         this.activityHistory = TraceMachine.getActivityHistory();
-        this.sessionAttributes = sessionAttributes;
+        this.sessionAttributes = getCrashSessionAttributes(sessionAttributes);
         this.events = events;
         this.analyticsEnabled = analyticsEnabled;
         this.uploadCount = 0;
@@ -139,7 +140,7 @@ public class Crash extends HarvestableObject {
     }
 
     public void setSessionAttributes(Set<AnalyticsAttribute> sessionAttributes) {
-        this.sessionAttributes = sessionAttributes;
+        this.sessionAttributes = getCrashSessionAttributes(sessionAttributes);
     }
 
     public Set<AnalyticsAttribute> getSessionAttributes() {
@@ -148,6 +149,19 @@ public class Crash extends HarvestableObject {
 
     public void setAnalyticsEvents(Collection<AnalyticsEvent> events) {
         this.events = events;
+    }
+
+    public boolean getIsObfuscated() {
+        return Agent.getIsObfuscated();
+    }
+
+    public Set<AnalyticsAttribute> getCrashSessionAttributes(Set<AnalyticsAttribute> sessionAttributes) {
+        if(sessionAttributes == null) {
+            return null;
+        }
+        Set<AnalyticsAttribute> attrs = new HashSet<>(sessionAttributes);
+        attrs.add(new AnalyticsAttribute("obfuscated", this.getIsObfuscated()));
+        return Collections.unmodifiableSet(attrs);
     }
 
     @Override

--- a/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataControllerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataControllerTest.java
@@ -149,6 +149,7 @@ public class AgentDataControllerTest {
         for (AnalyticsAttribute sessionAttr : AnalyticsControllerImpl.getInstance().getSessionAttributes()) {
             Assert.assertTrue("Should contain essential session attributes", attributeMap.containsKey(sessionAttr.getName()));
         }
+        Assert.assertTrue("Should contain obfuscated state", attributeMap.containsKey("obfuscated"));
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashTests.java
@@ -116,7 +116,8 @@ public class CrashTests {
         crash = new Crash(new RuntimeException("testCrashAnalytics"), sessionAttributes, events, true);
         JsonObject json = crash.asJsonObject();
         Assert.assertTrue("Should contain analytics struct", json.has("sessionAttributes") && json.has("analyticsEvents"));
-        Assert.assertEquals("Should contain session attributes", json.getAsJsonObject("sessionAttributes").entrySet().size(), sessionAttributes.size());
+        // We add 1 to the sessionAttributes size since 'OBFUSCATED' is only added as a session attribute on crash
+        Assert.assertEquals("Should contain session attributes", json.getAsJsonObject("sessionAttributes").entrySet().size(), sessionAttributes.size() + 1);
         Assert.assertEquals("Should contain analytics events", json.getAsJsonArray("analyticsEvents").size(), events.size());
 
         crash = new Crash(new RuntimeException("testCrashAnalytics"), null, null, true);
@@ -124,7 +125,8 @@ public class CrashTests {
         crash.setAnalyticsEvents(events);
         json = crash.asJsonObject();
         Assert.assertTrue("Should contain analytics structs", json.has("sessionAttributes") && json.has("analyticsEvents"));
-        Assert.assertEquals("Should contain session attributes", json.getAsJsonObject("sessionAttributes").entrySet().size(), sessionAttributes.size());
+        // We add 1 to the sessionAttributes size since 'OBFUSCATED' is only added as a session attribute on crash
+        Assert.assertEquals("Should contain session attributes", json.getAsJsonObject("sessionAttributes").entrySet().size(), sessionAttributes.size() + 1);
         Assert.assertEquals("Should contain analytics events", json.getAsJsonArray("analyticsEvents").size(), events.size());
     }
 
@@ -202,8 +204,20 @@ public class CrashTests {
 
         JsonObject json = crashFromJson.asJsonObject();
         Assert.assertTrue("Should contain analytics structs", json.has("sessionAttributes") && json.has("analyticsEvents"));
-        Assert.assertEquals("Should contain session attributes", json.getAsJsonObject("sessionAttributes").entrySet().size(), sessionAttributes.size());
+        // We add 1 to the sessionAttributes size since 'OBFUSCATED' is only added as a session attribute on crash
+        Assert.assertEquals("Should contain session attributes", json.getAsJsonObject("sessionAttributes").entrySet().size(), sessionAttributes.size() + 1);
         Assert.assertEquals("Should contain analytics events", json.getAsJsonArray("analyticsEvents").size(), events.size());
+    }
+
+    @Test
+    public void testObfuscated() {
+        crash = new Crash(new RuntimeException("testObfuscated"));
+
+        JsonObject json = crash.asJsonObject();
+        JsonObject sessionAttributesObj = json.getAsJsonObject("sessionAttributes");
+        Assert.assertTrue("Should contain obfuscated in session attributes", sessionAttributesObj.has("obfuscated"));
+        // NewRelicConfig.java has 'OBFUSCATED' set as true
+        Assert.assertTrue("Obfuscated should be set to true", sessionAttributesObj.getAsJsonPrimitive("obfuscated").getAsBoolean()) ;
     }
 
     private static class TestCrash extends Crash {


### PR DESCRIPTION
## What & Why
When an app is instrumented, an instance of NewRelicConfig is injected into the final classes. This object contains a field named “OBFUSCATED”, which can be queried at runtime. We are adding this into crash/hex payloads so users can query to see the obfuscated state.

## Testing
Tested locally and confirmed that obfuscated was sent on crash payloads in session attributes. On hex payloads, it is also a part of session attributes and appear on NR1.