### PR TITLE
fix: Fragment instrumentation broken by refactoring

### DIFF
--- a/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/AgentDelegateClassVisitor.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/AgentDelegateClassVisitor.java
@@ -60,6 +60,7 @@ public abstract class AgentDelegateClassVisitor extends ClassVisitor {
         }};
 
         this.methodAccessMap = delegateMethodAccessMap;
+        this.superName = context.getSuperClassName();
     }
 
     @Override
@@ -187,7 +188,7 @@ public abstract class AgentDelegateClassVisitor extends ClassVisitor {
                         for (int i = 0; i < method.getArgumentTypes().length; i++) {
                             loadArg(i);
                         }
-                        visitMethodInsn(Opcodes.INVOKESPECIAL, context.getFriendlySuperClassName(), method.getName(), method.getDescriptor(), false);
+                        visitMethodInsn(Opcodes.INVOKESPECIAL, superName, method.getName(), method.getDescriptor(), false);
                     }
                     injectIntoMethod(this, method, agentDelegateMethod);
                 }


### PR DESCRIPTION
Problem was a typo, really, but adds assignment of superName in ctor.