### PR TITLE
[NR-156833] Revert obfuscation flag name in embedded NewRelicConfig class

### DIFF
--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
@@ -73,6 +73,7 @@ class PluginJDK11SmokeSpec extends PluginSpec {
                     "/generated/java/newrelicConfig${var.capitalize()}/com/newrelic/agent/android/NewRelicConfig.java")
             configTmpl.exists() && configTmpl.canRead()
             configTmpl.text.find(~/BUILD_ID = \"(.*)\".*/)
+            configTmpl.text.contains("Boolean OBFUSCATED = true;")
 
             def configClass = new File(buildDir, "/intermediates/javac/${var}/classes/com/newrelic/agent/android/NewRelicConfig.class")
             configClass.exists() && configClass.canRead()

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
@@ -71,6 +71,7 @@ class PluginJDK17SmokeSpec extends PluginSpec {
                     "/generated/java/newrelicConfig${var.capitalize()}/com/newrelic/agent/android/NewRelicConfig.java")
             configTmpl.exists() && configTmpl.canRead()
             configTmpl.text.find(~/BUILD_ID = \"(.*)\".*/)
+            configTmpl.text.contains("Boolean OBFUSCATED = true;")
 
             def configClass = new File(buildDir, "/intermediates/javac/${var}/classes/com/newrelic/agent/android/NewRelicConfig.class")
             configClass.exists() && configClass.canRead()

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
@@ -52,7 +52,7 @@ abstract class NewRelicConfigTask extends DefaultTask {
                         final class NewRelicConfig {
                             static final String VERSION = "${InstrumentationAgent.getVersion()}";
                             static final String BUILD_ID = "${buildId.get()}";
-                            static final Boolean MINIFIED = ${minifyEnabled.getOrElse(false)};
+                            static final Boolean OBFUSCATED = ${minifyEnabled.getOrElse(false)};
                             static final String MAP_PROVIDER = "${mapProvider.get()}";
                             static final String METRICS = "${buildMetrics.getOrElse("")}";
                             public static String getBuildId() {


### PR DESCRIPTION
Normalized name breaks ingest crash/Hex deobfuscation. 

Updated tests.