### PR TITLE
[NR-172210] Event Persistence

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -6,6 +6,7 @@
 package com.newrelic.agent.android;
 
 import com.newrelic.agent.android.analytics.AnalyticsAttributeStore;
+import com.newrelic.agent.android.analytics.AnalyticsEventStore;
 import com.newrelic.agent.android.crash.CrashStore;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
@@ -58,6 +59,8 @@ public class AgentConfiguration {
     private CrashStore crashStore;
     private AnalyticsAttributeStore analyticsAttributeStore;
     private PayloadStore<Payload> payloadStore = new NullPayloadStore<Payload>();
+
+    private AnalyticsEventStore eventStore;
 
     private ApplicationFramework applicationFramework = ApplicationFramework.Native;
     private String applicationFrameworkVersion = Agent.getVersion();
@@ -125,6 +128,14 @@ public class AgentConfiguration {
 
     public void setCrashStore(CrashStore crashStore) {
         this.crashStore = crashStore;
+    }
+
+    public AnalyticsEventStore getEventStore() {
+        return eventStore;
+    }
+
+    public void setEventStore(AnalyticsEventStore eventStore) {
+        this.eventStore = eventStore;
     }
 
     public boolean getReportHandledExceptions() {

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsControllerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsControllerImpl.java
@@ -49,6 +49,8 @@ public class AnalyticsControllerImpl extends HarvestAdapter implements Analytics
     private AgentImpl agentImpl;
     private AnalyticsAttributeStore attributeStore;
 
+    private AnalyticsEventStore eventStore;
+
     class InteractionCompleteListener implements TraceLifecycleAware {
         @Override
         public void onEnterMethod() {
@@ -138,6 +140,7 @@ public class AnalyticsControllerImpl extends HarvestAdapter implements Analytics
         this.eventManager.initialize(agentConfiguration);
         this.isEnabled.set(agentConfiguration.getEnableAnalyticsEvents());
         this.attributeStore = agentConfiguration.getAnalyticsAttributeStore();
+        this.eventStore = agentConfiguration.getEventStore();
 
         loadPersistentAttributes();
 
@@ -1022,6 +1025,11 @@ public class AnalyticsControllerImpl extends HarvestAdapter implements Analytics
                     if (pendingEvents.size() > 0) {
                         harvestData.getAnalyticsEvents().addAll(pendingEvents);
                         log.debug("EventManager: [" + pendingEvents.size() + "] events moved from buffer to HarvestData");
+
+                        //remove events from pref
+                        for (AnalyticsEvent event : pendingEvents) {
+                            eventStore.delete(event);
+                        }
                     }
 
                     // event buffer _should_ be empty, but...

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
@@ -48,7 +48,7 @@ public class AnalyticsEvent extends HarvestableObject {
 
     protected final static AnalyticsValidator validator = new AnalyticsValidator();
 
-    protected AnalyticsEvent(String name) {
+    public AnalyticsEvent(String name) {
         this(name, AnalyticsEventCategory.Custom, null, null);
     }
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEventStore.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEventStore.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.analytics;
+
+import com.newrelic.agent.android.payload.PayloadStore;
+
+import java.util.List;
+
+public interface AnalyticsEventStore extends PayloadStore<AnalyticsEvent> {
+
+    /**
+     * Store an event
+     *
+     * @param event the event
+     * @return true if the operations succeeded, false otherwise
+     */
+    boolean store(AnalyticsEvent event);
+
+    /**
+     * Fetch all stored event
+     *
+     * @return A List containing all persistent event
+     */
+    List<AnalyticsEvent> fetchAll();
+
+    /**
+     * Returns the count of stored persistent events
+     *
+     * @return the count of stored persistent events
+     */
+    public int count();
+
+    /**
+     * Clears all stored persistent events
+     */
+    public void clear();
+
+    /**
+     * Delete a specific stored persistent event
+     *
+     * @param event the event to delete
+     */
+    public void delete(AnalyticsEvent event);
+}

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -54,6 +54,7 @@ import com.newrelic.agent.android.sample.Sampler;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.stores.SharedPrefsAnalyticsAttributeStore;
 import com.newrelic.agent.android.stores.SharedPrefsCrashStore;
+import com.newrelic.agent.android.stores.SharedPrefsEventStore;
 import com.newrelic.agent.android.stores.SharedPrefsPayloadStore;
 import com.newrelic.agent.android.tracing.TraceMachine;
 import com.newrelic.agent.android.util.ActivityLifecycleBackgroundListener;
@@ -116,6 +117,7 @@ public class AndroidAgentImpl implements
         agentConfiguration.setCrashStore(new SharedPrefsCrashStore(context));
         agentConfiguration.setPayloadStore(new SharedPrefsPayloadStore(context));
         agentConfiguration.setAnalyticsAttributeStore(new SharedPrefsAnalyticsAttributeStore(context));
+        agentConfiguration.setEventStore(new SharedPrefsEventStore(context));
 
         ApplicationStateMonitor.getInstance().addApplicationStateListener(this);
 

--- a/agent/src/main/java/com/newrelic/agent/android/stores/SharedPrefsEventStore.java
+++ b/agent/src/main/java/com/newrelic/agent/android/stores/SharedPrefsEventStore.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.stores;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.newrelic.agent.android.analytics.AnalyticsEvent;
+import com.newrelic.agent.android.analytics.AnalyticsEventStore;
+import com.newrelic.agent.android.crash.Crash;
+import com.newrelic.agent.android.logging.AgentLog;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.SafeJsonPrimitive;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SharedPrefsEventStore extends SharedPrefsStore implements AnalyticsEventStore {
+    private static final AgentLog log = AgentLogManager.getAgentLog();
+    private static final String STORE_FILE = "NREventStore";
+
+    public SharedPrefsEventStore(Context context) {
+        super(context, STORE_FILE);
+    }
+
+    public SharedPrefsEventStore(Context context, String storeFilename) {
+        super(context, storeFilename);
+    }
+
+    @Override
+    public boolean store(AnalyticsEvent event) {
+        synchronized (this) {
+            try {
+                final JsonObject jsonObj = event.asJsonObject();
+                String eventJson = jsonObj.toString();
+
+                // events should be stored synchronously, since the app is terminating
+                SharedPreferences.Editor editor = this.sharedPrefs.edit();
+                editor.putString(String.valueOf(event.getTimestamp()), eventJson);
+
+//                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_CRASH_SIZE_UNCOMPRESSED, eventJson.length());
+                return editor.commit();
+            } catch (Exception e) {
+                log.error("SharedPrefsStore.store(String, String): ", e);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public List<AnalyticsEvent> fetchAll() {
+        final List<AnalyticsEvent> events = new ArrayList<AnalyticsEvent>();
+        for (Object object : super.fetchAll()) {
+            if (object instanceof String) {
+                try {
+                    JsonObject eventObj = new Gson().fromJson((String) object, JsonObject.class);
+                    events.add(AnalyticsEvent.newFromJson(eventObj));
+                } catch (Exception e) {
+                    log.error("Exception encountered while deserializing crash", e);
+                }
+            }
+        }
+        return events;
+    }
+
+    @Override
+    public void delete(AnalyticsEvent event) {
+        try {
+            synchronized (this) {
+                final SharedPreferences.Editor editor = sharedPrefs.edit();
+                editor.remove(String.valueOf(event.getTimestamp())).commit();
+            }
+        } catch (Exception e) {
+            log.error("SharedPrefsEventStore.delete(): ", e);
+        }
+    }
+}

--- a/agent/src/test/java/com/newrelic/agent/android/stores/SharedPrefsEventStoreTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/stores/SharedPrefsEventStoreTest.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.stores;
+
+import static org.mockito.Mockito.spy;
+
+import android.content.Context;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.SpyContext;
+import com.newrelic.agent.android.analytics.AnalyticsEvent;
+import com.newrelic.agent.android.analytics.EventListener;
+import com.newrelic.agent.android.analytics.EventManager;
+import com.newrelic.agent.android.analytics.EventManagerImpl;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+public class SharedPrefsEventStoreTest implements EventListener {
+    private SharedPrefsEventStore eventStore;
+    private Context context = new SpyContext().getContext();
+    private AgentConfiguration agentConfiguration;
+    private EventManagerImpl manager = null;
+
+    @Before
+    public void setUp() throws Exception {
+        eventStore = spy(new SharedPrefsEventStore(context));
+
+        agentConfiguration = new AgentConfiguration();
+        agentConfiguration.setApplicationToken(SharedPrefsEventStoreTest.class.getSimpleName());
+        agentConfiguration.setEventStore(eventStore);
+        agentConfiguration.setEnableAnalyticsEvents(true);
+
+        manager = Mockito.spy(new EventManagerImpl());
+        manager.initialize(agentConfiguration);
+        manager.setEventListener(this);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        eventStore.clear();
+        Assert.assertTrue(eventStore.count() == 0);
+    }
+
+    @Test
+    public void store() throws Exception {
+        AnalyticsEvent event = new AnalyticsEvent("storeEvent");
+        eventStore.store(event);
+        List<AnalyticsEvent> list = eventStore.fetchAll();
+        Assert.assertNotNull("Should store event", list.contains(event));
+    }
+
+    @Test
+    public void fetchAll() throws Exception {
+        AnalyticsEvent event1 = new AnalyticsEvent("event1");
+        AnalyticsEvent event2 = new AnalyticsEvent("event2");
+        eventStore.store(event1);
+        eventStore.store(event2);
+        eventStore.store(event1);
+        List<AnalyticsEvent> list = eventStore.fetchAll();
+        Assert.assertNotNull("Should store event", list.contains(event1));
+        Assert.assertEquals("Should not store duplicates", 2, eventStore.fetchAll().size());
+    }
+
+    @Test
+    public void count() throws Exception {
+        AnalyticsEvent event1 = new AnalyticsEvent("event1");
+        AnalyticsEvent event2 = new AnalyticsEvent("event2");
+        eventStore.store(event1);
+        eventStore.store(event2);
+        eventStore.store(event1);
+        List<AnalyticsEvent> list = eventStore.fetchAll();
+        Assert.assertEquals("Should not store duplicates", 2, list.size());
+    }
+
+    @Test
+    public void clear() throws Exception {
+        AnalyticsEvent event1 = new AnalyticsEvent("event1");
+        AnalyticsEvent event2 = new AnalyticsEvent("event2");
+        eventStore.store(event1);
+        eventStore.store(event2);
+        eventStore.store(event1);
+        Assert.assertEquals("Should contains event(s)", 2, eventStore.fetchAll().size());
+
+        eventStore.clear();
+        Assert.assertTrue("Should remove all event(s)", eventStore.fetchAll().isEmpty());
+    }
+
+    @Test
+    public void delete() throws Exception {
+        AnalyticsEvent event1 = new AnalyticsEvent("event1");
+        AnalyticsEvent event2 = new AnalyticsEvent("event2");
+        eventStore.store(event1);
+        eventStore.store(event2);
+        eventStore.store(event1);
+        Assert.assertEquals("Should contain 2 events", 2, eventStore.fetchAll().size());
+
+        eventStore.delete(event1);
+        Assert.assertFalse("Should remove testEvent1", eventStore.fetchAll().contains(event1));
+
+        eventStore.delete(event2);
+        Assert.assertFalse("Should remove testEvent2", eventStore.fetchAll().contains(event2));
+
+        Assert.assertEquals("Should contain 0 event(s)", 0, eventStore.fetchAll().size());
+    }
+
+    @Test
+    public void testStoreLotsOfEvents() throws Exception {
+        int reps = 20;
+        for (Integer i = 0; i < reps; i++) {
+            AnalyticsEvent event = new AnalyticsEvent("event" + i);
+            manager.addEvent(event);
+        }
+        // eventStore.store() is an async call, so it's possible the last element was not written
+        // by the time the assert is hit. Use a delta of 1 in the assertion.
+        Assert.assertEquals("Should contain " + Integer.valueOf(reps).toString() + " events", reps, eventStore.count(), 20);
+    }
+
+    @Override
+    public boolean onEventAdded(AnalyticsEvent analyticsEvent) {
+        return true;
+    }
+
+    @Override
+    public boolean onEventOverflow(AnalyticsEvent analyticsEvent) {
+        return true;
+    }
+
+    @Override
+    public boolean onEventEvicted(AnalyticsEvent analyticsEvent) {
+        return true;
+    }
+
+    @Override
+    public void onEventQueueSizeExceeded(int currentQueueSize) {
+
+    }
+
+    @Override
+    public void onEventQueueTimeExceeded(int maxBufferTimeInSec) {
+
+    }
+
+    @Override
+    public void onEventFlush() {
+
+    }
+
+    @Override
+    public void onStart(EventManager eventManager) {
+
+    }
+
+    @Override
+    public void onShutdown() {
+
+    }
+}


### PR DESCRIPTION
[Ticket](https://new-relic.atlassian.net/browse/NR-172210): Events are stored in memory, in the event of a force kill of the app, all events will be lost.
1. Add SharedPreference to store events
2. Retrieve events when re-initialize the eventManager