### PR TITLE
Update functionalTests.yml to disable JDK17 func test

### DIFF
--- a/.github/workflows/functionalTests.yml
+++ b/.github/workflows/functionalTests.yml
@@ -98,7 +98,7 @@ jobs:
           retention-days: 5
 
   functional-regressions-jdk17:
-    # if: ${{ false }}  # disable for until tests are resolved
+    if: ${{ false }}  # disable for until tests are resolved
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
JDK Gradle TestKit blows out heap. This test should have been disabled until fully resolved. We were lucky it ran before, but the dynamic feature merge wasn't vetted for this test.