### PR TITLE
[NR-50941] migrate: return HarvestData element formerly holding HttpErrors

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestData.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestData.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 /**
  * Information used in the {@code data} phase of harvesting.
- * <p>
+ *
  * The following entities are included in HarvestData:
  * <ul>
  *     <li>A {@link DataToken} which holds application identifying information.</li>
@@ -33,6 +33,11 @@ import java.util.Set;
  *     <li>The time since last harvest.</li>
  *     <li>{@link HttpTransactions} which contains HTTP request metrics.</li>
  *     <li>{@link MachineMeasurements} for resource metrics such as CPU and Memory.</li>
+ *     <li>{@link ActivityTraces} which contains interactions.</li>
+ *     <li>{@link AgentHealth} unused.</li>
+ *     <li>{@link AnalyticsAttribute} all session attribytes.</li>
+ *     <li>{@link AnalyticsEvent} all events collected, empty if event cache time > harvest period.</li>
+ *     </li>
  * </ul>
  */
 public class HarvestData extends HarvestableArray {
@@ -64,16 +69,33 @@ public class HarvestData extends HarvestableArray {
     /**
      * Creates JSON suitable for a harvest {@code data} post.
      *
-     * @return A {@code JsonArray} suitable vor a harvest {@code data} post.
+     * @return A {@code JsonArray} suitable for a harvest {@code data} post.
      */
     @Override
     public JsonArray asJsonArray() {
         JsonArray array = new JsonArray();
+
+        /**
+         * The JSON payload is an array of nine elements:
+         *
+         * DATA = [
+         *  DATA_TOKEN,
+         *  DEVICE_INFORMATION,
+         *  TIME_SINCE_LAST_HARVEST,
+         *  HTTP_TRANSACTIONS,
+         *  METRICS,
+         *  HTTP_ERROR_TRACES,      // DEPRECATED
+         *  ACTIVITY_TRACES,
+         *  SESSION_ATTRIBUTES,
+         *  ANALYTICS_EVENT ]
+         **/
+
         array.add(dataToken.asJson());
         array.add(deviceInformation.asJson());
         array.add(new JsonPrimitive(harvestTimeDelta));
         array.add(httpTransactions.asJson());
         array.add(machineMeasurements.asJson());
+        array.add(new JsonArray()); // must be empty per the harvest data spec
 
         JsonElement activityTracesElement = activityTraces.asJson();
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestDataTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestDataTests.java
@@ -51,6 +51,7 @@ public class HarvestDataTests {
 
     @Before
     public void setUpFeatureFlags() {
+        FeatureFlag.resetFeatures();
         FeatureFlag.enableFeature(FeatureFlag.DefaultInteractions);
         FeatureFlag.enableFeature(FeatureFlag.HttpResponseBodyCapture);
     }
@@ -94,6 +95,7 @@ public class HarvestDataTests {
         harvestData.setSessionAttributes(sessionAttributes);
 
         // Analytic Events
+        long eventCreationTime = System.currentTimeMillis();
         Set<AnalyticsEvent> events = Providers.provideSessionEvents();
         harvestData.setAnalyticsEvents(events);
 
@@ -104,16 +106,17 @@ public class HarvestDataTests {
         // Convert the string back into a JSON array and validate the contents
         JsonArray array = JsonParser.parseString(harvestJson).getAsJsonArray();
 
-        Assert.assertEquals(9, array.size());
+        Assert.assertEquals(10, array.size());
         JsonArray dataTokenElement = array.get(0).getAsJsonArray();
         JsonArray deviceInfoElement = array.get(1).getAsJsonArray();
         double timeSinceHarvestElement = array.get(2).getAsDouble();
         JsonArray httpTransactionsElement = array.get(3).getAsJsonArray();
         JsonArray metricsElement = array.get(4).getAsJsonArray();
-        JsonArray activityTracesElement = array.get(5).getAsJsonArray();
-        JsonArray agentHealthElement = array.get(6).getAsJsonArray();
-        JsonObject sessionAttributesElement = array.get(7).getAsJsonObject();
-        JsonArray analyticsEventsElement = array.get(8).getAsJsonArray();
+        JsonArray httpErrorsElement = array.get(5).getAsJsonArray();
+        JsonArray activityTracesElement = array.get(6).getAsJsonArray();
+        JsonArray agentHealthElement = array.get(7).getAsJsonArray();
+        JsonObject sessionAttributesElement = array.get(8).getAsJsonObject();
+        JsonArray analyticsEventsElement = array.get(9).getAsJsonArray();
 
         // Validate data token
         Assert.assertEquals(2, dataTokenElement.size());
@@ -137,6 +140,9 @@ public class HarvestDataTests {
 
         // Validate the metrics
         Assert.assertEquals(6, metricsElement.size());
+
+        // Validate the element formerly holding HTTP errors
+        Assert.assertEquals(0, httpErrorsElement.size());
 
         // Validate the activity traces
         Assert.assertEquals(0, activityTracesElement.size());
@@ -171,7 +177,7 @@ public class HarvestDataTests {
         Assert.assertNotNull(eventAttr4);
         Assert.assertNotNull(eventAttr5);
 
-        //Assert.assertEquals(eventTimestamp, eventAttr1.getAsInt());
+        Assert.assertEquals(eventCreationTime, eventAttr1.getAsLong(), 1000L);
         Assert.assertEquals("CustomEvent", eventAttr2.getAsString());
         Assert.assertEquals("Custom", eventAttr3.getAsString());
         Assert.assertEquals("Mobile", eventAttr4.getAsString());
@@ -285,11 +291,11 @@ public class HarvestDataTests {
         // Convert the string back into a JSON array and validate the contents
         JsonArray array = JsonParser.parseString(harvestJson).getAsJsonArray();
 
-        Assert.assertEquals(7, array.size());
+        Assert.assertEquals(8, array.size());
         JsonArray activityTracesElement = array.get(6).getAsJsonArray();
 
         // Validate the activity traces
-        Assert.assertEquals(0, activityTracesElement.size());
+        Assert.assertEquals(2, activityTracesElement.size());
     }
 
     private class TestHarvest extends Harvest {


### PR DESCRIPTION
The harvest data spec still contains a JSON array element for deprecated HttpErrors in the harvest json payload. The array must be empty. This was migrated from GHE 6.9.2 release.

* updated comments and tests