### PR TITLE
[NR-163742] AGP 7.2, 7.3 must use legacy class transformer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.1.0
+newrelic.agent.version = 7.1.1
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 

--- a/plugins/gradle/build.gradle
+++ b/plugins/gradle/build.gradle
@@ -157,7 +157,6 @@ def functionalTestTask = tasks.register("functionalTests", Test) {
 
 tasks.named('check') {
     dependsOn(tasks.named("integrationTests"))
- // dependsOn(tasks.named("functionalTests"))
 }
 
 artifacts {

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/VariantAdapterTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/VariantAdapterTest.groovy
@@ -92,8 +92,7 @@ class VariantAdapterTest extends PluginTest {
     @Test
     void getMappingFile() {
         variantAdapter.getVariantValues().each { variant ->
-            def provider = variantAdapter.getMappingFileProvider("release")
-            // variant.name)
+            def provider = variantAdapter.getMappingFileProvider(variant.name)
             Assert.assertTrue(provider instanceof RegularFileProperty)
             Assert.assertTrue(provider.get().asFile.absolutePath.startsWith(project.layout.buildDirectory.asFile.get().absolutePath))
         }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/VariantAdapterTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/VariantAdapterTest.groovy
@@ -5,16 +5,14 @@
 
 package com.newrelic.agent.android
 
-import com.newrelic.agent.android.obfuscation.Proguard
+import com.newrelic.agent.android.agp4.AGP4Adapter
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.compile.JavaCompile
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 
-@Ignore("TODO")
 class VariantAdapterTest extends PluginTest {
 
     BuildHelper buildHelper
@@ -28,23 +26,19 @@ class VariantAdapterTest extends PluginTest {
 
     @BeforeEach
     void setup() {
-        // Create the instances needed to test this class
         if (applyPlugin) {
             ext = plugin.pluginExtension
-            buildHelper = plugin.buildHelper
+            buildHelper = Mockito.spy(plugin.buildHelper)
         } else {
             ext = NewRelicExtension.register(project)
             buildHelper = Mockito.spy(BuildHelper.register(project))
-            Mockito.doReturn("7.6").when(buildHelper).getGradleVersion()
         }
         variantAdapter = buildHelper.variantAdapter
-        variantAdapter.configure(ext)
-
-        Assert.assertFalse(variantAdapter.getVariantValues().isEmpty())
     }
 
     @Test
     void getVariants() {
+        variantAdapter.configure(ext)
         Assert.assertFalse(variantAdapter.getVariantValues().isEmpty())
     }
 
@@ -98,7 +92,8 @@ class VariantAdapterTest extends PluginTest {
     @Test
     void getMappingFile() {
         variantAdapter.getVariantValues().each { variant ->
-            def provider = variantAdapter.getMappingFileProvider("release") // variant.name)
+            def provider = variantAdapter.getMappingFileProvider("release")
+            // variant.name)
             Assert.assertTrue(provider instanceof RegularFileProperty)
             Assert.assertTrue(provider.get().asFile.absolutePath.startsWith(project.layout.buildDirectory.asFile.get().absolutePath))
         }
@@ -135,4 +130,28 @@ class VariantAdapterTest extends PluginTest {
     void getLogger() {
         Assert.assertEquals(buildHelper.logger, NewRelicGradlePlugin.LOGGER)
     }
+
+    @Test
+    void getVariantAdapterByGradleVersion() {
+        buildHelper = Mockito.spy(BuildHelper.register(project))
+        Mockito.doReturn("7.2").when(buildHelper).getAgpVersion()
+        Mockito.doReturn("7.3.3").when(buildHelper).getGradleVersion()
+        def adapter = VariantAdapter.register(buildHelper)
+        Assert.assertTrue(adapter instanceof AGP4Adapter)
+
+        buildHelper = Mockito.spy(BuildHelper.register(project))
+        Mockito.doReturn("7.3").when(buildHelper).getAgpVersion()
+        Mockito.doReturn("7.4").when(buildHelper).getGradleVersion()
+        adapter = VariantAdapter.register(buildHelper)
+        Assert.assertTrue(adapter instanceof AGP4Adapter)
+    }
+
+    @Test
+    void getVariantAdapterByAGPVersion() {
+        buildHelper = Mockito.spy(BuildHelper.register(project))
+        Mockito.doReturn("7.3.3").when(buildHelper).getAgpVersion()
+        def adapter = VariantAdapter.register(buildHelper)
+        Assert.assertTrue(adapter instanceof AGP4Adapter)
+    }
+
 }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -62,17 +62,13 @@ abstract class VariantAdapter {
      */
     static VariantAdapter register(BuildHelper buildHelper) {
         def currentGradleVersion = GradleVersion.version(buildHelper.getGradleVersion())
+        def currentAgpVersion = GradleVersion.version(buildHelper.getAgpVersion())
 
-        if (currentGradleVersion >= GradleVersion.version("7.4")) {
-            return new AGP74Adapter(buildHelper)
-        } else if (currentGradleVersion >= GradleVersion.version("7.2")) {
-            if (GradleVersion.version(buildHelper.agpVersion) < GradleVersion.version("7.2")) {
-                return new AGP4Adapter(buildHelper)
-            }
-            return new AGP70Adapter(buildHelper)
-        } else {
+        if (currentAgpVersion < GradleVersion.version("7.4")) {
             return new AGP4Adapter(buildHelper)
         }
+
+        return new AGP74Adapter(buildHelper)
     }
 
     Set<String> getVariantNames() {
@@ -259,7 +255,7 @@ abstract class VariantAdapter {
      */
     def assembleDataModel(String variantName) {
         // assemble and configure model
-        if (buildHelper.extension.shouldIncludeVariant(variantName)) {
+         if (buildHelper.extension.shouldIncludeVariant(variantName)) {
             wiredWithTransformProvider(variantName)
         }
 


### PR DESCRIPTION
Transform API is still available to those using Gradle 7.4.0 and below, so default to that for AGP 7.3, 7.2 and lower.