### PR TITLE
[NR-152229] Silence "duplicate entry" errors during instrumentation

### DIFF
--- a/.github/workflows/sonatypeDeployment.yml
+++ b/.github/workflows/sonatypeDeployment.yml
@@ -1,8 +1,6 @@
 name: Sonatype Deployment
 
 on:
-  push:
-    branches: ["main", "release/*"]
   pull_request:
     branches: ["main", "release/*"]
   workflow_dispatch:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.0.1
+newrelic.agent.version = 7.1.0
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 


### PR DESCRIPTION
This is not a bug, but rather a side-effect of AGP's instrumentation model. Prior, JAR files were rewritten in place, and with updated model all instrumented classes to into the same JAR. So if dependencies share the same package names, manifest and directory entries will be rejected as duplicates when processed. As long as these aren't class files, the error is misleading.