### PR TITLE
[NR-124057] Update ASM opcode to support sealed intf/classes

### DIFF
--- a/instrumentation/src/main/java/com/newrelic/agent/compile/ClassAdapterBase.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/ClassAdapterBase.java
@@ -24,7 +24,7 @@ public class ClassAdapterBase extends ClassVisitor {
     private final Logger log;
 
     public ClassAdapterBase(Logger log, ClassVisitor cv, Map<Method, MethodVisitorFactory> methodVisitors) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.methodVisitors = methodVisitors;
         this.log = log;
     }

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ActivityClassAdapter.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ActivityClassAdapter.java
@@ -50,7 +50,7 @@ public abstract class ActivityClassAdapter extends ClassVisitor {
 
 
     public ActivityClassAdapter(ClassVisitor cv, InstrumentationContext context, Logger log, Set<String> baseClasses, Map<Method, Method> methodMappings) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
         this.log = log;
 
@@ -169,7 +169,7 @@ public abstract class ActivityClassAdapter extends ClassVisitor {
         }
 
         public MethodVisitor createMethodVisitor(int access, final Method method, MethodVisitor mv, final boolean callSuper) {
-            return new GeneratorAdapter(Opcodes.ASM8, mv, access, method.getName(), method.getDescriptor()) {
+            return new GeneratorAdapter(Opcodes.ASM9, mv, access, method.getName(), method.getDescriptor()) {
                 @Override
                 public void visitMaxs(int maxStack, int maxLocals) {
                     super.visitMaxs(Math.max(maxStack, 8), Math.max(maxLocals, 8));

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/AnnotatingClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/AnnotatingClassVisitor.java
@@ -19,7 +19,7 @@ public class AnnotatingClassVisitor extends ClassVisitor {
     private final Logger log;
 
     public AnnotatingClassVisitor(ClassVisitor cv, final InstrumentationContext context, final Logger log) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
         this.log = log;
     }

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/AsyncTaskClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/AsyncTaskClassVisitor.java
@@ -45,7 +45,7 @@ public class AsyncTaskClassVisitor extends ClassVisitor {
     );
 
     public AsyncTaskClassVisitor(ClassVisitor cv, InstrumentationContext context, Logger log) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
         this.log = log;
     }

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/BaseMethodVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/BaseMethodVisitor.java
@@ -19,7 +19,7 @@ public abstract class BaseMethodVisitor extends AdviceAdapter {
     protected final BytecodeBuilder builder = new BytecodeBuilder(this);
 
     protected BaseMethodVisitor(MethodVisitor mv, int access, String methodName, String desc) {
-        super(Opcodes.ASM8, mv, access, methodName, desc);
+        super(Opcodes.ASM9, mv, access, methodName, desc);
         this.methodName = methodName;
     }
 

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ClassAnnotationVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ClassAnnotationVisitor.java
@@ -25,7 +25,7 @@ public class ClassAnnotationVisitor extends ClassVisitor {
     private final String annotationDescription;
 
     public ClassAnnotationVisitor(String annotationDescription) {
-        super(Opcodes.ASM8);
+        super(Opcodes.ASM9);
         this.annotationDescription = annotationDescription;
     }
 

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ContextInitializationClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ContextInitializationClassVisitor.java
@@ -14,7 +14,7 @@ public class ContextInitializationClassVisitor extends ClassVisitor {
     private final InstrumentationContext context;
 
     public ContextInitializationClassVisitor(final ClassVisitor cv, final InstrumentationContext context) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
     }
 

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/MethodAnnotationVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/MethodAnnotationVisitor.java
@@ -31,7 +31,7 @@ public class MethodAnnotationVisitor {
         private final Collection<MethodAnnotation> annotations = new ArrayList<MethodAnnotation>();
 
         public MethodAnnotationClassVisitor(String annotationDescription) {
-            super(Opcodes.ASM8);
+            super(Opcodes.ASM9);
             this.annotationDescription = annotationDescription;
         }
 
@@ -56,7 +56,7 @@ public class MethodAnnotationVisitor {
             private final String methodDesc;
 
             public MethodAnnotationVisitorImpl(String name, String desc) {
-                super(Opcodes.ASM8);
+                super(Opcodes.ASM9);
                 this.methodName = name;
                 this.methodDesc = desc;
             }

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/NewRelicClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/NewRelicClassVisitor.java
@@ -22,7 +22,7 @@ public class NewRelicClassVisitor extends ClassVisitor {
     private final Logger log;
 
     public NewRelicClassVisitor(ClassVisitor cv, final InstrumentationContext context, final Logger log) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
         this.log = log;
     }
@@ -59,7 +59,7 @@ public class NewRelicClassVisitor extends ClassVisitor {
     // the proguard file in the future.
     private final class BuildIdMethodVisitor extends GeneratorAdapter {
         public BuildIdMethodVisitor(MethodVisitor mv, final int access, final String name, final String desc) {
-            super(Opcodes.ASM8, mv, access, name, desc);
+            super(Opcodes.ASM9, mv, access, name, desc);
         }
 
         @Override
@@ -82,7 +82,7 @@ public class NewRelicClassVisitor extends ClassVisitor {
      */
     private final class NewRelicMethodVisitor extends GeneratorAdapter {
         public NewRelicMethodVisitor(MethodVisitor mv, final int access, final String name, final String desc) {
-            super(Opcodes.ASM8, mv, access, name, desc);
+            super(Opcodes.ASM9, mv, access, name, desc);
         }
 
         @Override

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/PrefilterClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/PrefilterClassVisitor.java
@@ -25,7 +25,7 @@ public class PrefilterClassVisitor extends ClassVisitor {
     private final Logger log;
 
     public PrefilterClassVisitor(final InstrumentationContext context, final Logger log) {
-        super(Opcodes.ASM8);
+        super(Opcodes.ASM9);
         this.context = context;
         this.log = log;
     }
@@ -53,7 +53,7 @@ public class PrefilterClassVisitor extends ClassVisitor {
 
     @Override
     public MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature, final String[] exceptions) {
-        MethodVisitor methodVisitor = new MethodVisitor(Opcodes.ASM8) {
+        MethodVisitor methodVisitor = new MethodVisitor(Opcodes.ASM9) {
             @Override
             public AnnotationVisitor visitAnnotationDefault() {
                 return null;

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ReplaceCallSiteClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/ReplaceCallSiteClassVisitor.java
@@ -20,7 +20,7 @@ public class ReplaceCallSiteClassVisitor extends ClassVisitor {
     private final Logger log;
 
     public ReplaceCallSiteClassVisitor(ClassVisitor cv, final InstrumentationContext context, final Logger log) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
         this.log = log;
     }

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/SkipInstrumentedMethodsMethodVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/SkipInstrumentedMethodsMethodVisitor.java
@@ -16,7 +16,7 @@ import org.objectweb.asm.Type;
 public class SkipInstrumentedMethodsMethodVisitor extends MethodVisitor {
 
     public SkipInstrumentedMethodsMethodVisitor(MethodVisitor mv) {
-        super(Opcodes.ASM8, mv);
+        super(Opcodes.ASM9, mv);
     }
 
     @Override

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/TraceAnnotationClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/TraceAnnotationClassVisitor.java
@@ -16,7 +16,7 @@ public class TraceAnnotationClassVisitor extends ClassVisitor {
     private final InstrumentationContext context;
 
     public TraceAnnotationClassVisitor(ClassVisitor cv, InstrumentationContext context, Logger log) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
     }
 

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/TraceClassDecorator.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/TraceClassDecorator.java
@@ -41,7 +41,7 @@ public class TraceClassDecorator {
         Method method = new Method(Constants.TRACE_SETTRACE_METHOD_NAME, Constants.TRACE_SIGNATURE);
         MethodVisitor mv = adapter.visitMethod(Opcodes.ACC_PUBLIC, method.getName(), method.getDescriptor(), null, null);
 
-        GeneratorAdapter adapter = new GeneratorAdapter(Opcodes.ASM8, mv, Opcodes.ACC_PUBLIC, method.getName(), method.getDescriptor()) {
+        GeneratorAdapter adapter = new GeneratorAdapter(Opcodes.ASM9, mv, Opcodes.ACC_PUBLIC, method.getName(), method.getDescriptor()) {
             @Override
             public void visitCode() {
                 Label tryStart = new Label();

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/TraceMethodVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/TraceMethodVisitor.java
@@ -27,7 +27,7 @@ public class TraceMethodVisitor extends AdviceAdapter {
     private final int access;
 
     public TraceMethodVisitor(MethodVisitor mv, final int access, final String name, final String desc, final InstrumentationContext context) {
-        super(Opcodes.ASM8, mv, access, name, desc);
+        super(Opcodes.ASM9, mv, access, name, desc);
         this.access = access;
         this.context = context;
         this.log = context.getLog();

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/WrapMethodClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/WrapMethodClassVisitor.java
@@ -24,7 +24,7 @@ public class WrapMethodClassVisitor extends ClassVisitor {
     private final Logger log;
 
     public WrapMethodClassVisitor(ClassVisitor cv, final InstrumentationContext context, final Logger log) {
-        super(Opcodes.ASM8, cv);
+        super(Opcodes.ASM9, cv);
         this.context = context;
         this.log = log;
     }
@@ -47,7 +47,7 @@ public class WrapMethodClassVisitor extends ClassVisitor {
         private boolean dupInstructionFound = false;
 
         public MethodWrapMethodVisitor(MethodVisitor mv, final int access, final String name, final String desc, final InstrumentationContext context, final Logger log) {
-            super(Opcodes.ASM8, mv, access, name, desc);
+            super(Opcodes.ASM9, mv, access, name, desc);
             this.name = name;
             this.desc = desc;
             this.context = context;

--- a/instrumentation/src/main/java/com/newrelic/agent/util/AnnotationImpl.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/util/AnnotationImpl.java
@@ -18,7 +18,7 @@ public class AnnotationImpl extends AnnotationVisitor {
     private Map<String, Object> attributes;
 
     public AnnotationImpl(String name) {
-        super(Opcodes.ASM8);
+        super(Opcodes.ASM9);
         this.name = name;
     }
 
@@ -61,7 +61,7 @@ public class AnnotationImpl extends AnnotationVisitor {
         private final ArrayList<Object> values = new ArrayList<Object>();
 
         public ArrayVisitor(final String name) {
-            super(Opcodes.ASM8);
+            super(Opcodes.ASM9);
             this.name = name;
         }
 

--- a/instrumentation/src/test/java/com/newrelic/agent/TestContext.java
+++ b/instrumentation/src/test/java/com/newrelic/agent/TestContext.java
@@ -177,7 +177,7 @@ public class TestContext {
     }
 
     public ClassNode toClassNode(byte classBytes[]) {
-        return toClassNode(classBytes, new ClassVisitor(Opcodes.ASM7, cn) {
+        return toClassNode(classBytes, new ClassVisitor(Opcodes.ASM9, cn) {
         });
     }
 

--- a/instrumentation/src/test/java/com/newrelic/agent/compile/visitor/TraceClassDecoratorTest.java
+++ b/instrumentation/src/test/java/com/newrelic/agent/compile/visitor/TraceClassDecoratorTest.java
@@ -33,7 +33,7 @@ public class TraceClassDecoratorTest {
     public void setUp() throws Exception {
         testContext = new TestContext();
         tcd = new TraceClassDecorator(testContext.classWriter);
-        testContext.classWriter.visit(Opcodes.ASM7, Opcodes.ACC_PROTECTED, method.getName(), method.getDescriptor(), null, null);
+        testContext.classWriter.visit(Opcodes.ASM9, Opcodes.ACC_PROTECTED, method.getName(), method.getDescriptor(), null, null);
         classBytes = testContext.classBytesFromResource("/MainActivity.class");
     }
 


### PR DESCRIPTION
Should fix: ```
com.newrelic.org.objectweb.asm.ClassVisitor.visitPermittedSubclass(ClassVisitor.java:266) at com.newrelic.org.objectweb.asm.ClassReader.accept(ClassReader.java:683) at com.newrelic.org.objectweb.asm.ClassReader.accept(ClassReader.java:401) at com.newrelic.agent.compile.InvocationDispatcher.visitClassBytesWithOptions(InvocationDispatcher.java:128)  ```

See https://issuetracker.google.com/issues/265309495