### PR TITLE
HttpHeaders as Custom Attributes and GRAPHQL Request Headers Capture

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/HttpHeaders.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/HttpHeaders.java
@@ -1,0 +1,62 @@
+package com.newrelic.agent.android;
+
+
+import com.newrelic.agent.android.util.Constants;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class HttpHeaders {
+
+    protected static final AtomicReference<HttpHeaders> instance = new AtomicReference<>(new HttpHeaders());
+    private final Set<String> httpHeaders;
+
+    public static final String OPERATION_NAME = "operationName";
+    public static final String OPERATION_TYPE = "operationType";
+    public static final String OPERATION_ID = "operationId";
+
+    private HttpHeaders() {
+        httpHeaders = new HashSet<>();
+        httpHeaders.add(Constants.ApolloGraphQLHeader.OPERATION_NAME);
+        httpHeaders.add(Constants.ApolloGraphQLHeader.OPERATION_ID);
+        httpHeaders.add(Constants.ApolloGraphQLHeader.OPERATION_TYPE);
+    }
+
+    public static HttpHeaders getInstance() {
+        return instance.get();
+    }
+
+    public void addHttpHeaderAsAttribute(String httpHeader) {
+        httpHeaders.add(httpHeader);
+    }
+
+    public void removeHttpHeaderAsAttribute(String httpHeader) {
+        if (!(Constants.ApolloGraphQLHeader.OPERATION_ID.equalsIgnoreCase(httpHeader) || Constants.ApolloGraphQLHeader.OPERATION_NAME.equalsIgnoreCase(httpHeader) || Constants.ApolloGraphQLHeader.OPERATION_TYPE.equalsIgnoreCase(httpHeader)))
+            httpHeaders.remove(httpHeader);
+    }
+
+    public boolean addHttpHeadersAsAttributes(List<String> httpHeaders) {
+        return this.httpHeaders.addAll(httpHeaders);
+    }
+
+    public Set<String> getHttpHeaders() {
+        return httpHeaders;
+    }
+
+
+    public static String translateApolloHeader(String s) {
+
+        switch (s) {
+            case Constants.ApolloGraphQLHeader.OPERATION_NAME:
+                return OPERATION_NAME;
+            case Constants.ApolloGraphQLHeader.OPERATION_ID:
+                return OPERATION_ID;
+            case Constants.ApolloGraphQLHeader.OPERATION_TYPE:
+                return OPERATION_TYPE;
+            default:
+                return s;
+        }
+    }
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/api/common/TransactionData.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/api/common/TransactionData.java
@@ -9,6 +9,7 @@ import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.distributedtracing.TraceContext;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -30,9 +31,9 @@ public class TransactionData {
 
 
     // optionals
-    private int errorCode = 0;
-    private String responseBody = null;
-    private Map<String, String> params = null;
+    private int errorCode;
+    private String responseBody;
+    private Map<String, String> params;
 
 
     public TransactionData(final String url, final String httpMethod, final String carrier, final float time,
@@ -45,9 +46,8 @@ public class TransactionData {
                 endPos = url.length();
             }
         }
-        final String trimmedUrl = url.substring(0, endPos);
 
-        this.url = trimmedUrl;
+        this.url = url.substring(0, endPos);
         this.httpMethod = httpMethod;
         this.carrier = carrier;
         this.time = time;
@@ -59,7 +59,7 @@ public class TransactionData {
         this.wanType = wanType;
         this.timestamp = System.currentTimeMillis();
         this.responseBody = null;
-        this.params = null;
+        this.params = new HashMap<>();
         this.traceContext = traceContext;
         this.traceAttributes = traceAttributes;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/HttpsURLConnectionExtension.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/HttpsURLConnectionExtension.java
@@ -45,7 +45,7 @@ import javax.net.ssl.SSLSocketFactory;
 // The constraints that apply to HttpURLConnectionExtension also apply to this class.
 //
 public class HttpsURLConnectionExtension extends HttpsURLConnection {
-    private HttpsURLConnection impl;
+    private final HttpsURLConnection impl;
     private TransactionState transactionState;
     private CountingInputStream errorStream = null;
 
@@ -84,6 +84,7 @@ public class HttpsURLConnectionExtension extends HttpsURLConnection {
     @Override
     public void addRequestProperty(String field, String newValue) {
         impl.addRequestProperty(field, newValue);
+        TransactionStateUtil.addHeadersAsCustomAttribute(transactionState, field, newValue);
     }
 
     @Override
@@ -111,6 +112,7 @@ public class HttpsURLConnectionExtension extends HttpsURLConnection {
         //     and we'll never know about it. That's okay.
         //
         getTransactionState();
+
 
         try {
             impl.connect();
@@ -217,7 +219,7 @@ public class HttpsURLConnectionExtension extends HttpsURLConnection {
                 }
             }
         } catch (Exception e) {
-            log.error("HttpsURLConnectionExtension: " + e.toString());
+            log.error("HttpsURLConnectionExtension: " + e);
             return impl.getErrorStream();
         }
         return errorStream;
@@ -527,6 +529,7 @@ public class HttpsURLConnectionExtension extends HttpsURLConnection {
     @Override
     public void setRequestProperty(String field, String newValue) {
         impl.setRequestProperty(field, newValue);
+        TransactionStateUtil.addHeadersAsCustomAttribute(transactionState, field, newValue);
     }
 
     @Override
@@ -599,7 +602,7 @@ public class HttpsURLConnectionExtension extends HttpsURLConnection {
                         responseBody = ((CountingInputStream) errorStream).getBufferAsString();
                     }
                 } catch (Exception e1) {
-                    log.error("HttpsURLConnectionExtension.error: " + e1.toString());
+                    log.error("HttpsURLConnectionExtension.error: " + e1);
                 }
 
                 transactionData.setResponseBody(responseBody);
@@ -625,7 +628,7 @@ public class HttpsURLConnectionExtension extends HttpsURLConnection {
                     responseBody = ((CountingInputStream) errorStream).getBufferAsString();
                 }
             } catch (Exception e) {
-                log.error("HttpsURLConnectionExtension.addTransactionAndErrorData: " + e.toString());
+                log.error("HttpsURLConnectionExtension.addTransactionAndErrorData: " + e);
             }
 
             // If there is a Content-Type header present, add it to the error param map.
@@ -642,7 +645,8 @@ public class HttpsURLConnectionExtension extends HttpsURLConnection {
             params.put(Constants.Transactions.CONTENT_LENGTH, transactionState.getBytesReceived() + "");
 
             transactionData.setResponseBody(responseBody);
-            transactionData.setParams(params);
+
+            transactionData.getParams().putAll(params);
 
         }
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/TransactionState.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/TransactionState.java
@@ -19,6 +19,8 @@ import com.newrelic.agent.android.util.Util;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 public class TransactionState {
 
@@ -36,7 +38,7 @@ public class TransactionState {
     private int errorCode = 0;
     private long bytesSent = 0;
     private long bytesReceived = 0;
-    private long startTime = 0;
+    private long startTime;
     private long endTime = 0;
     private String appData;
     private String carrier = CarrierType.UNKNOWN;
@@ -46,8 +48,19 @@ public class TransactionState {
     private TransactionData transactionData;
     private TraceContext trace;
 
+    private Map<String, String> params;
+
+    public Map<String, String> getParams() {
+        return params;
+    }
+
+    public void setParams(Map<String, String> params) {
+        this.params = params;
+    }
+
     public TransactionState() {
         this.startTime = System.currentTimeMillis();
+        this.params = new HashMap<>();
         TraceMachine.enterNetworkSegment("External/unknownhost");
     }
 
@@ -229,7 +242,7 @@ public class TransactionState {
                     bytesSent,
                     bytesReceived,
                     appData,
-                    wanType, trace, null);
+                    wanType, trace, "", params, null);
         }
 
         return transactionData;

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/TransactionStateUtil.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/TransactionStateUtil.java
@@ -7,6 +7,7 @@ package com.newrelic.agent.android.instrumentation;
 
 import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.FeatureFlag;
+import com.newrelic.agent.android.HttpHeaders;
 import com.newrelic.agent.android.distributedtracing.DistributedTracing;
 import com.newrelic.agent.android.distributedtracing.TraceContext;
 import com.newrelic.agent.android.distributedtracing.TraceHeader;
@@ -17,6 +18,8 @@ import com.newrelic.agent.android.util.ExceptionHelper;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
 
 @SuppressWarnings("deprecation")
 public class TransactionStateUtil {
@@ -90,6 +93,7 @@ public class TransactionStateUtil {
      * @param conn
      */
     static void setDistributedTraceHeaders(TransactionState transactionState, HttpURLConnection conn) {
+
         if (FeatureFlag.featureEnabled(FeatureFlag.DistributedTracing)) {
             try {
                 TraceContext traceContext = transactionState.getTrace();
@@ -118,4 +122,16 @@ public class TransactionStateUtil {
         }
     }
 
+
+    public static void addHeadersAsCustomAttribute(TransactionState transactionState, String field, String newValue) {
+        if (HttpHeaders.getInstance().getHttpHeaders().contains(field)) {
+            if (transactionState.getParams() != null) {
+                transactionState.getParams().put(field, newValue);
+            } else {
+                Map<String, String> headers = new HashMap<>();
+                headers.put(field, newValue);
+                transactionState.setParams(headers);
+            }
+        }
+    }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp2/OkHttp2TransactionStateUtil.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp2/OkHttp2TransactionStateUtil.java
@@ -6,7 +6,6 @@
 package com.newrelic.agent.android.instrumentation.okhttp2;
 
 import com.newrelic.agent.android.FeatureFlag;
-import com.newrelic.agent.android.Measurements;
 import com.newrelic.agent.android.TaskQueue;
 import com.newrelic.agent.android.api.common.TransactionData;
 import com.newrelic.agent.android.distributedtracing.TraceContext;
@@ -132,7 +131,7 @@ public class OkHttp2TransactionStateUtil extends TransactionStateUtil {
                 }
 
                 transactionData.setResponseBody(responseBodyString);
-                transactionData.setParams(params);
+                transactionData.getParams().putAll(params);
 
 
                 response = setDistributedTraceHeaders(transactionState, response);
@@ -185,9 +184,8 @@ public class OkHttp2TransactionStateUtil extends TransactionStateUtil {
                                 }
                             }
                         }
-                    } else {
-                        // read the response? bad!
-                    }
+                    }  // read the response? bad!
+
                 }
             }
         }

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3Instrumentation.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3Instrumentation.java
@@ -6,6 +6,7 @@
 package com.newrelic.agent.android.instrumentation.okhttp3;
 
 import com.newrelic.agent.android.FeatureFlag;
+import com.newrelic.agent.android.HttpHeaders;
 import com.newrelic.agent.android.distributedtracing.DistributedTracing;
 import com.newrelic.agent.android.distributedtracing.TraceContext;
 import com.newrelic.agent.android.instrumentation.HttpURLConnectionExtension;
@@ -18,6 +19,8 @@ import com.newrelic.agent.android.logging.AgentLogManager;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -42,6 +45,7 @@ public class OkHttp3Instrumentation {
     @ReplaceCallSite
     public static Call newCall(OkHttpClient client, Request request) {
         TransactionState transactionState = new TransactionState();
+        addHeadersAsCustomAttribute(transactionState, request);
         if (FeatureFlag.featureEnabled(FeatureFlag.DistributedTracing)) {
             try {
                 // start the trace with a new call
@@ -56,6 +60,17 @@ public class OkHttp3Instrumentation {
             }
         }
         return new CallExtension(client, request, client.newCall(request), transactionState);
+    }
+
+    private static void addHeadersAsCustomAttribute(TransactionState transactionState, Request request) {
+
+        Map<String, String> headers = new HashMap<>();
+        for (String s : HttpHeaders.getInstance().getHttpHeaders()) {
+            if (request.headers().get(s) != null) {
+                headers.put(HttpHeaders.translateApolloHeader(s), request.headers().get(s));
+            }
+        }
+        transactionState.setParams(headers);
     }
 
     @ReplaceCallSite

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3TransactionStateUtil.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3TransactionStateUtil.java
@@ -6,7 +6,6 @@
 package com.newrelic.agent.android.instrumentation.okhttp3;
 
 import com.newrelic.agent.android.FeatureFlag;
-import com.newrelic.agent.android.Measurements;
 import com.newrelic.agent.android.TaskQueue;
 import com.newrelic.agent.android.api.common.TransactionData;
 import com.newrelic.agent.android.distributedtracing.TraceContext;
@@ -94,7 +93,7 @@ public class OkHttp3TransactionStateUtil extends TransactionStateUtil {
                     try {
                         contentLength = Long.parseLong(responseBodyString);
                     } catch (NumberFormatException var10) {
-                        log.debug("Failed to parse content length: " + var10.toString());
+                        log.debug("Failed to parse content length: " + var10);
                     }
                 } else {
                     Response networkResponse = response.networkResponse();
@@ -104,7 +103,7 @@ public class OkHttp3TransactionStateUtil extends TransactionStateUtil {
                             try {
                                 contentLength = Long.parseLong(responseBodyString);
                             } catch (NumberFormatException var5) {
-                                log.debug("Failed to parse network response content length: " + var5.toString());
+                                log.debug("Failed to parse network response content length: " + var5);
                             }
                         } else {
                             if (networkResponse.body() != null) {
@@ -158,7 +157,8 @@ public class OkHttp3TransactionStateUtil extends TransactionStateUtil {
                 }
 
                 transactionData.setResponseBody(responseBodyString);
-                transactionData.setParams(params);
+                transactionData.getParams().putAll(params);
+
 
             }
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
@@ -12,6 +12,13 @@ public final class Constants {
         public static final String CONTENT_TYPE = "content_type";
     }
 
+    public static final class ApolloGraphQLHeader {
+        public static final String OPERATION_NAME = "X-APOLLO-OPERATION-NAME";
+        public static final String OPERATION_TYPE = "X-APOLLO-OPERATION-TYPE";
+        public static final String OPERATION_ID = "X-APOLLO-OPERATION-ID";
+
+    }
+
     public final class Network {
         public static final String APPLICATION_LICENSE_HEADER = "X-App-License-Key";
         public static final String APPLICATION_ID_HEADER = "X-APPLICATION-ID";

--- a/agent-core/src/test/java/com/newrelic/agent/android/HttpHeadersTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/HttpHeadersTest.java
@@ -1,0 +1,77 @@
+package com.newrelic.agent.android;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.newrelic.agent.android.util.Constants;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class HttpHeadersTest {
+    private HttpHeaders httpHeaders;
+
+    @Before
+    public void setUp() {
+        httpHeaders = HttpHeaders.getInstance();
+
+    }
+
+    @Test
+    public void testGetInstance() {
+        HttpHeaders newInstance = HttpHeaders.getInstance();
+        assertNotNull(newInstance);
+        assertEquals(httpHeaders, newInstance);
+    }
+
+    @Test
+    public void testAddHttpHeaderAsAttribute() {
+        httpHeaders.addHttpHeaderAsAttribute("X-Custom-Header");
+        assertTrue(httpHeaders.getHttpHeaders().contains("X-Custom-Header"));
+    }
+
+    @Test
+    public void testDefaultHttpHeadersAsAttributes() {
+        List<String> headers = Arrays.asList("X-Custom-Header", "X-APOLLO-OPERATION-NAME", "X-APOLLO-OPERATION-TYPE", "X-APOLLO-OPERATION-ID", "X-Custom-Header-1", "X-Custom-Header-2");
+        HashSet<String> headersSet = new HashSet<>(headers);
+        assertEquals(headersSet, httpHeaders.getHttpHeaders());
+    }
+
+
+    @Test
+    public void testAddHttpHeadersAsAttributes() {
+        List<String> headersToAdd = Arrays.asList("X-Custom-Header-1", "X-Custom-Header-2");
+        assertTrue(httpHeaders.addHttpHeadersAsAttributes(headersToAdd));
+        assertEquals(5, httpHeaders.getHttpHeaders().size());
+    }
+
+    @Test
+    public void testRemoveHttpHeaderAsAttribute() {
+        httpHeaders.removeHttpHeaderAsAttribute("X-Custom-Header");
+        assertFalse(httpHeaders.getHttpHeaders().contains("X-Custom-Header"));
+    }
+
+    @Test
+    public void testTranslateApolloHeader() {
+        String otherHeader = "otherHeader";
+
+        assertEquals(HttpHeaders.OPERATION_NAME,
+                HttpHeaders.translateApolloHeader(Constants.ApolloGraphQLHeader.OPERATION_NAME));
+        assertEquals(HttpHeaders.OPERATION_ID,
+                HttpHeaders.translateApolloHeader(Constants.ApolloGraphQLHeader.OPERATION_ID));
+        assertEquals(HttpHeaders.OPERATION_TYPE,
+                HttpHeaders.translateApolloHeader(Constants.ApolloGraphQLHeader.OPERATION_TYPE));
+
+        assertEquals(otherHeader,
+                HttpHeaders.translateApolloHeader(otherHeader));
+    }
+
+
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/instrumentation/HttpsURLConnectionExtensionTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/instrumentation/HttpsURLConnectionExtensionTest.java
@@ -6,6 +6,7 @@
 package com.newrelic.agent.android.instrumentation;
 
 import com.newrelic.agent.android.FeatureFlag;
+import com.newrelic.agent.android.HttpHeaders;
 import com.newrelic.agent.android.distributedtracing.TraceParent;
 import com.newrelic.agent.android.distributedtracing.TracePayload;
 import com.newrelic.agent.android.distributedtracing.TraceState;
@@ -14,6 +15,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -22,9 +24,16 @@ import javax.net.ssl.HttpsURLConnection;
 public class HttpsURLConnectionExtensionTest {
 
     final String requestUrl = "https://httpbin.org/status/418";
+    final String headerName = "X-Custom-Header-1";
+
+    final String header2Name = "X-Custom-Header-2";
+
+    final String headerValue = "Custom-Value";
+
+    final String header2Value = "Custom-Value-1";
 
     @Test
-    public void testInjectDistributedTracePayload(){
+    public void testInjectDistributedTracePayload() {
         FeatureFlag.enableFeature(FeatureFlag.DistributedTracing);
 
         try {
@@ -39,12 +48,59 @@ public class HttpsURLConnectionExtensionTest {
             Assert.assertTrue(requestPayload.containsKey(TracePayload.TRACE_PAYLOAD_HEADER));
             Assert.assertTrue(requestPayload.containsKey(TraceState.TRACE_STATE_HEADER));
             Assert.assertTrue(requestPayload.containsKey(TraceParent.TRACE_PARENT_HEADER));
-        } catch (IllegalStateException e) {
-            Assert.fail(e.getMessage());
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
 
         FeatureFlag.disableFeature(FeatureFlag.DistributedTracing);
+    }
+
+    @Test
+    public void testHeadersCaptureFromRequestForCustomAttribute() {
+
+
+        List<String> httpHeaders = new ArrayList<>();
+        httpHeaders.add(headerName);
+        httpHeaders.add(header2Name);
+        HttpHeaders.getInstance().addHttpHeadersAsAttributes(httpHeaders);
+
+        try {
+            URL url = new URL(requestUrl);
+            HttpsURLConnection urlConnection = (HttpsURLConnection) url.openConnection();
+            final HttpsURLConnectionExtension instrumentedConnection = new HttpsURLConnectionExtension(urlConnection);
+            instrumentedConnection.setRequestProperty(headerName, headerValue);
+            instrumentedConnection.setRequestProperty(header2Name, header2Value);
+            TransactionState transactionState = instrumentedConnection.getTransactionState();
+            Assert.assertNotNull(transactionState.getTrace());
+
+            Assert.assertEquals(2, transactionState.getParams().size());
+            Assert.assertTrue(transactionState.getParams().containsKey(headerName));
+            Assert.assertTrue(transactionState.getParams().containsKey(header2Name));
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+
+        FeatureFlag.disableFeature(FeatureFlag.DistributedTracing);
+    }
+
+    @Test
+    public void testHeadersCaptureFromRequestForCustomAttributeWhenNoHeadersToCapture() {
+
+        HttpHeaders.getInstance().removeHttpHeaderAsAttribute(headerName);
+        try {
+            URL url = new URL(requestUrl);
+            HttpsURLConnection urlConnection = (HttpsURLConnection) url.openConnection();
+            final HttpURLConnectionExtension instrumentedConnection = new HttpURLConnectionExtension(urlConnection);
+            instrumentedConnection.setRequestProperty(headerName, headerValue);
+            TransactionState transactionState = instrumentedConnection.getTransactionState();
+            Assert.assertNotNull(transactionState.getTrace());
+
+            Assert.assertEquals(0, transactionState.getParams().size());
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+
+        HttpHeaders.getInstance().addHttpHeaderAsAttribute(headerName);
+
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/instrumentation/okhttp2/OkHttp2TransactionStateUtilTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/instrumentation/okhttp2/OkHttp2TransactionStateUtilTest.java
@@ -6,6 +6,7 @@
 package com.newrelic.agent.android.instrumentation.okhttp2;
 
 import com.newrelic.agent.android.FeatureFlag;
+import com.newrelic.agent.android.HttpHeaders;
 import com.newrelic.agent.android.distributedtracing.TraceParent;
 import com.newrelic.agent.android.distributedtracing.TracePayload;
 import com.newrelic.agent.android.distributedtracing.TraceState;
@@ -30,6 +31,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.newrelic.agent.android.harvest.type.HarvestErrorCodes.NSURLErrorDNSLookupFailed;
 import static org.junit.Assert.assertEquals;
@@ -41,10 +44,15 @@ public class OkHttp2TransactionStateUtilTest {
     private TransactionState transactionState;
     private OkHttpClient client = new OkHttpClient();
 
+    private List<String> headers;
+
     @Before
     public void setUp() throws Exception {
         transactionState = Providers.provideTransactionState();
         client = new OkHttpClient();
+        headers = new ArrayList<>();
+        headers.add("X-Custom-Header-1");
+        HttpHeaders.getInstance().addHttpHeadersAsAttributes(headers);
     }
 
     @Test
@@ -205,6 +213,55 @@ public class OkHttp2TransactionStateUtilTest {
         Assert.assertNotNull(transactionState.getTrace());
 
         FeatureFlag.disableFeature(FeatureFlag.DistributedTracing);
+    }
+
+    @Test
+    public void testHeadersCaptureFromRequestForCustomAttribute() {
+        final String requestUrl = "http://www.foo.com/";
+        final String appId = "some-app-id";
+
+        final StubAgentImpl agent = StubAgentImpl.install();
+
+        assertEquals(0, agent.getTransactionData().size());
+
+        final Request.Builder builder = new Request.Builder().
+                url(requestUrl).
+                header(Constants.Network.APPLICATION_ID_HEADER, appId).
+                header("X-Custom-Header-1", "custom").
+                get();
+
+        final Request request = OkHttp2Instrumentation.build(builder);
+
+        CallExtension call = (CallExtension) OkHttp2Instrumentation.newCall(client, request);
+        transactionState = call.getTransactionState();
+
+        Assert.assertNotNull(transactionState.getParams());
+
+    }
+
+    @Test
+    public void testHeadersCaptureWhenHeadersRemoved() {
+        final String requestUrl = "http://www.foo.com/";
+        final String appId = "some-app-id";
+
+        HttpHeaders.getInstance().removeHttpHeaderAsAttribute("X-Custom-Header-1");
+        final StubAgentImpl agent = StubAgentImpl.install();
+
+        assertEquals(0, agent.getTransactionData().size());
+
+        final Request.Builder builder = new Request.Builder().
+                url(requestUrl).
+                header(Constants.Network.APPLICATION_ID_HEADER, appId).
+                header("X-Custom-Header-1", "custom").
+                get();
+
+        final Request request = OkHttp2Instrumentation.build(builder);
+
+        CallExtension call = (CallExtension) OkHttp2Instrumentation.newCall(client, request);
+        transactionState = call.getTransactionState();
+
+        Assert.assertEquals(0, transactionState.getParams().size());
+
     }
 
     private Request provideRequest() {

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -36,6 +36,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 
@@ -1058,5 +1059,10 @@ public final class NewRelic {
      */
     public static boolean recordJSErrorException(StackTrace stackTrace) {
         return DataController.sendAgentData(stackTrace);
+    }
+
+
+    public static boolean  addHTTPHeadersTrackingFor(List<String> headers) {
+        return HttpHeaders.getInstance().addHttpHeadersAsAttributes(headers);
     }
 }


### PR DESCRIPTION
1) implemented a new feature to track HTTP headers that are added by the client when making an HTTP request. To achieve this, we added a static method that records these headers and adds them as custom attributes at the HTTP request level.

2) added a new feature to capture Apollo GraphQL HTTP headers, specifically related to the operation name, type, and ID. By capturing these headers, we can provide more granular insights into how GraphQL is being used, empowering our customers to gain a deeper understanding of their GraphQL data.



