### PR TITLE
[nr120265] Verify Dexguard 9 support

### DIFF
--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginSpec.groovy
@@ -97,7 +97,7 @@ abstract class PluginSpec extends Specification {
                 .forwardStdError(errorOutput)
                 .withGradleVersion(gradleVersion)
 
-        return debuggable ? runner.withDebug(debuggable) : runner.withEnvironment(localEnv)
+        return debuggable ? runner.withDebug(true) : runner.withEnvironment(localEnv)
     }
 
 }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -46,7 +46,7 @@ class DexGuardHelperTest extends PluginTest {
         def buildHelper = BuildHelper.register(project)
         buildHelper.variantAdapter.configure(buildHelper.extension)
         buildHelper.variantAdapter.getVariantValues().each { variant ->
-            def mapPath = dexGuardHelper.getDefaultMapPathProvider(variant.name)
+            def mapPath = dexGuardHelper.getMappingFileProvider(variant.name)
             Assert.assertNotNull(mapPath)
             Assert.assertTrue(mapPath.getAsFile().get().getAbsolutePath().contains("/${variant.dirName}/"))
             if (dexGuardHelper.isDexGuard9()) {

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
@@ -109,6 +109,9 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
         return Set.of(
                 "minify${vnc}WithR8",
                 "minify${vnc}WithProguard",
+                "transformClassesAndResourcesWithProguardTransformFor${vnc}",
+                "transformClassesAndResourcesWithProguardFor${vnc}",
+                "transformClassesAndResourcesWithR8For${vnc}",
                 "lintVitalAnalyze${vnc}",
                 "lintVitalReport${vnc}",
                 "dexguardApk${vnc}",

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -150,6 +150,12 @@ abstract class VariantAdapter {
         def variant = withVariant(variantName)
         def buildType = withBuildType(variantName)
 
+        if (buildHelper.dexguardHelper?.getEnabled()) {
+            if (buildHelper.dexguardHelper.variantConfigurations.get().containsKey(buildType.name)) {
+                return true
+            }
+        }
+
         return (buildType.minified && (buildHelper.extension.shouldIncludeMapUpload(buildType.name) ||
                 buildHelper.extension.shouldIncludeMapUpload(buildType.buildType)))
     }
@@ -221,7 +227,7 @@ abstract class VariantAdapter {
             }
         } catch (InvalidUserDataException ignored) {
             return buildHelper.project.tasks.named(name, clazz) {
-                // action?.execute(it)
+                action?.execute(it)
             }
         }
     }
@@ -232,8 +238,8 @@ abstract class VariantAdapter {
     def assembleDataModel(String variantName) {
         // assemble and configure model
         wiredWithTransformProvider(variantName)
-        if (buildHelper.project.plugins.hasPlugin("com.android.application")) {
-            // inject config lass into apps
+        if (buildHelper.checkApplication()) {
+            // inject config class into apps
             wiredWithConfigProvider(variantName)
         }
         if (shouldUploadVariantMap(variantName)) {

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
@@ -151,7 +151,7 @@ class AGP4Adapter extends VariantAdapter {
         // FIXME DRY up
         // dexguard maps are handled separately
         if (buildHelper.checkDexGuard()) {
-            return buildHelper.dexguardHelper.getDefaultMapPathProvider(variant.dirName)
+            return buildHelper.dexguardHelper.getMappingFileProvider(variantName)
         }
 
         def variantConfiguration = buildHelper.extension.variantConfigurations.findByName(variant.name)

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP74Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP74Adapter.groovy
@@ -13,51 +13,55 @@ import org.gradle.api.provider.Provider
 import org.gradle.util.GradleVersion
 
 class AGP74Adapter extends AGP70Adapter {
-        AGP74Adapter(BuildHelper buildHelper) {
-            super(buildHelper)
-        }
-
-        /* TODO
-        @Override
-        TaskProvider getTransformProvider(String variantName) {
-            def provider = super.getTransformProvider(variantName)
-            variant.transformClassesWith(TraceClassVisitorFactory.class, InstrumentationScope.PROJECT) { params ->
-                params.getTruth().set(true)
-            }
-            variant.setAsmFramesComputationMode(FramesComputationMode.COMPUTE_FRAMES_FOR_ALL_CLASSES)
-            provider
-        }
-        /* TODO */
-
-        @Override
-        Provider<BuildTypeAdapter> getBuildTypeProvider(String variantName) {
-            def variant = withVariant(variantName)
-            def isMinifyEnabled = variant.properties.getOrDefault('minifyEnabled', variant.properties.get("minifiedEnabled"))   // really?
-            def buildTypeAdapter = new BuildTypeAdapter(variant.name, isMinifyEnabled, variant.flavorName, variant.buildType)
-
-            return buildHelper.project.objects.property(Object).value(buildTypeAdapter)
-        }
-
-        @Override
-        def wiredWithTransformProvider(String variantName) {
-            if (GradleVersion.current() < GradleVersion.version("7.5")) {
-                return super.wiredWithTransformProvider(variantName)
-            }
-
-            def transformProvider = getTransformProvider(variantName)
-            withVariant(variantName).artifacts
-                    .forScope(ScopedArtifacts.Scope.ALL)
-                    .use(transformProvider)
-                    .toTransform(ScopedArtifact.CLASSES.INSTANCE, { it.getClassJars() }, { it.getClassDirectories() }, { it.getOutputJar() })
-
-            return transformProvider
-        }
-
-        @Override
-        def wiredWithConfigProvider(String variantName) {
-            def configProvider = super.wiredWithConfigProvider(variantName)
-            withVariant(variantName).sources.java.addGeneratedSourceDirectory(configProvider, { it.getSourceOutputDir() })
-
-            return configProvider
-        }
+    AGP74Adapter(BuildHelper buildHelper) {
+        super(buildHelper)
     }
+
+    /* TODO
+    @Override
+    TaskProvider getTransformProvider(String variantName) {
+        def provider = super.getTransformProvider(variantName)
+        variant.transformClassesWith(TraceClassVisitorFactory.class, InstrumentationScope.PROJECT) { params ->
+            params.getTruth().set(true)
+        }
+        variant.setAsmFramesComputationMode(FramesComputationMode.COMPUTE_FRAMES_FOR_ALL_CLASSES)
+        provider
+    }
+    /* TODO */
+
+    @Override
+    Provider<BuildTypeAdapter> getBuildTypeProvider(String variantName) {
+        def variant = withVariant(variantName)
+        def isMinifyEnabled = variant.properties.getOrDefault('minifyEnabled',
+                variant.properties.get("minifiedEnabled"))  // really?
+        if (buildHelper.dexguardHelper && buildHelper.dexguardHelper.enabled) {
+            isMinifyEnabled |= buildHelper.dexguardHelper.variantConfigurations.get().containsKey(variantName)
+        }
+        def buildTypeAdapter = new BuildTypeAdapter(variant.name, isMinifyEnabled, variant.flavorName, variant.buildType)
+
+        return buildHelper.project.objects.property(Object).value(buildTypeAdapter)
+    }
+
+    @Override
+    def wiredWithTransformProvider(String variantName) {
+        if (GradleVersion.current() < GradleVersion.version("7.5")) {
+            return super.wiredWithTransformProvider(variantName)
+        }
+
+        def transformProvider = getTransformProvider(variantName)
+        withVariant(variantName).artifacts
+                .forScope(ScopedArtifacts.Scope.ALL)
+                .use(transformProvider)
+                .toTransform(ScopedArtifact.CLASSES.INSTANCE, { it.getClassJars() }, { it.getClassDirectories() }, { it.getOutputJar() })
+
+        return transformProvider
+    }
+
+    @Override
+    def wiredWithConfigProvider(String variantName) {
+        def configProvider = super.wiredWithConfigProvider(variantName)
+        withVariant(variantName).sources.java.addGeneratedSourceDirectory(configProvider, { it.getSourceOutputDir() })
+
+        return configProvider
+    }
+}

--- a/samples/agent-test-app/android.gradle
+++ b/samples/agent-test-app/android.gradle
@@ -93,9 +93,8 @@ dependencies {
 // DG 9.+
 //
 if (project.plugins.hasPlugin("dexguard")) {
-    logger.quiet "[newrelic] [agent-test-app] using DexGuard[${versions.dexguard.base}]"
-
     if (compiler == 'dexguard') {
+        logger.quiet "[newrelic] [agent-test-app] using DexGuard[${versions.dexguard.base}]"
         dexguard {
             version = versions.dexguard.base
 

--- a/samples/agent-test-app/build.gradle
+++ b/samples/agent-test-app/build.gradle
@@ -79,19 +79,11 @@ subprojects {
 
 
 logger.quiet "[newrelic] [agent-test-app] JDK version [${System.getProperty('java.version')}]"
-logger.quiet "[newrelic] [agent-test-app] Gradle version [${GradleVersion.current()}]"
+logger.quiet "[newrelic] [agent-test-app] Gradle version [${GradleVersion.current().version}]"
 logger.quiet "[newrelic] [agent-test-app] AGP plugin version [${versions.agp.plugin}]"
 logger.quiet "[newrelic] [agent-test-app] withProductFlavors[${project.withProductFlavors.toBoolean()}]"
 logger.quiet "[newrelic] [agent-test-app] using dex compiler[$project.compiler]"
 logger.quiet "[newrelic] [agent-test-app] appy NR plugins[$project.applyPlugin]"
-
-if (project.compiler && project.compiler.startsWith('dexguard')) {
-    logger.quiet "[newrelic] [agent-test-app] Dexguard license[${System.getProperty('dexguard.license', System.getenv('DEXGUARD_LICENSE'))}]"
-    logger.quiet "[newrelic] [agent-test-app] Dexguard home[${versions.dexguard.home}]"
-    logger.quiet "[newrelic] [agent-test-app] Dexguard base version[${versions.dexguard.base}]"
-    logger.quiet "[newrelic] [agent-test-app] Dexguard plugin version[${versions.dexguard.plugin}]"
-    apply plugin: 'dexguard'
-}
 
 project.tasks.register("cleanRoot", Delete) {
     delete rootProject.buildDir
@@ -104,6 +96,13 @@ project.tasks.register("cleanRoot", Delete) {
  */
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
+if (project.compiler && project.compiler.startsWith('dexguard')) {
+    logger.quiet "[newrelic] [agent-test-app] Dexguard license[${System.getProperty('dexguard.license', System.getenv('DEXGUARD_LICENSE'))}]"
+    logger.quiet "[newrelic] [agent-test-app] Dexguard home[${versions.dexguard.home}]"
+    logger.quiet "[newrelic] [agent-test-app] Dexguard base version[${versions.dexguard.base}]"
+    logger.quiet "[newrelic] [agent-test-app] Dexguard plugin version[${versions.dexguard.plugin}]"
+    apply plugin: 'dexguard'
+}
 apply from: "android.gradle"
 
 android {

--- a/samples/agent-test-app/buildconfig.gradle
+++ b/samples/agent-test-app/buildconfig.gradle
@@ -43,7 +43,7 @@ buildscript {
                 ],
 
                 dexguard: [
-                        base  : hasOptional('dexguard.base.version', '9.3.6'),
+                        base  : hasOptional('dexguard.base.version', '9.3.26'),
                         plugin: hasOptional('dexguard.plugin.version', '1.+'),
                         home  : hasOptional('dexguard.home', '')
                 ],

--- a/samples/agent-test-app/gradle.properties
+++ b/samples/agent-test-app/gradle.properties
@@ -22,7 +22,7 @@ applyPlugin=true
 
 ## DexGuard 9.+
 # compiler=dexguard
-# dexguard.base.version=9.3.6
+# dexguard.base.version=9.3.26
 # dexguard.plugin.version=1.+
 # dexguardMavenToken=<from GuardSquare account>
 

--- a/samples/agent-test-app/library/build.gradle
+++ b/samples/agent-test-app/library/build.gradle
@@ -7,8 +7,6 @@
  *  Android library component
  */
 
-project.applyPlugin = true
-
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.kotlin.android"
 

--- a/samples/agent-test-app/src/main/AndroidManifest.xml
+++ b/samples/agent-test-app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.newrelic.agent.android.testapp">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
DG 9 does *not* yet support AGP 8, so this is to validate the plugin with DG 9.3 on AGP 7.x. 

**DG 9.4.+ appears the fail regardless of whether the agent is involved.**

* Updated tests
* Update agent test harness for DexGuard

@ywang-nr We need to update DexGuard levels (DG 9 is minimum, but only up to AGP7.x), and add comments regarding DG support for Gradle 8