### PR TITLE
[NR-215504} Jar meta inf rewriting - test updates

### DIFF
--- a/buildconfig.gradle
+++ b/buildconfig.gradle
@@ -53,7 +53,7 @@ buildscript {
 
                 agp   : [
                         // https://developer.android.com/studio/releases/platforms
-                        plugin       : '7.1.+', // using Gradle 7.2
+                        plugin       : '7.4.2', // using Gradle 7.5
                         minSdk       : 24, // Android 7.0
                         compileSdk   : 28, // Android 9.0
                         targetSdk    : 28, // Android 9.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginRegressionSpec.groovy
@@ -31,7 +31,7 @@ class PluginRegressionSpec extends PluginSpec {
     def "Regress agent[#agent] against AGP[#agp] Gradle[#gradle]"() {
         given: "Run plugin using the AGP/Gradle combination"
         def agentVer = agent as String
-        def includeLibrary = GradleVersion.version(agentVer.replace('+', '0')) >= GradleVersion.version("7.0")
+        def agent7orHigher = GradleVersion.version(agentVer.replace('+', '0')) >= GradleVersion.version("7.0")
         def runner = provideRunner()
                 .withGradleVersion(gradle)
                 .withArguments(
@@ -40,7 +40,8 @@ class PluginRegressionSpec extends PluginSpec {
                         "-Pcompiler=r8",
                         "-PagentRepo=${localEnv["M2_REPO"]}",
                         "-PwithProductFlavors=false",
-                        "-PincludeLibrary=${includeLibrary}",
+                        "-PincludeLibrary=${agent7orHigher}",
+                        "-PincludeFeature=${agent7orHigher}",
                         "clean",
                         testTask)
 

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/BuildHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/BuildHelperTest.groovy
@@ -25,8 +25,8 @@ class BuildHelperTest extends PluginTest {
 
     @BeforeEach
     void setUp() {
-        buildHelper = Mockito.spy(BuildHelper.register(project))
-        buildHelper.logger = Mockito.spy(buildHelper.logger)
+        buildHelper = Mockito.spy(plugin.buildHelper)
+        buildHelper.logger = Mockito.spy(buildHelper.getLogger())
     }
 
     @Test
@@ -144,7 +144,7 @@ class BuildHelperTest extends PluginTest {
 
     @Test
     void getDefaultMapUploadProvider() {
-        buildHelper.variantAdapter.getVariantValues().each { variant ->
+        buildHelper.variantAdapter.withVariant("release").tap { variant ->
             def provider = project.tasks.named("${NewRelicMapUploadTask.NAME}${variant.name.capitalize()}")
             Assert.assertEquals(NewRelicMapUploadTask, provider.type)
         }
@@ -161,7 +161,7 @@ class BuildHelperTest extends PluginTest {
 
     @Test
     void getMappingFile() {
-        buildHelper.variantAdapter.getVariantValues().each { variant ->
+        buildHelper.variantAdapter.withVariant("release").tap  { variant ->
             def provider = buildHelper.variantAdapter.getMappingFileProvider(variant.name)
             Assert.assertTrue(provider instanceof RegularFileProperty)
             // TODO
@@ -199,15 +199,15 @@ class BuildHelperTest extends PluginTest {
 
     @Test
     void isUsingLegacyTransform() {
-        buildHelper = Mockito.spy(new BuildHelper(project))
-        Mockito.when(buildHelper.getGradleVersion()).thenReturn("6.7.1")
+        buildHelper = Mockito.spy(plugin.buildHelper)
+        Mockito.when(buildHelper.getAgpVersion()).thenReturn("7.3.3")
         buildHelper.variantAdapter = VariantAdapter.register(buildHelper)
         Assert.assertTrue(buildHelper.isUsingLegacyTransform())
     }
 
     @Test
     void isUsing7xTransform() {
-        buildHelper = Mockito.spy(new BuildHelper(project))
+        buildHelper = Mockito.spy(plugin.buildHelper)
         Mockito.when(buildHelper.getGradleVersion()).thenReturn("7.999")
 
         def ext = Mockito.spy(buildHelper.androidComponentsExtension)

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -5,15 +5,15 @@
 
 package com.newrelic.agent.android
 
-import org.gradle.util.GradleVersion
+
 import org.junit.Assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 
 class DexGuardHelperTest extends PluginTest {
-    def dexGuardHelper
     def buildHelper
+    def dexGuardHelper
 
     @BeforeEach
     void setUp() {
@@ -23,14 +23,13 @@ class DexGuardHelperTest extends PluginTest {
         Mockito.when(project.getPlugins()).thenReturn(plugins)
         Mockito.when(plugins.hasPlugin(DexGuardHelper.PLUGIN_EXTENSION_NAME)).thenReturn(true)
 
-        buildHelper = Mockito.spy(BuildHelper.register(project))
-        buildHelper.variantAdapter.configure(buildHelper.extension)
-        Mockito.doReturn("7.6").when(buildHelper).getGradleVersion()
+        buildHelper = Mockito.spy(plugin.buildHelper)
+        Mockito.when(buildHelper.getGradleVersion()).thenReturn("7.6")
+        Mockito.when(buildHelper.getProject()).thenReturn(project);
 
         dexGuardHelper = Mockito.spy(DexGuardHelper.register(buildHelper))
-        Mockito.doReturn(true).when(dexGuardHelper).getEnabled()
-        Mockito.doReturn(DexGuardHelper.minSupportedVersion).when(dexGuardHelper).getCurrentVersion()
-
+        Mockito.when(dexGuardHelper.getEnabled()).thenReturn(true)
+        Mockito.when(dexGuardHelper.getCurrentVersion()). thenReturn(DexGuardHelper.minSupportedVersion)
     }
 
     @Test

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicMapUploadTaskTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicMapUploadTaskTest.groovy
@@ -10,9 +10,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class NewRelicMapUploadTaskTest extends PluginTest {
-    NewRelicExtension ext
-    BuildHelper buildHelper
-    VariantAdapter variantAdapter
     def provider
 
     NewRelicMapUploadTaskTest() {
@@ -21,64 +18,41 @@ class NewRelicMapUploadTaskTest extends PluginTest {
 
     @BeforeEach
     void setup() {
-        // Create the instances needed to test this class
-        ext = NewRelicExtension.register(project)
-        buildHelper = BuildHelper.register(project)
-        variantAdapter = buildHelper.variantAdapter
-        variantAdapter.configure(ext)
-
-        provider = buildHelper.variantAdapter.getMapUploadProvider("release")
+        provider = plugin.buildHelper.variantAdapter.getMapUploadProvider("release").get()
     }
 
     @Test
     void getVariantName() {
-        provider.get().tap {
-            Assert.assertEquals("release", getVariantName().get())
-        }
+        Assert.assertEquals("release", provider.getVariantName().get())
     }
 
     @Test
     void getProjectRoot() {
-        provider.get().tap {
-            Assert.assertEquals(project.layout.projectDirectory, it.getProjectRoot().get())
-        }
+        Assert.assertEquals(project.layout.projectDirectory, provider.getProjectRoot().get())
     }
 
     @Test
     void getBuildId() {
-        def task = provider.get().tap {
-            Assert.assertFalse(getBuildId().get().isEmpty())
-            Assert.assertFalse(UUID.fromString(getBuildId().get()).toString().isEmpty())
-        }
+        def buildId = provider.getBuildId().get()
+        Assert.assertFalse(buildId.isEmpty())
+        Assert.assertFalse(UUID.fromString(buildId).toString().isEmpty())
     }
 
     @Test
     void getMapProvider() {
-        def task = provider.get().tap {
-            Assert.assertEquals("r8", getMapProvider().get().toLowerCase())
-        }
+        Assert.assertEquals("r8", provider.getMapProvider().get().toLowerCase())
     }
 
     @Test
     void getMappingFile() {
-        def task = provider.get().tap {
-            def f = getMappingFile().asFile
-            Assert.assertFalse(f.get().absolutePath.isEmpty())
-            def m = buildHelper.variantAdapter.getMappingFileProvider("release")
-            Assert.assertEquals(f.get(), m.get().asFile)
-        }
-    }
-
-    @Test
-    void newRelicMapUploadTask() {
-        provider.configure {
-            // @TaskAction
-            newRelicMapUploadTask()
-        }
+        def f = provider.getMappingFile().asFile
+        Assert.assertFalse(f.get().absolutePath.isEmpty())
+        def m = plugin.buildHelper.variantAdapter.getMappingFileProvider("release")
+        Assert.assertEquals(f.get(), m.get().asFile)
     }
 
     @Test
     void getLogger() {
-        Assert.assertEquals(provider.get().logger, NewRelicGradlePlugin.LOGGER)
+        Assert.assertEquals(provider.getLogger(), NewRelicGradlePlugin.LOGGER)
     }
 }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/PluginTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/PluginTest.groovy
@@ -11,14 +11,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.rules.TemporaryFolder
 
-/**
- * The Plugin tests assumes using the test harness at <rootProjectDir>/samples/agent-test-app.
- * All assertions and assumptions are based on that project's configuration
- */
 abstract class PluginTest {
-    final def rootDir = new File("../..").absoluteFile
-    final def projectDir = new File(rootDir, "samples/agent-test-app/")
-
     def tmpProjectDir
     def project
     def agp
@@ -37,9 +30,6 @@ abstract class PluginTest {
     void beforeEach() {
         tmpProjectDir = TemporaryFolder.builder().assureDeletion().build()
         tmpProjectDir.create()
-
-        def settings = tmpProjectDir.newFile("settings.gradle")
-        Files.write(getClass().getResource("/gradle/settings.gradle").bytes, settings)
 
         def build = tmpProjectDir.newFile("build.gradle")
         Files.write(getClass().getResource("/gradle/build.gradle").bytes, build)

--- a/plugins/gradle/src/integration/resources/gradle/build.gradle
+++ b/plugins/gradle/src/integration/resources/gradle/build.gradle
@@ -9,15 +9,10 @@ buildscript {
         google()
         mavenCentral()
     }
-    dependencies {
-        classpath "com.android.tools.build:gradle:7.+"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.+
-    }
 }
 
 plugins {
-    id 'com.android.application' version "7.+"
-    id 'org.jetbrains.kotlin.android'
+    id 'com.android.application' version "7.4.2"
 }
 */
 
@@ -26,7 +21,7 @@ android {
     compileSdk 33
 
     defaultConfig {
-        applicationId "com.newrelic.agent.android"
+        applicationId "com.newrelic.agent.android.PluginTest"
         minSdk 24
         targetSdk 33
         versionCode 1

--- a/plugins/gradle/src/integration/resources/gradle/nr-extension.gradle
+++ b/plugins/gradle/src/integration/resources/gradle/nr-extension.gradle
@@ -1,0 +1,10 @@
+newrelic {
+    // Tag and report Proguard maps for these build types (default: release):
+    // uploadMapsForVariant 'release'
+
+    // do not instrument these variant builds
+    // excludeVariantInstrumentation 'debug'
+
+    // do not instrument these specific packages
+    excludePackageInstrumentation 'com.newrelic'
+}

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/BuildHelper.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/BuildHelper.groovy
@@ -37,6 +37,9 @@ class BuildHelper {
      * 7.4              7.5
      * 8.0              8.0
      * 8.1              8.2
+     * 8.2              8.2
+     * 8.3              8.4
+     * 8.4              8.6
      *
      **/
 
@@ -378,4 +381,7 @@ class BuildHelper {
         }
     }
 
+    Project getProject() {
+        return project
+    }
 }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -6,7 +6,6 @@
 package com.newrelic.agent.android
 
 import com.newrelic.agent.android.agp4.AGP4Adapter
-import com.newrelic.agent.android.agp7.AGP70Adapter
 import com.newrelic.agent.android.agp7.AGP74Adapter
 import com.newrelic.agent.android.obfuscation.Proguard
 import com.newrelic.agent.util.BuildId
@@ -89,7 +88,7 @@ abstract class VariantAdapter {
      * @return Instance of this variant, null if missing
      */
     def withVariant(String variantName) {
-        return variants.get().get(variantName.toLowerCase())
+        return variants.getting(variantName.toLowerCase()).getOrElse(null)
     }
 
     /**
@@ -99,9 +98,9 @@ abstract class VariantAdapter {
      */
     BuildTypeAdapter withBuildType(String variantName) {
         if (!buildTypes.getting(variantName).isPresent()) {
-            buildTypes.put(variantName, getBuildTypeProvider(variantName).get())
+            buildTypes.put(variantName, getBuildTypeProvider(variantName))
         }
-        return buildTypes.getting(variantName).get()
+        return buildTypes.getting(variantName).getOrElse(null)
     }
 
     /**
@@ -162,7 +161,7 @@ abstract class VariantAdapter {
     def wiredWithConfigProvider(String variantName) {
         def configProvider = getConfigProvider(variantName) { configTask ->
             def buildType = withBuildType(variantName)
-            def genSrcFolder = buildHelper.project.layout.buildDirectory.dir("generated/java/newrelicConfig${buildType.name}")
+            def genSrcFolder = buildHelper.project.layout.buildDirectory.dir("generated/java/newrelicConfig${buildType.name.capitalize()}")
 
             configTask.sourceOutputDir.set(objectFactory.directoryProperty().value(genSrcFolder))
             configTask.mapProvider.set(objectFactory.property(String).value(buildHelper.getMapCompilerName()))

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
@@ -71,7 +71,7 @@ class AGP4Adapter extends VariantAdapter {
     Provider<Object> getBuildTypeProvider(String variantName) {
         def variant = withVariant(variantName)
         def buildType = new BuildTypeAdapter(variant.name, variant.buildType.minifyEnabled, variant.buildType.name)
-        return objectFactory.property(Object).value(buildType)
+        return objectFactory.property(BuildTypeAdapter).value(buildType)
     }
 
     @Override

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP74Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP74Adapter.groovy
@@ -39,7 +39,7 @@ class AGP74Adapter extends AGP70Adapter {
         }
         def buildTypeAdapter = new BuildTypeAdapter(variant.name, isMinifyEnabled, variant.flavorName, variant.buildType)
 
-        return buildHelper.project.objects.property(Object).value(buildTypeAdapter)
+        return objectFactory.property(BuildTypeAdapter).value(buildTypeAdapter)
     }
 
     @Override


### PR DESCRIPTION
Update plugin integration tests to use AGP7 variant adapter. Tis required increasing the agent's `compileSdk` value to 30. All affected tests were updated.