### PR TITLE
fix: Log reporter not started

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogForwarder.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogForwarder.java
@@ -5,7 +5,6 @@
 
 package com.newrelic.agent.android.logging;
 
-import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.Payload;
@@ -19,9 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
-import java.net.NetworkInterface;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -121,18 +121,14 @@ public class LogReporter extends PayloadReporter {
         try {
             resetWorkingLogFile();
         } catch (IOException e) {
-            log.error("LogReporter error; " + e);
+            log.error("LogReporter error: " + e);
+            setEnabled(false);
         }
     }
 
     @Override
     protected void start() {
         Harvest.addHarvestListener(instance.get());
-
-        if (isEnabled()) {
-            onHarvestStart();   // sweep for any cached report from last session
-        }
-
         isStarted.set(true);
     }
 
@@ -171,7 +167,7 @@ public class LogReporter extends PayloadReporter {
             }
 
             // The logger can continue to run collecting log data until the agent exists.
-            // but will no longer be triggered by the harvest lifecycle
+            // but will no longer be triggered by the harvest lifecycle nor uploaded to ingest
 
         } catch (Exception e) {
             log.error(e.toString());

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -44,7 +44,8 @@ import javax.net.ssl.HttpsURLConnection;
 
 public class LogReporter extends PayloadReporter {
 
-    protected static final Type gtype = new TypeToken<Map<String, Object>>() {}.getType();
+    protected static final Type gtype = new TypeToken<Map<String, Object>>() {
+    }.getType();
     protected static final Gson gson = new GsonBuilder()
             .enableComplexMapKeySerialization()
             .create();
@@ -128,8 +129,12 @@ public class LogReporter extends PayloadReporter {
 
     @Override
     protected void start() {
-        Harvest.addHarvestListener(instance.get());
-        isStarted.set(true);
+        if (isEnabled()) {
+            Harvest.addHarvestListener(instance.get());
+            isStarted.set(true);
+        } else {
+            log.error("Attempted to start the log reported when disabled.");
+        }
     }
 
     @Override
@@ -137,7 +142,6 @@ public class LogReporter extends PayloadReporter {
         Harvest.removeHarvestListener(instance.get());
 
         isStarted.set(false);
-
         if (isEnabled()) {
             onHarvestStop();
         }

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
@@ -233,6 +233,9 @@ public abstract class LogReporting {
     public static void initialize(File cacheDir, AgentConfiguration agentConfiguration) throws IOException {
         LogReporting.setLogLevel(agentConfiguration.getLogReportingConfiguration().getLogLevel());
         LogReporter.initialize(cacheDir, agentConfiguration);
+        if( LogReporter.getInstance().isEnabled()) {
+            LogReporter.getInstance().start();
+        }
     }
 
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
  * LogReporting public interface, exposed to NewRelic API
  */
 public abstract class LogReporting {
-    static final String NULL_MSG = "<empty message>";
+    public static final String INVALID_MSG = "<invalid message>";
 
     // Logging payload attributes
     protected static final String LOG_TIMESTAMP_ATTRIBUTE = AnalyticsAttribute.EVENT_TIMESTAMP_ATTRIBUTE;
@@ -37,8 +37,22 @@ public abstract class LogReporting {
     protected static LogLevel logLevel = LogLevel.WARN;
     protected static AgentLogger agentLogger = new AgentLogger();
     protected static AtomicReference<Logger> instance = new AtomicReference<>(agentLogger);
-
     protected static String entityGuid = "";
+
+    public static MessageValidator validator = new MessageValidator() {};
+
+    public static void initialize(File cacheDir, AgentConfiguration agentConfiguration) throws IOException {
+        LogReporting.setLogLevel(agentConfiguration.getLogReportingConfiguration().getLogLevel());
+        LogReporter.initialize(cacheDir, agentConfiguration);
+
+        if (LogReporter.getInstance().isEnabled()) {
+            LogReporter.getInstance().start();
+        }
+
+        if (!LogReporter.getInstance().isStarted()) {
+            agentLogger.log(LogLevel.ERROR, "LogReporting failed to initialize!");
+        }
+    }
 
     public static Logger getLogger() {
         return instance.get();
@@ -116,15 +130,16 @@ public abstract class LogReporting {
     }
 
     public static class AgentLogger implements Logger {
+        MessageValidator validator = new MessageValidator() {
+        };
+
         /**
          * Writes a message to the current agent log using the provided log level.
          * At runtime, this will be the Android logger (Log) instance.
          */
         public void logToAgent(LogLevel level, String message) {
             if (LogReporting.isLevelEnabled(level)) {
-                if (null == message || message.isEmpty()) {
-                    message = LogReporting.NULL_MSG;
-                }
+                message = validator.validate(message);
 
                 final AgentLog agentLog = AgentLogManager.getAgentLog();
                 switch (level) {
@@ -154,15 +169,21 @@ public abstract class LogReporting {
 
         public void logThrowable(LogLevel logLevel, String message, Throwable throwable) {
             StringWriter sw = new StringWriter();
+
+            message = validator.validate(message);
+            throwable = validator.validate(throwable);
             throwable.printStackTrace(new PrintWriter(sw));
 
             logToAgent(logLevel, String.format(Locale.getDefault(), "%s: %s", message, sw.toString()));
         }
 
         public void logAttributes(Map<String, Object> attributes) {
+            attributes = validator.validate(attributes);
+
             String logLevel = (String) attributes.getOrDefault("level", LogLevel.INFO.name());
+            Map<String, Object> finalAttributes = attributes;
             String mapAsString = attributes.keySet().stream()
-                    .map(key -> key + "=" + attributes.get(key))
+                    .map(key -> key + "=" + finalAttributes.get(key))
                     .collect(Collectors.joining(",", "{", "}"));
 
             logToAgent(LogLevel.valueOf(logLevel.toUpperCase()), String.format(Locale.getDefault(),
@@ -170,34 +191,20 @@ public abstract class LogReporting {
         }
 
         public void logAll(Throwable throwable, Map<String, Object> attributes) {
+            attributes = validator.validate(attributes);
+
             String logLevel = (String) attributes.getOrDefault("level", LogLevel.INFO.name());
             StringWriter sw = new StringWriter();
-            String mapAsString = attributes.keySet().stream()
-                    .map(key -> key + "=" + attributes.get(key))
+            Map<String, Object> finalAttributes = attributes;
+            String mapAsString = finalAttributes.keySet().stream()
+                    .map(key -> key + "=" + finalAttributes.get(key))
                     .collect(Collectors.joining(",", "{", "}"));
 
+            throwable = validator.validate(throwable);
             throwable.printStackTrace(new PrintWriter(sw));
+
             logToAgent(LogLevel.valueOf(logLevel.toUpperCase()), String.format(Locale.getDefault(),
                     "%s: %s %s", TAG, sw.toString(), mapAsString));
-        }
-    }
-
-    // TODO
-    public interface LogMessageValidator {
-        String INVALID_KEYSET = "{}\\[\\]]";
-        String[] ANONYMIZATION_TARGETS = {
-                "http?//{.*}/{.*}",
-                "{.*}\\@{.*}\\.{.*}"
-        };
-
-        boolean validateAttributes(Map<String, Object> attributes);
-
-        default boolean anonymize(Map<String, Object> attributes) {
-            return true;
-        }
-
-        default boolean validateThrowable(final Throwable throwable) {
-            return true;
         }
     }
 
@@ -206,16 +213,18 @@ public abstract class LogReporting {
      *
      * @link https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#supported-types
      */
-    protected Map<String, Object> validateLogData(LogMessageValidator validator, Map<String, Object> logDataMap) {
-        logDataMap.forEach((key, value) -> {
-            if (value instanceof String) {
-                // TODO https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#message-attribute-parsin
-                // Enforce log message constraints:
-                //  static int MAX_ATTRIBUTES_PER_EVENT = 255;
-                //  static int MAX_ATTRIBUTES_NAME_SIZE = 255;
-                //  static int MAX_ATTRIBUTES_VALUE_SIZE = 4096;
-            }
-        });
+    protected static Map<String, Object> validateLogData(MessageValidator validator, Map<String, Object> logDataMap) {
+        if (null != logDataMap) {
+            logDataMap.forEach((key, value) -> {
+                if (value instanceof String) {
+                    // TODO https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#message-attribute-parsin
+                    // Enforce log message constraints:
+                    //  static int MAX_ATTRIBUTES_PER_EVENT = 255;
+                    //  static int MAX_ATTRIBUTES_NAME_SIZE = 255;
+                    //  static int MAX_ATTRIBUTES_VALUE_SIZE = 4096;
+                }
+            });
+        }
 
         return logDataMap;
     }
@@ -225,17 +234,9 @@ public abstract class LogReporting {
      *
      * @link https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#supported-types
      */
-    protected Map<String, Object> decorateLogData(LogMessageValidator validator, Map<String, Object> logDataMap) {
+    protected Map<String, Object> decorateLogData(MessageValidator validator, Map<String, Object> logDataMap) {
         // TODO
         return logDataMap;
-    }
-
-    public static void initialize(File cacheDir, AgentConfiguration agentConfiguration) throws IOException {
-        LogReporting.setLogLevel(agentConfiguration.getLogReportingConfiguration().getLogLevel());
-        LogReporter.initialize(cacheDir, agentConfiguration);
-        if( LogReporter.getInstance().isEnabled()) {
-            LogReporter.getInstance().start();
-        }
     }
 
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/MessageValidator.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/MessageValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.logging;
+
+import static com.newrelic.agent.android.logging.LogReporting.INVALID_MSG;
+import static com.newrelic.agent.android.logging.LogReporting.LOG_LEVEL_ATTRIBUTE;
+import static com.newrelic.agent.android.logging.LogReporting.LOG_MESSAGE_ATTRIBUTE;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public interface MessageValidator {
+
+    String INVALID_KEYSET = "{}\\[\\]]";
+    String[] ANONYMIZATION_TARGETS = {
+            "http?//{.*}/{.*}",
+            "{.*}\\@{.*}\\.{.*}"
+    };
+
+    default String validate(String message) {
+        return (null == message || message.isEmpty()) ? INVALID_MSG : message;
+    }
+
+    default Map<String, Object> validate(Map<String, Object> attributes) {
+        if (null == attributes) {
+            attributes = new HashMap<>();
+        }
+
+        if (!attributes.containsKey(LOG_MESSAGE_ATTRIBUTE)) {
+            attributes.put(LOG_MESSAGE_ATTRIBUTE, INVALID_MSG);
+        }
+
+        if (!attributes.containsKey(LOG_LEVEL_ATTRIBUTE)) {
+            attributes.put(LOG_LEVEL_ATTRIBUTE, LogLevel.INFO.name());
+        }
+
+        return attributes;
+    }
+
+    default Throwable validate(final Throwable throwable) {
+        return null != throwable ? throwable : new IllegalArgumentException();   // TODO
+    }
+
+    default Map<String, Object> anonymize(Map<String, Object> attributes) {
+        attributes = validate(attributes);
+        return attributes;    // TODO
+    }
+}
+

--- a/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadReporter.java
@@ -16,6 +16,7 @@ public abstract class PayloadReporter implements HarvestLifecycleAware {
     protected static final AgentLog log = AgentLogManager.getAgentLog();
 
     protected final AtomicBoolean isEnabled;
+
     protected final AtomicBoolean isStarted;
     protected final AgentConfiguration agentConfiguration;
 
@@ -30,6 +31,10 @@ public abstract class PayloadReporter implements HarvestLifecycleAware {
 
     public boolean isEnabled() {
         return isEnabled.get();
+    }
+
+    public boolean isStarted() {
+        return isStarted.get();
     }
 
     public void setEnabled(boolean enabled) {

--- a/agent-core/src/main/java/com/newrelic/agent/android/stats/TicToc.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/stats/TicToc.java
@@ -37,7 +37,7 @@ public class TicToc {
     }
 
     public long duration() {
-        return (state == State.STARTED) ? peek() : startTime - System.currentTimeMillis();
+        return (state == State.STARTED) ? peek() : System.currentTimeMillis() - startTime;
 
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogForwarderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogForwarderTest.java
@@ -7,7 +7,6 @@ package com.newrelic.agent.android.logging;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReporterTest.java
@@ -99,7 +99,7 @@ public class LogReporterTest extends LoggingTests {
     @Test
     public void start() {
         logReporter.start();
-        verify(logReporter, times(1)).onHarvestStart();
+        verify(logReporter, never()).onHarvestStart();
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingTest.java
@@ -5,11 +5,14 @@
 
 package com.newrelic.agent.android.logging;
 
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.FeatureFlag;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class LogReportingTest {
+public class LogReportingTest extends LoggingTests {
 
     @Before
     public void setUp() throws Exception {
@@ -66,6 +69,25 @@ public class LogReportingTest {
     }
 
     @Test
-    public void notice() {
+    public void initializeLogReporting() throws Exception {
+        AgentConfiguration.getInstance().getLogReportingConfiguration().setLogLevel(LogLevel.DEBUG);
+
+        FeatureFlag.disableFeature(FeatureFlag.LogReporting);
+        LogReporting.initialize(reportsDir, AgentConfiguration.getInstance());
+        Assert.assertNotNull("LogReporter not initialized", LogReporter.getInstance());
+        Assert.assertFalse("LogReport was enabled despite configuration settings", LogReporter.getInstance().isEnabled());
+
+        FeatureFlag.enableFeature(FeatureFlag.LogReporting);
+        AgentConfiguration.getInstance().getLogReportingConfiguration().setLoggingEnabled(false);
+        LogReporting.initialize(reportsDir, AgentConfiguration.getInstance());
+        Assert.assertFalse("LogReport was started despite configuration settings", LogReporter.getInstance().isEnabled());
+
+        FeatureFlag.enableFeature(FeatureFlag.LogReporting);
+        AgentConfiguration.getInstance().getLogReportingConfiguration().setLoggingEnabled(true);
+        LogReporting.initialize(reportsDir, AgentConfiguration.getInstance());
+        Assert.assertTrue("LogReport not enabled despite configuration settings", LogReporter.getInstance().isEnabled());
+        Assert.assertTrue("LogReport not started despite configuration settings", LogReporter.getInstance().isStarted());
+
+        Assert.assertTrue(LogReporting.getLogger() instanceof RemoteLogger);
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingTest.java
@@ -5,18 +5,30 @@
 
 package com.newrelic.agent.android.logging;
 
+import static com.newrelic.agent.android.logging.LogReporting.agentLogger;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.verify;
+
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.FeatureFlag;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
 
 public class LogReportingTest extends LoggingTests {
 
     @Before
     public void setUp() throws Exception {
         LogReporting.setLogLevel("InFo");
+        agentLogger = Mockito.spy(agentLogger);
     }
 
     @Test
@@ -89,5 +101,24 @@ public class LogReportingTest extends LoggingTests {
         Assert.assertTrue("LogReport not started despite configuration settings", LogReporter.getInstance().isStarted());
 
         Assert.assertTrue(LogReporting.getLogger() instanceof RemoteLogger);
+    }
+
+    @Test
+    public void testInvalidLogMessages() {
+        Logger logger = LogReporting.getLogger();
+
+        logger.log(LogLevel.ERROR, null);
+        verify(agentLogger, atMostOnce()).log(LogLevel.ERROR, LogReporting.INVALID_MSG);
+
+        logger.logAttributes(null);
+        verify(agentLogger, atMostOnce()).logAttributes(anyMap());
+
+        logger.logThrowable(LogLevel.WARN, null, (Throwable) null);
+        verify(agentLogger, atMostOnce()).logThrowable(any(LogLevel.class), isNull(), any(IllegalArgumentException.class));
+
+        logger.logAll((Throwable) null, (Map<String, Object>) null);
+        verify(agentLogger, atMostOnce()).logAll(any(IllegalArgumentException.class), anyMap());
+
+        // TODO LogReporting.validateLogData(LogReporting.validator, null);
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LoggingTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LoggingTests.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 public class LoggingTests {
     protected static File reportsDir;
-
     long tStart;
 
     @BeforeClass
@@ -38,7 +37,6 @@ public class LoggingTests {
         AgentConfiguration.getInstance().setApplicationToken("<APP-TOKEN>>");
         LogReporting.setEntityGuid("ENTITY-GUID");
     }
-
 
     public LoggingTests() {
         this.tStart = System.currentTimeMillis();

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/MessageValidatorTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/MessageValidatorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.logging;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MessageValidatorTest extends LoggingTests {
+    private MessageValidator validator = LogReporting.validator;
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void messageValidation() {
+        String message = validator.validate((String) null);
+        Assert.assertNotNull(message);
+        Assert.assertEquals(LogReporting.INVALID_MSG, message);
+
+        message = validator.validate(getRandomMsg(12));
+        Assert.assertNotEquals(LogReporting.INVALID_MSG, message);
+    }
+
+    @Test
+    public void attributeValidation() {
+        Map<String, Object> attributes = validator.validate((Map<String, Object>) null);
+        Assert.assertNotNull(attributes);
+        Assert.assertTrue((attributes.containsKey(LogReporting.LOG_MESSAGE_ATTRIBUTE)));
+        Assert.assertTrue((attributes.containsKey(LogReporting.LOG_LEVEL_ATTRIBUTE)));
+
+        attributes = validator.validate(new HashMap<>());
+        Assert.assertTrue((attributes.containsKey(LogReporting.LOG_MESSAGE_ATTRIBUTE)));
+        Assert.assertTrue((attributes.containsKey(LogReporting.LOG_LEVEL_ATTRIBUTE)));
+    }
+
+    @Test
+    public void throwableValidation() {
+        Throwable throwable = validator.validate((Throwable) null);
+        Assert.assertTrue(throwable instanceof IllegalArgumentException);
+    }
+
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
@@ -6,7 +6,9 @@
 package com.newrelic.agent.android.logging;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -230,7 +232,21 @@ public class RemoteLoggerTest extends LoggingTests {
          * Length of attribute value: 4,094 characters are stored in NRDB as a Log event field
          */
 
-        // TODO
+        Mockito.reset(logger);
+        logger.log(LogLevel.INFO, null);
+        verify(logger, times(1)).appendToWorkingLogFile(LogLevel.INFO, LogReporting.INVALID_MSG, null, null);
+
+        Mockito.reset(logger);
+        logger.logAttributes(null);
+        verify(logger, times(1)).appendToWorkingLogFile(any(LogLevel.class), anyString(), isNull(), anyMap());
+
+        Mockito.reset(logger);
+        logger.logThrowable(LogLevel.ERROR, "", null);
+        verify(logger, times(1)).appendToWorkingLogFile(any(LogLevel.class), anyString(), any(Throwable.class), isNull());
+
+        Mockito.reset(logger);
+        logger.logAll(null, null);
+        verify(logger, times(1)).appendToWorkingLogFile(any(LogLevel.class), anyString(), isNull(), anyMap());
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
@@ -274,7 +274,7 @@ public class RemoteLoggerTest extends LoggingTests {
                     String msg = getRandomMsg(msgSize);
 
                     Map<String, Object> attrs = new HashMap<>();
-                    attrs.put("level", LogLevel.INFO.name());
+                    attrs.put("level", LogLevel.values()[(int) (Math.random() * LogLevel.values().length)].name());
                     attrs.put("message", msg);
                     attrs.put("name", getRandomMsg(8));
                     attrs.put("age", (double) Math.random() * 117);
@@ -298,7 +298,7 @@ public class RemoteLoggerTest extends LoggingTests {
             TicToc fileIOTimer = new TicToc().tic();
             logger.flush();
             logReporter.finalizeWorkingLogFile();
-            logReporter.rollWorkingLogFile();
+            File rolledLog = logReporter.rollWorkingLogFile();
             logReporter.resetWorkingLogFile();
             agentLog.warn("Run[" + testRun + "] File finalization[" + fileIOTimer.peek() + "] ms");
 
@@ -310,6 +310,7 @@ public class RemoteLoggerTest extends LoggingTests {
             agentLog.info("Run[" + testRun + "] Iterations[" + iterations + "] Msgs[" + nMsgs + "]");
             agentLog.info("Run[" + testRun + "] Iteration service time[" + tPerIteration + "] ms");
             agentLog.info("Run[" + testRun + "] Service time per record[" + tPerMsg + "] ms");
+            agentLog.warn("Run[" + testRun + "] Logs reported [" + rolledLog.length() + "] bytes");
 
             iterations *= 2;
             msgPerIteration *= 2;

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -1212,6 +1212,8 @@ public final class NewRelic {
      *                   }
      */
     public static void logAttributes(Map<String, Object> attributes) {
+        attributes = LogReporting.validator.validate(attributes);
+
         final String level = String.valueOf(attributes.getOrDefault("level", LogLevel.NONE.toString()));
         final LogLevel logLevel = LogLevel.valueOf(level.toUpperCase());
 
@@ -1235,6 +1237,8 @@ public final class NewRelic {
      *                   }
      */
     public static void logAll(Throwable throwable, Map<String, Object> attributes) {
+        attributes = LogReporting.validator.validate(attributes);
+
         final String level = String.valueOf(attributes.getOrDefault("level", LogLevel.NONE.toString()));
         final LogLevel logLevel = LogLevel.valueOf(level.toUpperCase());
 
@@ -1243,6 +1247,7 @@ public final class NewRelic {
                 .replace(MetricNames.TAG_STATE, logLevel.name()));
 
         if (LogReporting.isLevelEnabled(logLevel)) {
+            throwable = LogReporting.validator.validate(throwable);
             LogReporting.getLogger().logAll(throwable, attributes);
         }
     }


### PR DESCRIPTION
### [NR-178365] fix: LogReporter not started

LogReporter start call should probably be made when other components are started (after the harvester is established).

  * added test
  * fixes timer calculations in tests 
   
### [NR-173691] Refactor and extend message validation

For MVP review, null message, attribute and throwable values are translated to recognizable string ("invalid message"), map containing that message, and exception type (IllegalArgumentException).  The goal is to help the customer  (and us) isolate when invalid arguments are passed to the logging methods.

For GA, we may remove this to reduce the amount of data forwarded to ingest.

