### PR TITLE
[NR-24643] Exclude package instrumentation

### DIFF
--- a/.github/workflows/smokeTests.yml
+++ b/.github/workflows/smokeTests.yml
@@ -1,0 +1,62 @@
+name: Android Smoke Test Workflows
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke-test-jdk11:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - uses: gradle/gradle-build-action@v2.4.2
+        with:
+          gradle-version: current
+      - name: Stage with Gradle
+        run: ./gradlew publish
+      - name: Test with Gradle
+        run: ./gradlew :plugins:gradle:functionalTests --tests "com.newrelic.agent.android.PluginJDK11SmokeSpec"
+      - name: Upload build reports
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: smoke-test-jdk11-reports
+          path: |
+            build/reports/tests/test/index.html
+            build/reports/tests/integrationTests/index.html
+          if-no-files-found: ignore
+          retention-days: 3
+
+  smoke-test-jdk17:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - uses: gradle/gradle-build-action@v2.4.2
+        with:
+          gradle-version: current
+      - name: Stage with Gradle
+        run: ./gradlew publish
+      - name: Test with Gradle
+        run: ./gradlew :plugins:gradle:functionalTests --tests "com.newrelic.agent.android.PluginJDK17SmokeSpec"
+      - name: Upload build reports
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: smoke-test-jdk17-reports
+          path: |
+            build/reports/tests/test/index.html
+            build/reports/tests/integrationTests/index.html
+          if-no-files-found: ignore
+          retention-days: 3
+

