### PR TITLE
[NR-]  [Android] Add Trusted Account Key for Distributed Tracing Header

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/distributedtracing/TraceConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/distributedtracing/TraceConfiguration.java
@@ -38,7 +38,7 @@ public class TraceConfiguration extends HarvestAdapter {
     public TraceConfiguration(HarvestConfiguration harvestConfiguration) {
         this(harvestConfiguration.getAccount_id(),
                 harvestConfiguration.getApplication_id(),
-                TraceContext.TRACE_FIELD_UNUSED);
+                harvestConfiguration.getTrusted_account_key());
     }
 
     public TraceConfiguration() {
@@ -57,5 +57,6 @@ public class TraceConfiguration extends HarvestAdapter {
     void setConfiguration(HarvestConfiguration harvestConfiguration) {
         applicationId = harvestConfiguration.getApplication_id();
         accountId = harvestConfiguration.getAccount_id();
+        trustedAccountId = harvestConfiguration.getTrusted_account_key();
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/distributedtracing/TracePayload.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/distributedtracing/TracePayload.java
@@ -31,6 +31,7 @@ public class TracePayload implements TraceHeader {
     static final String APP_ID_KEY = "ap";
     static final String GUID_KEY = "id";
     static final String TRACE_ID_KEY = "tr";
+    static final String TRUST_ACCOUNT_KEY = "tk";
     static final String TIMESTAMP_KEY = "ti";
 
     static final String CALLER_TYPE = "Mobile";
@@ -70,6 +71,7 @@ public class TracePayload implements TraceHeader {
             data.add(TRACE_ID_KEY, new JsonPrimitive(traceContext.traceId));
             data.add(GUID_KEY, new JsonPrimitive(spanId));
             data.add(TIMESTAMP_KEY, new JsonPrimitive(timestampMs));
+            data.add(TRUST_ACCOUNT_KEY, new JsonPrimitive(traceContext.traceConfiguration.trustedAccountId));
 
             payload.add(VERSION_KEY, version);
             payload.add(DATA_KEY, data);

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConfiguration.java
@@ -27,6 +27,7 @@ public class HarvestConfiguration {
     private final static String DEFAULT_PRIORITY_ENCODING_KEY = "d67afc830dab717fd163bfcb0b8b88423e9a1a3b";
     private final static String DEFAULT_ACCOUNT_ID = "";
     private final static String DEFAULT_APP_ID = "";
+    private final static String DEFAULT_TRUSTED_ACCOUNT_KEY = "";
 
     @SerializedName("collect_network_errors")
     private boolean collect_network_errors;
@@ -62,6 +63,8 @@ public class HarvestConfiguration {
     private String account_id;
     @SerializedName("application_id")
     private String application_id;
+    @SerializedName("trusted_account_key")
+    private String trusted_account_key;
 
     private static HarvestConfiguration defaultHarvestConfiguration;
 
@@ -70,7 +73,7 @@ public class HarvestConfiguration {
     }
 
     public void setDefaultValues() {
-        setData_token(new int[]{0,0});
+        setData_token(new int[]{0, 0});
         setCollect_network_errors(true);
         setCross_process_id(null);
         setData_report_period(DEFAULT_REPORT_PERIOD);
@@ -86,6 +89,7 @@ public class HarvestConfiguration {
         setPriority_encoding_key(DEFAULT_PRIORITY_ENCODING_KEY);
         setAccount_id(DEFAULT_ACCOUNT_ID);
         setApplication_id(DEFAULT_APP_ID);
+        setTrusted_account_key(DEFAULT_TRUSTED_ACCOUNT_KEY);
     }
 
     public static HarvestConfiguration getDefaultHarvestConfiguration() {
@@ -123,6 +127,7 @@ public class HarvestConfiguration {
         setPriority_encoding_key(configuration.getPriority_encoding_key());
         setAccount_id(configuration.getAccount_id());
         setApplication_id(configuration.getApplication_id());
+        setTrusted_account_key(configuration.getTrusted_account_key());
     }
 
     public void setCollect_network_errors(boolean collect_network_errors) {
@@ -278,6 +283,18 @@ public class HarvestConfiguration {
         this.account_id = account_id;
     }
 
+    public String getTrusted_account_key() {
+
+        if (trusted_account_key == null) {
+            return "";
+        }
+        return trusted_account_key;
+    }
+
+    public void setTrusted_account_key(String trusted_account_key) {
+        this.trusted_account_key = trusted_account_key;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -306,6 +323,8 @@ public class HarvestConfiguration {
         if (application_id == null && that.application_id != null) return false;
         if (application_id != null && that.application_id == null) return false;
         if (application_id != null && !application_id.equals(that.application_id)) return false;
+        if (trusted_account_key != null && !trusted_account_key.equals(that.trusted_account_key))
+            return false;
 
         // Round the double value to 2 places.
         int thisMinUtil = (int) activity_trace_min_utilization * 100;
@@ -339,6 +358,7 @@ public class HarvestConfiguration {
         result = 31 * result + (account_id != null ? account_id.hashCode() : 0);
         result = 31 * result + (application_id != null ? application_id.hashCode() : 0);
         result = 31 * result + (priority_encoding_key != null ? priority_encoding_key.hashCode() : 0);
+        result = 31 * result + (trusted_account_key != null ? trusted_account_key.hashCode() : 0);
         return result;
     }
 
@@ -362,6 +382,7 @@ public class HarvestConfiguration {
                 ", priority_encoding_key=" + priority_encoding_key +
                 ", account_id=" + account_id +
                 ", application_id=" + application_id +
+                ", trusted_account_key=" + trusted_account_key +
                 '}';
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/distributedtracing/TracePayloadTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/distributedtracing/TracePayloadTest.java
@@ -69,7 +69,7 @@ public class TracePayloadTest extends TestCase {
 
             Assert.assertTrue(jsonObject.has(TracePayload.DATA_KEY));
             JsonObject data = jsonObject.get(TracePayload.DATA_KEY).getAsJsonObject();
-            Assert.assertEquals(6, data.entrySet().size());
+            Assert.assertEquals(7, data.entrySet().size());
             Assert.assertNotNull(data);
             Assert.assertEquals(TracePayload.CALLER_TYPE, data.get(TracePayload.PAYLOAD_TYPE_KEY).getAsString());
             Assert.assertEquals(traceContext.getTraceId(), data.get(TracePayload.TRACE_ID_KEY).getAsString());
@@ -83,6 +83,7 @@ public class TracePayloadTest extends TestCase {
             Assert.assertNull(data.get("d.tr"));
             Assert.assertNull(data.get("d.id"));
             Assert.assertNull(data.get("d.ti"));
+            Assert.assertNull(data.get("d.tk"));
 
         } catch (Exception e) {
             Assert.fail("Not a valid Json string");

--- a/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvesterConfigurationTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvesterConfigurationTests.java
@@ -6,6 +6,7 @@
 package com.newrelic.agent.android.harvest;
 
 import com.google.gson.Gson;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +49,7 @@ public class HarvesterConfigurationTests {
         config.setPriority_encoding_key(priority_encoding_key);
         config.setAccount_id("1");
         config.setApplication_id("100");
+        config.setTrusted_account_key("33");
 
         Gson gson = new Gson();
         String configJson = gson.toJson(config);
@@ -57,7 +59,7 @@ public class HarvesterConfigurationTests {
                 "\"report_max_transaction_age\":600,\"report_max_transaction_count\":1000,\"response_body_limit\":2048," +
                 "\"server_timestamp\":1365724800,\"stack_trace_limit\":100,\"activity_trace_max_size\":65534," +
                 "\"activity_trace_max_report_attempts\":1,\"activity_trace_min_utilization\":0.3,\"at_capture\":{\"maxTotalTraceCount\":1}," +
-                "\"priority_encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\",\"account_id\":\"1\",\"application_id\":\"100\"" +
+                "\"priority_encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\",\"account_id\":\"1\",\"application_id\":\"100\",\"trusted_account_key\":\"33\"" +
                 "}";
 
         Assert.assertEquals(expectedJson, configJson);
@@ -77,6 +79,7 @@ public class HarvesterConfigurationTests {
         String priority_encoding_key = "d67afc830dab717fd163bfcb0b8b88423e9a1a3b";
         String account_id = "1";
         String application_id = "100";
+        String trusted_account_key = "33";
 
         HarvestConfiguration expectedConfig = new HarvestConfiguration();
 
@@ -93,6 +96,7 @@ public class HarvesterConfigurationTests {
         expectedConfig.setPriority_encoding_key(priority_encoding_key);
         expectedConfig.setAccount_id(account_id);
         expectedConfig.setApplication_id(application_id);
+        expectedConfig.setTrusted_account_key(trusted_account_key);
 
 
         String serializedJson = "{\"collect_network_errors\":true,\"cross_process_id\":\"VgMPV1ZTGwIGUFdWAQk\\u003d\"," +
@@ -100,7 +104,7 @@ public class HarvesterConfigurationTests {
                 "\"report_max_transaction_age\":600,\"report_max_transaction_count\":1000,\"response_body_limit\":2048," +
                 "\"server_timestamp\":1365724800,\"stack_trace_limit\":100," +
                 "\"priority_encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\",\"account_id\":\"1\"," +
-                "\"application_id\":\"100\"}";
+                "\"application_id\":\"100\",\"trusted_account_key\":\"33\"}";
 
         Gson gson = new Gson();
         HarvestConfiguration config = gson.fromJson(serializedJson, HarvestConfiguration.class);
@@ -122,6 +126,7 @@ public class HarvesterConfigurationTests {
         String priority_encoding_key = "d67afc830dab717fd163bfcb0b8b88423e9a1a3b";
         String account_id = "1";
         String application_id = "100";
+        String trusted_account_key = "33";
 
         HarvestConfiguration expectedConfig = new HarvestConfiguration();
 
@@ -138,13 +143,14 @@ public class HarvesterConfigurationTests {
         expectedConfig.setPriority_encoding_key(priority_encoding_key);
         expectedConfig.setAccount_id(account_id);
         expectedConfig.setApplication_id(application_id);
+        expectedConfig.setTrusted_account_key(trusted_account_key);
 
         String serializedJson = "{\"collect_network_errors\":true,\"cross_process_id\":\"VgMPV1ZTGwIGUFdWAQk\\u003d\"," +
                 "\"data_report_period\":60,\"data_token\":[1646468,1997527],\"error_limit\":50," +
                 "\"report_max_transaction_age\":600,\"report_max_transaction_count\":1000,\"response_body_limit\":2048," +
                 "\"server_timestamp\":1365724800,\"stack_trace_limit\":100," +
                 "\"priority_encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\",\"account_id\":\"1\"," +
-                "\"application_id\":\"100\"}";
+                "\"application_id\":\"100\",\"trusted_account_key\":\"33\"}";
 
         Gson gson = new Gson();
         HarvestConfiguration config = gson.fromJson(serializedJson, HarvestConfiguration.class);

--- a/agent-core/src/test/java/com/newrelic/agent/android/test/mock/Providers.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/test/mock/Providers.java
@@ -278,6 +278,7 @@ public class Providers {
         harvestConfiguration.setActivity_trace_min_utilization(0.3333);
         harvestConfiguration.setServer_timestamp(9876543210L);
         harvestConfiguration.setResponse_body_limit(1111);
+        harvestConfiguration.setTrusted_account_key("33");
         return harvestConfiguration;
     }
 

--- a/agent/src/main/java/com/newrelic/agent/android/SavedState.java
+++ b/agent/src/main/java/com/newrelic/agent/android/SavedState.java
@@ -43,6 +43,7 @@ public class SavedState extends HarvestAdapter {
     private final String PREF_PRIORITY_ENCODING_KEY = "encoding_key";
     private final String PREF_ACCOUNT_ID = "account_id";
     private final String PREF_APPLICATION_ID = "application_id";
+    private final String PREF_TRUSTED_ACCOUNT_KEY = "trusted_account_key";
     private final String PREF_DATA_TOKEN = "dataToken";
     private final String PREF_DATA_TOKEN_EXPIRATION = "dataTokenExpiration";
     private final String PREF_CONNECT_HASH = "connectHash";
@@ -133,6 +134,7 @@ public class SavedState extends HarvestAdapter {
         save(PREF_PRIORITY_ENCODING_KEY, newConfiguration.getPriority_encoding_key());
         save(PREF_ACCOUNT_ID, newConfiguration.getAccount_id());
         save(PREF_APPLICATION_ID, newConfiguration.getApplication_id());
+        save(PREF_TRUSTED_ACCOUNT_KEY, newConfiguration.getTrusted_account_key());
 
         saveActivityTraceMinUtilization((float) newConfiguration.getActivity_trace_min_utilization());
 
@@ -189,6 +191,11 @@ public class SavedState extends HarvestAdapter {
         if (has(PREF_PRIORITY_ENCODING_KEY)) {
             configuration.setPriority_encoding_key(getPriorityEncodingKey());
         }
+
+        if (has(PREF_TRUSTED_ACCOUNT_KEY)) {
+            configuration.setTrusted_account_key(getTrustedAccountKey());
+        }
+
 
         log.info("Loaded configuration: " + configuration);
     }
@@ -478,6 +485,10 @@ public class SavedState extends HarvestAdapter {
 
     public String getApplicationId() {
         return getString(PREF_APPLICATION_ID);
+    }
+
+    public String getTrustedAccountKey() {
+        return getString(PREF_TRUSTED_ACCOUNT_KEY);
     }
 
     public boolean isCollectingNetworkErrors() {

--- a/agent/src/test/java/com/newrelic/agent/android/SavedStateTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/SavedStateTest.java
@@ -5,6 +5,12 @@
 
 package com.newrelic.agent.android;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.newrelic.agent.android.harvest.ApplicationInformation;
 import com.newrelic.agent.android.harvest.ConnectInformation;
 import com.newrelic.agent.android.harvest.DeviceInformation;
@@ -20,12 +26,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Config.OLDEST_SDK)
@@ -229,7 +229,7 @@ public class SavedStateTest {
         HarvestConfiguration harvestConfig = Providers.provideHarvestConfiguration();
 
         harvestConfig.setData_token(null);
-        savedState.getHarvestConfiguration().setData_token(new int[]{1,2});
+        savedState.getHarvestConfiguration().setData_token(new int[]{1, 2});
         savedState.saveHarvestConfiguration(harvestConfig);
         int[] dataToken = savedState.getDataToken();
         Assert.assertEquals(1, dataToken[0]);
@@ -241,6 +241,13 @@ public class SavedStateTest {
         savedState.saveHarvestConfiguration(Providers.provideHarvestConfiguration());
         Assert.assertEquals("Should contain cross-process id", "x-process-id", savedState.getCrossProcessId());
     }
+
+    @Test
+    public void testGetTrustedAccountKey() throws Exception {
+        savedState.saveHarvestConfiguration(Providers.provideHarvestConfiguration());
+        Assert.assertEquals("Should contain Trusted Account Key", "33", savedState.getTrustedAccountKey());
+    }
+
 
     @Test
     public void testIsCollectingNetworkErrors() throws Exception {

--- a/agent/src/test/java/com/newrelic/agent/android/test/mock/Providers.java
+++ b/agent/src/test/java/com/newrelic/agent/android/test/mock/Providers.java
@@ -228,6 +228,7 @@ public class Providers {
         harvestConfiguration.setResponse_body_limit(1111);
         harvestConfiguration.setAccount_id("12345");
         harvestConfiguration.setApplication_id("app-token");
+        harvestConfiguration.setTrusted_account_key("33");
         return harvestConfiguration;
     }
 

--- a/docs/TraceMachine.md
+++ b/docs/TraceMachine.md
@@ -1,60 +1,73 @@
 # Trace Machine (Traces and Interactions)
 
-Interactions and traces follow the threading of the app. If the app is complex, traces will be as well, which is why having more data is better. Log data should include data from before the app starts, to 30 seconds after it has backgrounded.
+Interactions and traces follow the threading of the app. If the app is complex, traces will be as
+well, which is why having more data is better. Log data should include data from before the app
+starts, to 30 seconds after it has backgrounded.
 
-Agent data harvests occur every 60 seconds, and any traces created since the last harvest will be stopped. If an app starts a trace, but the code does nothing else that would trigger an update, that trace would report _duration_ as the difference between its start time and the current harvest time.
+Agent data harvests occur every 60 seconds, and any traces created since the last harvest will be
+stopped. If an app starts a trace, but the code does nothing else that would trigger an update, that
+trace would report _duration_ as the difference between its start time and the current harvest time.
 
 Actions that update trace state include:
+
 * return from a method
 * start a new activity or fragment
 * make a network request
 * calling the static API NewRelic.endInteraction()
 
-
 ## TraceMachine
+
 * Requires FeatureFlag.InteractionTracing
 * There is a single TraceMachine
-	* startTracing() replaces TraceMachine singleton, and connects activityTrace to new TraceMachine
+    * startTracing() replaces TraceMachine singleton, and connects activityTrace to new TraceMachine
 * There is a single TraceMachineInterface
 * There is a single activityHistory list
 * Single ThreadLocal trace and ThreadLocal trace stack
 * TraceMachine is highly contentious: all running threads can impact state of traces
 
 ### Typical trace sequence:
+
 1. Start trace
-	* Called automatically through code injection, and manually through API
+    * Called automatically through code injection, and manually through API
 2. For all child traces:
-	* enter method
-	* exit method
+    * enter method
+    * exit method
 3. End trace
-	* `endTrace` is only called directly from AsyncTask.onPostExecute
+    * `endTrace` is only called directly from AsyncTask.onPostExecute
 
 ### HEALTHY_TRACE_TIMEOUT
-The minimum trace duration, as the time since the trace's last last update. Timed-out traces are completed.
-Default: 500 ms.
+
+The minimum trace duration, as the time since the trace's last last update. Timed-out traces are
+completed. Default: 500 ms.
 
 ### UNHEALTHY_TRACE_TIMEOUT
+
 The maximum trace duration, as the time since the trace's creation. Timed-out traces are completed.
 Default: 60000 ms. (1 minutes, or harvest period)
 
 ## Trace
+
 * Contains trace start/end times
 * Contains child traces
 * Completed traces are added to current ActivityTrace
 
 ### Child trace
-Any trace in another thread started automatically (through injection) or manually (@Trace annotation or API)
+
+Any trace in another thread started automatically (through injection) or manually (@Trace annotation
+or API)
 
 ## ActivityTrace
+
 * TraceMachine has a single ActivityTrace
 * ActivityTrace must have root trace
 * ActivityTraces are completed if another trace is started before the current completes
-* ActivityTrace is completed if time since last update is > HEALTHY_TRACE_TIMEOUT (0.5s) and has no pending child traces, or time since trace inception is > UNHEALTHY_TRACE_TIMEOUT (60s)
-	* applies when a new method is entered, and immediately before a harvest starts
-* ActivityTrace is not recorded if it has no children, or child exclusive time < 33% of total trace duration
+* ActivityTrace is completed if time since last update is > HEALTHY_TRACE_TIMEOUT (0.5s) and has no
+  pending child traces, or time since trace inception is > UNHEALTHY_TRACE_TIMEOUT (60s)
+    * applies when a new method is entered, and immediately before a harvest starts
+* ActivityTrace is not recorded if it has no children, or child exclusive time < 33% of total trace
+  duration
 * If activityTrace limit (1) is reached, all further traces are dropped:
-	* "Activity trace limit of 1 exceeded. Ignoring trace: "
-
+    * "Activity trace limit of 1 exceeded. Ignoring trace: "
 
 	* complete current ActivityTrace if a trace is running
 	* creates a new rootTrace
@@ -80,23 +93,27 @@ Any trace in another thread started automatically (through injection) or manuall
 		addHarvestListener(this)
 	```
 
-
 ## Class rewriter
-TraceMethodVisitor injects calls to `TraceMachine.startTracing({activityName})` and ` ApplicationStateMonitor.onStart()` into the start of all classes derived from Android Activity and Fragment classes. Traces are injected into the following overridden class methods:
+
+TraceMethodVisitor injects calls to `TraceMachine.startTracing({activityName})`
+and ` ApplicationStateMonitor.onStart()` into the start of all classes derived from Android Activity
+and Fragment classes. Traces are injected into the following overridden class methods:
+
 * Activity.onCreate()
 * Activity.onCreateView
 * Fragment.onCreate()
 * Fragment.onCreateView
 
-ActivityTraces are completed if another trace is started before the current completes
-ActivityTraces are completed on harvest (every ~60 secs), regardless of when it was started
-ActivityTraces are expired if could not be reported in harvest
+ActivityTraces are completed if another trace is started before the current completes ActivityTraces
+are completed on harvest (every ~60 secs), regardless of when it was started ActivityTraces are
+expired if could not be reported in harvest
 
 If activityTrace limit (1) is reached, all further traces are dropped
+
 * ```Activity trace limit of 1 exceeded. Ignoring trace: ```
 
-Class rewriter *does not* inject calls to `endTrace`: allows runtime behavior to shut down running traces through preemption and timeouts
-
+Class rewriter *does not* inject calls to `endTrace`: allows runtime behavior to shut down running
+traces through preemption and timeouts
 
 ## Method Tracing
 
@@ -111,56 +128,68 @@ TraceMachine.exitMethod();
 ```
 
 ## Activity injection
-Class rewriter also injects call to `TraceMachine.enterMethod("Activity#onCreate")` into start of all Activity.onCreate()/Fragment.onCreate() overrides.
+
+Class rewriter also injects call to `TraceMachine.enterMethod("Activity#onCreate")` into start of
+all Activity.onCreate()/Fragment.onCreate() overrides.
 
 ### Prune healthy timeouts that have no missing children
-if (currentTrace.lastUpdatedAt + (long)HEALTHY_TRACE_TIMEOUT < currentTime && activityTrace has no missing children
-	complete Activitytrace
-	* "missing children" - subtraces that have not completed
 
-// Prune unhealthy timeouts regardless of missing children
-if (currentTrace.inception + (long)UNHEALTHY_TRACE_TIMEOUT < currentTime)
-	complete ActivityTrace
+if (currentTrace.lastUpdatedAt + (long)HEALTHY_TRACE_TIMEOUT < currentTime && activityTrace has no
+missing children complete Activitytrace * "missing children" - subtraces that have not completed
 
+// Prune unhealthy timeouts regardless of missing children if (currentTrace.inception + (long)
+UNHEALTHY_TRACE_TIMEOUT < currentTime)
+complete ActivityTrace
 
 ### Inject call to TrcaeMachine.exitMethod()
-Class rewriter injects call to `TraceMachine.exitMethod(),activityName")` and `ApplicationStateMonitor.onStop()` into end of all Activity.onCreate()//Fragment.onCreate() overrides
 
-Trace may have already been completed via HEALTHY_TRACE_TIMEOUT or preemption from another trace starting
-current trace = threadLocalTrace
-shutdown current trace
+Class rewriter injects call to `TraceMachine.exitMethod(),activityName")`
+and `ApplicationStateMonitor.onStop()` into end of all Activity.onCreate()//Fragment.onCreate()
+overrides
+
+Trace may have already been completed via HEALTHY_TRACE_TIMEOUT or preemption from another trace
+starting current trace = threadLocalTrace shutdown current trace
 
 ### Completing trace
+
 * As each child trace (method) completes, total time is added to parent trace's '_exclusive time_'
-* ActivityTrace is dropped if traceUtilization (activityTrace.childExclusiveTime /  activityTrace.duration) <= 0.333 for all child traces
+* ActivityTrace is dropped if traceUtilization (activityTrace.childExclusiveTime /
+  activityTrace.duration) <= 0.333 for all child traces
 
 Look in logs for:
+
 ```
 Discarding trace of {trace display name}...
 Completing trace of {trace display name}...
 ```
 
 ## Network Requests
+
 * Current trace is renamed
+
 > TraceMachine.setCurrentDisplayName("External/" + (new URL(url)).getHost())
+
 * Any outstanding trace is ended when network request completes
-> Network traces may never end because the stream isn't read or the response was cached.
-In this case, current network traces are ended before starting another one.
+
+> Network traces may never end because the stream isn't read or the response was cached. In this case, current network traces are ended before starting another one.
 
 ## TraceFieldInterface
+
 Class rewriter (`TraceClassDecorator`) injects `TraceFieldInterface` into traced methods
 
 ## TraceMachineInterface
+
 Provides current thread context
 
 ## Trace Configuration
+
 * Mostly not used
 
 ```
 {
-	"server_timestamp": 1601520537,
+	"server_timestamp": 1680880043,
 	"data_report_period": 60,
-	"report_max_transaction_count": 1
+	"report_max_transaction_count": 1000,
 	"report_max_transaction_age": 600,
 	"collect_network_errors": true,
 	"error_limit": 50,
@@ -169,15 +198,17 @@ Provides current thread context
 	"activity_trace_max_size": 65535,
 	"activity_trace_min_utilization": 0.3,
 	"at_capture": [1, []],
-	"data_token": [52088176, 298381946],
-	"cross_process_id": "XAUAWFFQGwYCVFlaBgYB",
+	"data_token": [601336055, 601380446],
+	"cross_process_id": "VwUUV1ZSCwAGVFRX",
 	"encoding_key": "d67afc830dab717fd163bfcb0b8b88423e9a1a3b",
-	"account_id": "837973",
-	"application_id": "52088176"
+	"account_id": "33",
+	"application_id": "601336055",
+	"trusted_account_key": "33"
 }
 ```
 
 > Outstanding Questions [TO-DO]:
+
 * Interaction metrics vs InteractionEvents?
 * How to you time interactions (custom tracking)?
 * Does manually timed interaction contain time spent in children (threads)?


### PR DESCRIPTION
fix: When the trusted account key is missing from the DT headers, DT (Distributed Tracing) is unable to establish connections between child accounts.