### PR TITLE
[NR-89226] Add supportability metric when size > 1MB for each endpoint

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -129,7 +129,7 @@ public class AgentDataReporter extends PayloadReporter implements HarvestLifecyc
                     .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
                     .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
                     .replace(MetricNames.TAG_SUBDESTINATION, "f");
-            StatsEngine.get().inc(name);
+            StatsEngine.notice().inc(name);
             payloadStore.delete(payload);
             log.error("Unable to upload handled exceptions because payload is larger than 1 MB, handled exceptions are discarded.");
             return null;

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -18,6 +18,7 @@ import com.newrelic.agent.android.payload.PayloadReporter;
 import com.newrelic.agent.android.payload.PayloadSender;
 import com.newrelic.agent.android.payload.PayloadStore;
 import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.Constants;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -121,6 +122,19 @@ public class AgentDataReporter extends PayloadReporter implements HarvestLifecyc
 
     public Future reportAgentData(Payload payload) {
         PayloadSender payloadSender = new AgentDataSender(payload, getAgentConfiguration());
+
+        if (payload.getBytes().length > Constants.Network.MAXPAYLOADSIZELIMIT) {
+            DeviceInformation deviceInformation = Agent.getDeviceInformation();
+            String name = MetricNames.SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT
+                    .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
+                    .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
+                    .replace(MetricNames.TAG_SUBDESTINATION, "f");
+            StatsEngine.get().inc(name);
+            payloadStore.delete(payload);
+            log.error("Unable to upload handled exceptions because payload is larger than 1 MB, handled exceptions are discarded.");
+            return null;
+        }
+
         Future future = PayloadController.submitPayload(payloadSender, new PayloadSender.CompletionHandler() {
             @Override
             public void onResponse(PayloadSender payloadSender) {

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -123,7 +123,7 @@ public class AgentDataReporter extends PayloadReporter implements HarvestLifecyc
     public Future reportAgentData(Payload payload) {
         PayloadSender payloadSender = new AgentDataSender(payload, getAgentConfiguration());
 
-        if (payload.getBytes().length > Constants.Network.MAXPAYLOADSIZELIMIT) {
+        if (payload.getBytes().length > Constants.Network.MAX_PAYLOAD_SIZE) {
             DeviceInformation deviceInformation = Agent.getDeviceInformation();
             String name = MetricNames.SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT
                     .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
@@ -16,6 +16,7 @@ import com.newrelic.agent.android.payload.PayloadController;
 import com.newrelic.agent.android.payload.PayloadReporter;
 import com.newrelic.agent.android.payload.PayloadSender;
 import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.Constants;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -119,6 +120,19 @@ public class CrashReporter extends PayloadReporter implements HarvestLifecycleAw
             if (hasValidDataToken) {
                 if (crash != null) {
                     final CrashSender sender = new CrashSender(crash, agentConfiguration);
+
+                    long crashSize = crash.asJsonObject().toString().getBytes().length;
+                    if (crashSize > Constants.Network.MAXPAYLOADSIZELIMIT) {
+                        DeviceInformation deviceInformation = Agent.getDeviceInformation();
+                        String name = MetricNames.SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT
+                                .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
+                                .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
+                                .replace(MetricNames.TAG_SUBDESTINATION, "mobile_crash");
+                        StatsEngine.get().inc(name);
+                        crashStore.delete(crash);
+                        log.error("Unable to upload crashes because payload is larger than 1 MB, crash report is discarded.");
+                        return null;
+                    }
 
                     final PayloadSender.CompletionHandler completionHandler = new PayloadSender.CompletionHandler() {
                         @Override

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
@@ -122,7 +122,7 @@ public class CrashReporter extends PayloadReporter implements HarvestLifecycleAw
                     final CrashSender sender = new CrashSender(crash, agentConfiguration);
 
                     long crashSize = crash.asJsonObject().toString().getBytes().length;
-                    if (crashSize > Constants.Network.MAXPAYLOADSIZELIMIT) {
+                    if (crashSize > Constants.Network.MAX_PAYLOAD_SIZE) {
                         DeviceInformation deviceInformation = Agent.getDeviceInformation();
                         String name = MetricNames.SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT
                                 .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
@@ -128,7 +128,7 @@ public class CrashReporter extends PayloadReporter implements HarvestLifecycleAw
                                 .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
                                 .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
                                 .replace(MetricNames.TAG_SUBDESTINATION, "mobile_crash");
-                        StatsEngine.get().inc(name);
+                        StatsEngine.notice().inc(name);
                         crashStore.delete(crash);
                         log.error("Unable to upload crashes because payload is larger than 1 MB, crash report is discarded.");
                         return null;

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
@@ -133,16 +133,29 @@ public class HarvestConnection implements HarvestErrorCodes {
 
             //add supportability metrics
             DeviceInformation deviceInformation = Agent.getDeviceInformation();
-            String name = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
+            String outputByptesName = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
                     .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
                     .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR);
             if (connection.getURL().getFile().contains(COLLECTOR_CONNECT_URI)) {
-                name = name.replace(MetricNames.TAG_SUBDESTINATION, "connect");
+                outputByptesName = outputByptesName.replace(MetricNames.TAG_SUBDESTINATION, "connect");
             } else if (connection.getURL().getFile().contains(COLLECTOR_DATA_URI)) {
-                name = name.replace(MetricNames.TAG_SUBDESTINATION, "data");
+                outputByptesName = outputByptesName.replace(MetricNames.TAG_SUBDESTINATION, "data");
             }
             float byteReceived = harvestResponse.getResponseBody() == null ? 0 : harvestResponse.getResponseBody().length();
-            StatsEngine.get().sampleMetricDataUsage(name, byteBuffer.array().length, byteReceived);
+            StatsEngine.get().sampleMetricDataUsage(outputByptesName, byteBuffer.array().length, byteReceived);
+
+            if (byteBuffer.array().length > Constants.Network.MAXPAYLOADSIZELIMIT) {
+                String maxPayloadName = MetricNames.SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT
+                        .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
+                        .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR);
+                if (connection.getURL().getFile().contains(COLLECTOR_CONNECT_URI)) {
+                    maxPayloadName = maxPayloadName.replace(MetricNames.TAG_SUBDESTINATION, "connect");
+                } else if (connection.getURL().getFile().contains(COLLECTOR_DATA_URI)) {
+                    maxPayloadName = maxPayloadName.replace(MetricNames.TAG_SUBDESTINATION, "data");
+                }
+                StatsEngine.get().inc(maxPayloadName);
+                log.error("Unable to send harvest data because payload is larger than 1 MB, harvest data will be discarded.");
+            }
         } catch (IOException e) {
             log.error("Failed to retrieve collector response: " + e.getMessage());
             recordCollectorError(e);

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
@@ -153,7 +153,7 @@ public class HarvestConnection implements HarvestErrorCodes {
                 } else if (connection.getURL().getFile().contains(COLLECTOR_DATA_URI)) {
                     maxPayloadName = maxPayloadName.replace(MetricNames.TAG_SUBDESTINATION, "data");
                 }
-                StatsEngine.get().inc(maxPayloadName);
+                StatsEngine.notice().inc(maxPayloadName);
                 log.error("Unable to send harvest data because payload is larger than 1 MB, harvest data will be discarded.");
             }
         } catch (IOException e) {

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConnection.java
@@ -133,18 +133,18 @@ public class HarvestConnection implements HarvestErrorCodes {
 
             //add supportability metrics
             DeviceInformation deviceInformation = Agent.getDeviceInformation();
-            String outputByptesName = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
+            String outputBytesName = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
                     .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
                     .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR);
             if (connection.getURL().getFile().contains(COLLECTOR_CONNECT_URI)) {
-                outputByptesName = outputByptesName.replace(MetricNames.TAG_SUBDESTINATION, "connect");
+                outputBytesName = outputBytesName.replace(MetricNames.TAG_SUBDESTINATION, "connect");
             } else if (connection.getURL().getFile().contains(COLLECTOR_DATA_URI)) {
-                outputByptesName = outputByptesName.replace(MetricNames.TAG_SUBDESTINATION, "data");
+                outputBytesName = outputBytesName.replace(MetricNames.TAG_SUBDESTINATION, "data");
             }
             float byteReceived = harvestResponse.getResponseBody() == null ? 0 : harvestResponse.getResponseBody().length();
-            StatsEngine.get().sampleMetricDataUsage(outputByptesName, byteBuffer.array().length, byteReceived);
+            StatsEngine.get().sampleMetricDataUsage(outputBytesName, byteBuffer.array().length, byteReceived);
 
-            if (byteBuffer.array().length > Constants.Network.MAXPAYLOADSIZELIMIT) {
+            if (byteBuffer.array().length > Constants.Network.MAX_PAYLOAD_SIZE) {
                 String maxPayloadName = MetricNames.SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT
                         .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
                         .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR);

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -92,6 +92,7 @@ public class MetricNames {
     public static final String SUPPORTABILITY_OUTPUT_BYTES = "Output/Bytes";
     public static final String SUPPORTABILITY_DESTINATION_OUTPUT_BYTES = SUPPORTABILITY_MOBILE_ANDROID + "<framework>/<destination>/" + SUPPORTABILITY_OUTPUT_BYTES;
     public static final String SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES = SUPPORTABILITY_MOBILE_ANDROID + "<framework>/<destination>/<subdestination>/" + SUPPORTABILITY_OUTPUT_BYTES;
+    public static final String SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT = SUPPORTABILITY_MOBILE_ANDROID + "<framework>/<destination>/MaxPayloadSizeLimit/<subdestination>";
 
     public static final String METRIC_APP_LAUNCH = "AppLaunch/";
     public static final String APP_LAUNCH_COLD = METRIC_APP_LAUNCH + "Cold";

--- a/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
@@ -34,7 +34,7 @@ public final class Constants {
         public static final String CONTENT_LENGTH_HEADER = "Content-Length";
         public static final String USER_AGENT_HEADER = "User-Agent";
         public static final String HOST_HEADER = "Host";
-        public static final long MAXPAYLOADSIZELIMIT = 1000000; //bytes
+        public static final long MAX_PAYLOAD_SIZE = 1000000; //bytes
 
         public final class ContentType {
             public static final String URL_ENCODED = "application/x-www-form-urlencoded";

--- a/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
@@ -34,6 +34,7 @@ public final class Constants {
         public static final String CONTENT_LENGTH_HEADER = "Content-Length";
         public static final String USER_AGENT_HEADER = "User-Agent";
         public static final String HOST_HEADER = "Host";
+        public static final long MAXPAYLOADSIZELIMIT = 1000000; //bytes
 
         public final class ContentType {
             public static final String URL_ENCODED = "application/x-www-form-urlencoded";


### PR DESCRIPTION
Ticket: https://new-relic.atlassian.net/browse/NR-89226

**What's changed:**
1. Add supportability metric when payload size > 1MB based on agent spec [here](https://source.datanerd.us/agents/agent-specs/pull/585)

**Testing:**
1. Real device testing