### PR TITLE
HarvestTimer NPE Fix

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvest.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvest.java
@@ -58,11 +58,19 @@ public class Harvest {
     }
 
     public static void start() {
-        instance.getHarvestTimer().start();
+        if (instance.getHarvestTimer() != null) {
+            instance.getHarvestTimer().start();
+        } else {
+            log.error("Harvest timer is null");
+        }
     }
 
     public static void stop() {
-        instance.getHarvestTimer().stop();
+        if (instance.getHarvestTimer() != null) {
+            instance.getHarvestTimer().stop();
+        } else {
+            log.error("Harvest timer is null");
+        }
     }
 
     public static void harvestNow(boolean finalizeSession) {

--- a/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestTests.java
@@ -604,6 +604,25 @@ public class HarvestTests {
         Assert.assertFalse("Harvest should not execute when app in background", testAdapter.didStart());
     }
 
+    @Test
+    public void testStartStop() {
+        try {
+            HarvestTimer timer = null;
+            Harvest.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Harvest start failed when harvest timer is null");
+        }
+
+        try {
+            HarvestTimer timer = null;
+            Harvest.stop();
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Harvest stop failed when harvest timer is null");
+        }
+    }
+
 
     private class TestHarvestAdapter extends HarvestAdapter {
         private boolean started;


### PR DESCRIPTION
1. One of the clients provided debug log files for this specific cases, they are not able to reproduce on there side but can see the crashes for certain devices.
2. Add condition statement to prevent NPE
3. Add unit tests