### PR TITLE
[NR-178365] fix: payload overflow resulted in 413 from log collector

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
@@ -107,14 +107,14 @@ public class HarvestConnection implements HarvestErrorCodes {
     public HarvestResponse send(HttpURLConnection connection, String message) {
         final HarvestResponse harvestResponse = new HarvestResponse();
         final String contentEncoding = (message.length() <= MAX_PLAINTEXT_MESSAGE_SIZE)
-                ? Constants.Network.ContentType.IDENTITY : Constants.Network.ContentType.DEFLATE;
+                ? Constants.Network.Encoding.IDENTITY : Constants.Network.Encoding.DEFLATE;
 
         try {
             TicToc timer = new TicToc();
             timer.tic();
 
             ByteBuffer byteBuffer;
-            if (Constants.Network.ContentType.DEFLATE.equals(contentEncoding.toLowerCase())) {
+            if (Constants.Network.Encoding.DEFLATE.equals(contentEncoding.toLowerCase())) {
                 byteBuffer = ByteBuffer.wrap(Deflator.deflate(message.getBytes()));
             } else {
                 byteBuffer = ByteBuffer.wrap(message.getBytes());

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/ForwardingAgentLog.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/ForwardingAgentLog.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022-2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.logging;
+
+import com.newrelic.agent.android.Agent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AgentLog class that emits a log message to its provided delegate, the forwards the Remote logger.
+ */
+public class ForwardingAgentLog implements AgentLog {
+
+    private final AgentLog delegate;
+
+    public ForwardingAgentLog() {
+        this(new NullAgentLog());
+    }
+
+    public ForwardingAgentLog(AgentLog agentLog) {
+        this.delegate = agentLog;
+    }
+
+    public void audit(String message) {
+        delegate.audit(message);
+
+        if (delegate.getLevel() == AgentLog.AUDIT) {
+            if (LogReporting.getLogger() instanceof RemoteLogger) {
+                LogReporting.getLogger().logAttributes(asAttributes(LogLevel.DEBUG, message));
+            }
+        }
+    }
+
+    public void debug(final String message) {
+        delegate.debug(message);
+
+        if (delegate.getLevel() >= DEBUG) {
+            if (LogReporting.getLogger() instanceof RemoteLogger) {
+                LogReporting.getLogger().logAttributes(asAttributes(LogLevel.DEBUG, message));
+            }
+        }
+    }
+
+    public void verbose(final String message) {
+        delegate.verbose(message);
+
+        if (delegate.getLevel() >= VERBOSE) {
+            if (LogReporting.getLogger() instanceof RemoteLogger) {
+                LogReporting.getLogger().logAttributes(asAttributes(LogLevel.VERBOSE, message));
+            }
+        }
+    }
+
+    public void info(final String message) {
+        delegate.info(message);
+
+        if (delegate.getLevel() >= INFO) {
+            if (LogReporting.getLogger() instanceof RemoteLogger) {
+                LogReporting.getLogger().logAttributes(asAttributes(LogLevel.INFO, message));
+            }
+        }
+    }
+
+    public void warn(final String message) {
+        delegate.warn(message);
+
+        if (delegate.getLevel() >= WARN) {
+            if (LogReporting.getLogger() instanceof RemoteLogger) {
+                LogReporting.getLogger().logAttributes(asAttributes(LogLevel.WARN, message));
+            }
+        }
+    }
+
+    public void error(final String message) {
+        delegate.error(message);
+
+        if (delegate.getLevel() >= ERROR) {
+            if (LogReporting.getLogger() instanceof RemoteLogger) {
+                LogReporting.getLogger().logAttributes(asAttributes(LogLevel.ERROR, message));
+            }
+        }
+    }
+
+    public void error(final String message, Throwable throwable) {
+        delegate.error(message, throwable);
+
+        if (delegate.getLevel() >= ERROR) {
+            if (LogReporting.getLogger() instanceof RemoteLogger) {
+                Map<String, Object> attributes = asAttributes(LogLevel.ERROR, message);
+
+                attributes.put(LogReporting.LOG_ERROR_MESSAGE_ATTRIBUTE, throwable.toString());
+                attributes.put(LogReporting.LOG_ERROR_STACK_ATTRIBUTE, throwable.getStackTrace()[0].toString());
+                attributes.put(LogReporting.LOG_ERROR_CLASS_ATTRIBUTE, throwable.getClass().getSimpleName());
+                LogReporting.getLogger().logAttributes(attributes);
+            }
+        }
+    }
+
+    @Override
+    public int getLevel() {
+        return delegate.getLevel();
+    }
+
+    @Override
+    public void setLevel(int level) {
+        delegate.setLevel(level);
+    }
+
+    Map<String, Object> asAttributes(LogLevel level, String message) {
+        Map<String, Object> attributes = new HashMap<>();
+
+        attributes.put(LogReporting.logLevel.name(), level);
+        attributes.put(LogReporting.LOG_MESSAGE_ATTRIBUTE, message);
+        attributes.put(LogReporting.LOG_LOGGER_ATTRIBUTE, "Android agent " + Agent.getVersion());
+
+        return attributes;
+    }
+
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
@@ -30,6 +30,7 @@ public abstract class LogReporting {
     protected static final String LOG_MESSAGE_ATTRIBUTE = "message";
     protected static final String LOG_ATTRIBUTES_ATTRIBUTE = "attributes";
     protected static final String LOG_ENTITY_ATTRIBUTE = "entity.guid";
+    protected static final String LOG_LOGGER_ATTRIBUTE = "logger";
     protected static final String LOG_ERROR_MESSAGE_ATTRIBUTE = "error.message";
     protected static final String LOG_ERROR_STACK_ATTRIBUTE = "error.stack";
     protected static final String LOG_ERROR_CLASS_ATTRIBUTE = "error.class";

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/MessageValidator.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/MessageValidator.java
@@ -20,6 +20,12 @@ public interface MessageValidator {
             "{.*}\\@{.*}\\.{.*}"
     };
 
+    /**
+     * TODO The message attribute on a log record MUST be truncated to 32768 bytes (32Kib) on the agent side.
+     *
+     * @param message
+     * @return
+     */
     default String validate(String message) {
         return (null == message || message.isEmpty()) ? INVALID_MSG : message;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -74,7 +74,7 @@ public class MetricNames {
     public static final String SUPPORTABILITY_NDK_REPORTS_EXCEPTION = SUPPORTABILITY_NDK + "Reports/NativeException";
     public static final String SUPPORTABILITY_NDK_REPORTS_FLUSH = SUPPORTABILITY_NDK + "Reports/Flush";
 
-    public static final String SUPPORTABILITY_LOG_REPORTING = SUPPORTABILITY_AGENT + "LogReporting";
+    public static final String SUPPORTABILITY_LOG_REPORTING = SUPPORTABILITY_AGENT + "LogReporting/";
     public static final String SUPPORTABILITY_LOG_REPORTING_INIT = SUPPORTABILITY_LOG_REPORTING + "Init";
     public static final String SUPPORTABILITY_LOG_UPLOAD_TIME = SUPPORTABILITY_LOG_REPORTING + "UploadTime";
     public static final String SUPPORTABILITY_LOG_UPLOAD_TIMEOUT = SUPPORTABILITY_LOG_REPORTING + "UploadTimeOut";

--- a/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
@@ -40,6 +40,10 @@ public final class Constants {
             public static final String MULTIPART_FORM_DATA = "multipart/form-data";
             public static final String JSON = "application/json";
             public static final String OCTET_STREAM = "application/octet-stream";
+            public static final String GZIP = "application/gzip";
+        }
+
+        public final class Encoding {
             public static final String DEFLATE = "deflate";
             public static final String IDENTITY = "identity";
             public static final String GZIP = "gzip";

--- a/agent-core/src/main/java/com/newrelic/agent/android/util/Streams.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/util/Streams.java
@@ -16,6 +16,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -68,14 +69,39 @@ public class Streams {
         }
     }
 
+    /**
+     * Return contents of an InputStream as an encoded String.
+     *
+     * @param in
+     * @return String constructed of byte stream
+     * @throws IOException
+     */
     public static String slurpString(final InputStream in) throws IOException {
-        final byte[] bytes = slurpBytes(in);
-        return new String(bytes);
+        return slurpString(in, StandardCharsets.UTF_8.name());
     }
 
+    /**
+     * Return contents of an input stream as a String.
+     *
+     * @param in InputStream
+     * @param encoding StandardCharsets.UTF_8 if null
+     * @return encoded String
+     * @throws IOException
+     */
     public static String slurpString(final InputStream in, final String encoding) throws IOException {
-        final byte[] bytes = slurpBytes(in);
-        return new String(bytes, encoding);
+        return new String(slurpBytes(in), (null == encoding || encoding.isEmpty()) ? StandardCharsets.UTF_8.name() : encoding);
+    }
+
+    /**
+     * Return contents of file as an encoded String.
+     *
+     * @param file File
+     * @param encoding StandardCharsets.UTF_8 if null
+     * @return encoded String
+     * @throws IOException
+     */
+    public static String slurpString(File file, final String encoding) throws IOException {
+        return slurpString(new FileInputStream(file), encoding);
     }
 
     /**

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/ForwardingAgentLogTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/ForwardingAgentLogTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.  
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.logging;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.times;
+
+import com.newrelic.agent.android.FeatureFlag;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ForwardingAgentLogTest {
+    AgentLog delegate;
+    RemoteLogger remoteLogger;
+    ForwardingAgentLog forwardingLogger;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeatureFlag.enableFeature(FeatureFlag.LogReporting);
+        LogReporting.setLogLevel(LogLevel.DEBUG);
+        Assert.assertTrue(LogReporting.isRemoteLoggingEnabled());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        delegate = Mockito.spy(new ConsoleAgentLog());
+        delegate.setLevel(AgentLog.AUDIT);
+        AgentLogManager.setAgentLog(delegate);
+
+        forwardingLogger = Mockito.spy(new ForwardingAgentLog(AgentLogManager.getAgentLog()));
+
+        remoteLogger = Mockito.spy(new RemoteLogger());
+        LogReporting.setLogger(remoteLogger);
+    }
+
+    @Test
+    public void audit() {
+        final String msg = "Audit message";
+
+        forwardingLogger.audit(msg);
+        Mockito.verify(delegate, times(1)).audit(msg);
+        Mockito.verify(remoteLogger, times(1)).logAttributes(anyMap());
+    }
+
+    @Test
+    public void debug() {
+        final String msg = "Debug message";
+
+        forwardingLogger.debug(msg);
+        Mockito.verify(delegate, times(1)).debug(msg);
+        Mockito.verify(remoteLogger, times(1)).logAttributes(anyMap());
+    }
+
+    @Test
+    public void verbose() {
+        final String msg = "Verbose message";
+
+        forwardingLogger.verbose(msg);
+        Mockito.verify(delegate, times(1)).verbose(msg);
+        Mockito.verify(remoteLogger, times(1)).logAttributes(anyMap());
+    }
+
+    @Test
+    public void info() {
+        final String msg = "Info message";
+
+        forwardingLogger.info(msg);
+        Mockito.verify(delegate, times(1)).info(msg);
+        Mockito.verify(remoteLogger, times(1)).logAttributes(anyMap());
+    }
+
+    @Test
+    public void warn() {
+        final String msg = "Warn message";
+
+        forwardingLogger.warn(msg);
+        Mockito.verify(delegate, times(1)).warn(msg);
+        Mockito.verify(remoteLogger, times(1)).logAttributes(anyMap());
+    }
+
+    @Test
+    public void error() {
+        final String msg = "Error message";
+
+        forwardingLogger.error(msg);
+        Mockito.verify(delegate, times(1)).error(msg);
+        Mockito.verify(remoteLogger, times(1)).logAttributes(anyMap());
+    }
+
+    @Test
+    public void ErrorWithThrowable() {
+        final String msg = "Error with throwable message";
+        final Throwable throwable = new IllegalArgumentException(msg);
+
+        forwardingLogger.error(msg, throwable);
+        Mockito.verify(delegate, times(1)).error(msg, throwable);
+        Mockito.verify(remoteLogger, times(1)).logAttributes(anyMap());
+    }
+
+    @Test
+    public void asAttributes() {
+        final String msg = "Log message";
+
+        forwardingLogger.debug(msg);
+        Mockito.verify(forwardingLogger, times(1)).asAttributes(LogLevel.DEBUG, msg);
+    }
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReporterTest.java
@@ -184,7 +184,7 @@ public class LogReporterTest extends LoggingTests {
         File archivedLogFile = logReporter.rollupLogDataFiles();
 
         // should be at least one rollup file
-        Assert.assertEquals(archivedLogFile.length(), LogReporter.VORTEX_PAYLOAD_LIMIT, LogReporter.VORTEX_PAYLOAD_LIMIT / 10);
+        Assert.assertTrue(archivedLogFile.length() <= LogReporter.VORTEX_PAYLOAD_LIMIT);
 
         // and a few leftover close files
         Set<File> leftOvers = logReporter.getCachedLogReports(LogReporter.LogReportState.CLOSED);

--- a/agent-core/src/test/java/com/newrelic/agent/android/util/StreamsTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/util/StreamsTest.java
@@ -77,15 +77,23 @@ public class StreamsTest {
     }
 
     @Test
-    public void slurp() throws IOException {
+    public void slurpString() throws IOException {
         String encodedString = Streams.slurpString(new FileInputStream(testInputFile));
         Assert.assertTrue(encodedString.length() > 0);
     }
 
     @Test
-    public void slurpEncoded() throws IOException {
+    public void slurpEncodedString() throws IOException {
         String encoding = StandardCharsets.UTF_8.toString();
         String encodedString = Streams.slurpString(new FileInputStream(testInputFile), encoding);
+        Assert.assertTrue(encodedString.length() > 0);
+        Assert.assertNotNull(encodedString.getBytes(encoding));
+    }
+
+    @Test
+    public void slurpStringFromFile() throws IOException {
+        String encoding = StandardCharsets.UTF_8.toString();
+        String encodedString = Streams.slurpString(testInputFile, encoding);
         Assert.assertTrue(encodedString.length() > 0);
         Assert.assertNotNull(encodedString.getBytes(encoding));
     }

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -21,9 +21,8 @@ import com.newrelic.agent.android.hybrid.data.DataController;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.logging.AndroidAgentLog;
-import com.newrelic.agent.android.logging.RemoteLogger;
+import com.newrelic.agent.android.logging.ForwardingAgentLog;
 import com.newrelic.agent.android.logging.LogLevel;
-import com.newrelic.agent.android.logging.LogReporter;
 import com.newrelic.agent.android.logging.LogReporting;
 import com.newrelic.agent.android.logging.LogReportingConfiguration;
 import com.newrelic.agent.android.logging.NullAgentLog;
@@ -318,6 +317,11 @@ public final class NewRelic {
                     default:
                         break;
                 }
+
+                if (loggingEnabled) {
+                    AgentLogManager.setAgentLog(new ForwardingAgentLog(new AndroidAgentLog()));
+                }
+
                 agentConfiguration.setLogReportingConfiguration(new LogReportingConfiguration(loggingEnabled, level));
 
                 try {

--- a/agent/src/main/java/com/newrelic/agent/android/logging/AndroidAgentLog.java
+++ b/agent/src/main/java/com/newrelic/agent/android/logging/AndroidAgentLog.java
@@ -8,72 +8,51 @@ package com.newrelic.agent.android.logging;
 import android.util.Log;
 
 public class AndroidAgentLog implements AgentLog {
-	private static final String TAG = "newrelic";
+	protected static final String TAG = "newrelic";
 
     // Default to INFO
-    private int level = INFO;
+    protected int level = INFO;
 
     @Override
     public void audit(String message) {
         if (level == AUDIT) {
             Log.d(TAG, message);
-            if( LogReporting.getLogger() instanceof RemoteLogger) {
-                LogReporting.getLogger().log(LogLevel.DEBUG, message);
-            }
         }
     }
 
     public void debug(final String message) {
         if (level >= DEBUG) {
             Log.d(TAG, message);
-            if( LogReporting.getLogger() instanceof RemoteLogger) {
-                LogReporting.getLogger().log(LogLevel.DEBUG, message);
-            }
         }
 	}
 
     public void verbose(final String message) {
         if (level >= VERBOSE) {
             Log.v(TAG, message);
-            if( LogReporting.getLogger() instanceof RemoteLogger) {
-                LogReporting.getLogger().log(LogLevel.VERBOSE, message);
-            }
         }
     }
 
 	public void info(final String message) {
         if (level >= INFO) {
             Log.i(TAG, message);
-            if( LogReporting.getLogger() instanceof RemoteLogger) {
-                LogReporting.getLogger().log(LogLevel.INFO, message);
-            }
         }
 	}
 
     public void warn(final String message) {
         if (level >= WARN) {
             Log.w(TAG, message);
-            if( LogReporting.getLogger() instanceof RemoteLogger) {
-                LogReporting.getLogger().log(LogLevel.WARN, message);
-            }
         }
     }
 
     public void error(final String message) {
         if (level >= ERROR) {
             Log.e(TAG, message);
-            if( LogReporting.getLogger() instanceof RemoteLogger) {
-                LogReporting.getLogger().log(LogLevel.ERROR, message);
-            }
         }
 	}
 	
-	public void error(final String message, Throwable throwable) {
+	public void error(final String message, Throwable cause) {
         if (level >= ERROR) {
-            Log.e(TAG, message, throwable);
-            if( LogReporting.getLogger() instanceof RemoteLogger) {
-                LogReporting.getLogger().logThrowable(LogLevel.ERROR, message, throwable);
-            }
+            Log.e(TAG, message, cause);
         }
     }
 


### PR DESCRIPTION
[NR-178365] Pull up agent remote logging into its own class
* add `logger` attribute to indicate log message was sent by the agent

[NR-232439] Support all log collector endpoints

[NR-223199] fix: add missing supportability metric delimiter

chore: refactor request content type and encoder constants
* separates content-type form encoding
* adds GZIP content and encoding type constants

chore: add more stream helpers
* And Javadoc documentation; updated tests