### PR TITLE
Backport Release/7.2.1 to develop branch

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class EventManagerImpl implements EventManager, EventListener {
     private static final AgentLog log = AgentLogManager.getAgentLog();
     public static final int DEFAULT_MAX_EVENT_BUFFER_TIME = 600;    // 600 seconds (10 minutes)
-    public static final int DEFAULT_MAX_EVENT_BUFFER_SIZE = 4000;   // Beta testing value, to be revised with empirical data
+    public static final int DEFAULT_MAX_EVENT_BUFFER_SIZE = 1000;   // 1000 as the default
 
     public static final int DEFAULT_MIN_EVENT_BUFFER_SIZE = 64;
     public static final int DEFAULT_MIN_EVENT_BUFFER_TIME = (int) (HarvestTimer.DEFAULT_HARVEST_PERIOD / 1000);     // 60 seconds (1 minutes, same as harvest)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.2.0
+newrelic.agent.version = 7.2.1
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/BuildHelper.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/BuildHelper.groovy
@@ -47,7 +47,7 @@ class BuildHelper {
 
     public final String gradleVersion = GradleVersion.current().version
     static final String minSupportedAGPVersion = '7.0.0'
-    static final String maxSupportedAGPVersion = "8.2"
+    static final String maxSupportedAGPVersion = "8.4"
     static final String minSupportedGradleVersion = '7.1'
     static final String minSupportedGradleConfigCacheVersion = '6.6'
     static final String minSupportedAGPConfigCacheVersion = '7.0.0'


### PR DESCRIPTION
**Note:** 
1. The original release/7.2.1 is branched off main
2. When backporting to develop after release, release/7.2.1 is updated with all the commits in develop so we can merge

**What's changed:**
1. Upgrade AGP support version to 8.4
4. Correct DEFAULT_MAX_EVENT_BUFFER_SIZE to 1000