--- a/instrumentation/src/main/java/com/newrelic/agent/compile/InvocationDispatcher.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/compile/InvocationDispatcher.java
@@ -79,7 +79,7 @@ public class InvocationDispatcher {
 
         String lowercasePackageName = packageName.toLowerCase();
         for (String name : Constants.ANDROID_EXCLUDED_PACKAGES) {
-            if (lowercasePackageName.startsWith(name)) {
+            if (lowercasePackageName.startsWith(name) || lowercasePackageName.matches(name)) {
                 return true;
             }
         }
@@ -129,13 +129,6 @@ public class InvocationDispatcher {
 
             className = instrumentationContext.getClassName();
 
-/*
-            if (isAndroidSDKPackage(className)) {
-                log.info("COMPOSE:");
-                log.info("COMPOSE classname[" + className + "]");
-            }
-*/
-
             if (!instrumentationContext.hasTag(Constants.INSTRUMENTED_CLASS_NAME)) {
                 //
                 // Second pass to actually do the work
@@ -151,7 +144,7 @@ public class InvocationDispatcher {
                 } else if (isAndroidSDKPackage(className)) {
                     cv = new ActivityClassVisitor(cv, instrumentationContext, log);
                 } else if (isExcludedPackage(className)) {
-                    // log.warn("[InvocationDispatcher] Excluding class [" + className + "]");
+                    // log.debug("[InvocationDispatcher] Excluding class [" + className + "]");
                     return null;
                 } else {
                     cv = new AnnotatingClassVisitor(cv, instrumentationContext, log);

--- a/instrumentation/src/test/java/com/newrelic/agent/compile/ClassTransformerTest.java
+++ b/instrumentation/src/test/java/com/newrelic/agent/compile/ClassTransformerTest.java
@@ -126,7 +126,7 @@ public class ClassTransformerTest {
         Assert.assertTrue(transformer.transformClassFile(classFile));
 
         try (InputStream inputFilestream = new ByteArrayInputStream(new FileInputStream(classFile).readAllBytes());
-             ByteArrayInputStream outputFilestream = transformer.processClassBytes(classFile.getName(), inputFilestream)) {
+             ByteArrayInputStream outputFilestream = transformer.transformClassByteStream(classFile.getName(), inputFilestream)) {
 
             inputFilestream.reset();
             ByteBuffer inBytes = ByteBuffer.wrap(inputFilestream.readAllBytes());
@@ -145,7 +145,7 @@ public class ClassTransformerTest {
         Assert.assertFalse(transformer.transformClassFile(classFile));
 
         try (InputStream inputFilestream = new ByteArrayInputStream(new FileInputStream(classFile).readAllBytes());
-             ByteArrayInputStream outputFilestream = transformer.processClassBytes(classFile.getName(), inputFilestream)) {
+             ByteArrayInputStream outputFilestream = transformer.transformClassByteStream(classFile.getName(), inputFilestream)) {
             inputFilestream.reset();
             ByteBuffer inBytes = ByteBuffer.wrap(inputFilestream.readAllBytes());
             ByteBuffer outBytes = ByteBuffer.wrap(outputFilestream.readAllBytes());

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
@@ -13,7 +13,7 @@ import spock.lang.Shared
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 
-@Retry(delay = 15000, count=2)
+@Retry(delay = 15000, count = 2)
 class PluginJDK11SmokeSpec extends PluginSpec {
 
     /* Last levels for JDK 11. Must use JDK 17 for AGP/Gradle 8.+    */
@@ -26,9 +26,9 @@ class PluginJDK11SmokeSpec extends PluginSpec {
 
     def setupSpec() {
         given: "create the build runner"
-            with(new File(projectRootDir, ".gradle/configuration-cache")) {
-                it.deleteDir()
-            }
+        with(new File(projectRootDir, ".gradle/configuration-cache")) {
+            it.deleteDir()
+        }
 
         def runner = provideRunner()
                 .withGradleVersion(gradleVersion)
@@ -122,6 +122,10 @@ class PluginJDK11SmokeSpec extends PluginSpec {
                     buildResult.task("library::${ClassTransformWrapperTask.NAME}${var.capitalize()}")?.outcome == SUCCESS)
             buildResult.task(":library:newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
         }
+    }
+
+    def "verify package exclusion"() {
+        filteredOutput.contains("Package [org/bouncycastle/crypto] has been excluded from instrumentation");
     }
 
 }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicExtensionTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicExtensionTest.groovy
@@ -90,10 +90,20 @@ class NewRelicExtensionTest extends PluginTest {
     }
 
     @Test
-    @Ignore("TODO")
-    void excludePackageInstrumentation() {
-        ext.excludePackageInstrumentation("com.newrelic", "com.android")
+    void shouldExcludePackageInstrumentation() {
+        ext.excludePackageInstrumentation("com.newrelic.android", "com.android")
         Assert.assertEquals(2, ext.packageExclusions.size())
+        Assert.assertTrue(ext.shouldExcludePackageInstrumentation("com.newrelic.android.agent.Agent.class"))
+        Assert.assertFalse(ext.shouldExcludePackageInstrumentation("com.newrelic.agent.Agent.class"))
+
+        ext.excludePackageInstrumentation("com.newrelic.*Agent.class", ".*\\.android.*agent\\..*")
+        Assert.assertTrue(ext.shouldExcludePackageInstrumentation("com/newrelic/android/agentAgent.class"))
+        Assert.assertTrue(ext.shouldExcludePackageInstrumentation("com.newrelic.agent.Agent.class"))
+
+        ext.excludePackageInstrumentation("com/newrelic/.*Agent.class", ".*\\.android.*agent\\..*")
+        Assert.assertTrue(ext.shouldExcludePackageInstrumentation("com/newrelic/android/agent/Agent.class"))
+        Assert.assertTrue(ext.shouldExcludePackageInstrumentation("com.newrelic.agent.Agent.class"))
+        Assert.assertFalse(ext.shouldExcludePackageInstrumentation("com.newrelik.agent.Agent.class"))
     }
 
     @Test
@@ -110,7 +120,7 @@ class NewRelicExtensionTest extends PluginTest {
             Assert.assertTrue(ext.shouldExcludeVariant(it))
         }
 
-        ext.excludeVariantInstrumentation("dweezil", "ahmet", "moon unit" )
+        ext.excludeVariantInstrumentation("dweezil", "ahmet", "moon unit")
         Assert.assertTrue(ext.shouldExcludeVariant("dweezil"))
         Assert.assertTrue(ext.shouldExcludeVariant("ahmet"))
         Assert.assertFalse(ext.shouldExcludeVariant("diva"))

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicExtension.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicExtension.groovy
@@ -118,7 +118,7 @@ abstract class NewRelicExtension {
         // update variants configs with these values
         variantMapUploads.each { variantName ->
             variantConfigurations.findByName(variantName)?.with {
-                uploadMappingFile = true
+                it.uploadMappingFile = true
             }
         }
     }
@@ -130,18 +130,19 @@ abstract class NewRelicExtension {
         // update variants configs with these values
         variantExclusions.each { variantName ->
             variantConfigurations.findByName(variantName)?.with {
-                instrument = false
+                it.instrument = false
             }
         }
     }
 
     void excludePackageInstrumentation(String... e) {
         packageExclusions.clear()
-        packageExclusions.addAll(e.collect { i -> i.toString().toLowerCase() })
+        packageExclusions.addAll(e.collect { i -> i.toString().toLowerCase().replace('/', '.') })
 
-        variantMapUploads.each { variantName ->
+        // update variants configs with these values
+        variantExclusions.each { variantName ->
             variantConfigurations.findByName(variantName)?.with {
-                // TODO
+                it.packageExclusions = packageExclusions
             }
         }
     }
@@ -168,5 +169,12 @@ abstract class NewRelicExtension {
 
         return variantMapUploads.isEmpty() ||
                 !variantMapUploads.findAll { variantName.toLowerCase() == it || variantName.endsWith(it.capitalize()) }.empty
+    }
+
+    boolean shouldExcludePackageInstrumentation(String packageName) {
+        def pkg = packageName.toLowerCase().replace('/', '.')
+        return !packageExclusions.findAll { it ->
+            pkg.toLowerCase().startsWith(it) || pkg.toLowerCase().matches(it)
+        }.empty
     }
 }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicGradlePlugin.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicGradlePlugin.groovy
@@ -82,6 +82,10 @@ class NewRelicGradlePlugin implements Plugin<Project> {
                 LOGGER.info("Instrumentation will be disabled for variants ${variantExclusions}")
             }
 
+            if (!packageExclusions.isEmpty()) {
+                LOGGER.info("Instrumentation will be disabled for classes ${packageExclusions}")
+            }
+
             // Do all the variants if variant maps are disabled, or only those provided
             // in the extension. The default is ['release'].
             if (!variantMapsEnabled.get() || variantMapUploads.isEmpty()) {

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantConfiguration.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantConfiguration.groovy
@@ -16,6 +16,7 @@ abstract class VariantConfiguration {
     boolean instrument
     boolean uploadMappingFile
     File mappingFile
+    Set<String> packageExclusions
 
     @Inject
     VariantConfiguration(String name, Project project) {
@@ -24,6 +25,8 @@ abstract class VariantConfiguration {
         this.instrument = true
         this.uploadMappingFile = false
         this.mappingFile = null
+        this.packageExclusions = []
+
     }
 
     String getName() {

--- a/samples/agent-test-app/android.gradle
+++ b/samples/agent-test-app/android.gradle
@@ -120,7 +120,7 @@ if (project.applyPlugin && Boolean.valueOf(project.applyPlugin)) {
             excludeVariantInstrumentation 'debug'
 
             // do not instrument these specific packages
-            excludePackageInstrumentation 'com.newrelic'
+            excludePackageInstrumentation 'com.testapp', 'org.bouncycastle.crypto'
 
             try {
                 // allow overrides for specific (DexGuard) configuration


### PR DESCRIPTION
Caller can provide leading package components ('com.newrelic/android'), or regexp matching strings ('^com.newrelic.a.*$')

* Tests and sample test app updated
* Only supported in Gradle 7.4 and higher at the moment.