### PR TITLE
TicToc time calculation & convertion

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/stats/TicToc.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/stats/TicToc.java
@@ -5,8 +5,10 @@
 
 package com.newrelic.agent.android.stats;
 
+import java.util.concurrent.TimeUnit;
+
 public class TicToc {
-    private static enum State {
+    protected static enum State {
         STOPPED,
         STARTED,
     }
@@ -15,13 +17,16 @@ public class TicToc {
     private long endTime;
     private State state;
 
-    public void tic() {
+    public TicToc tic() {
         state = State.STARTED;
-        startTime = System.currentTimeMillis();
+        long nanoTime = System.nanoTime();
+        startTime = TimeUnit.MILLISECONDS.convert(nanoTime, TimeUnit.NANOSECONDS);
+        return this;
     }
 
     public long toc() {
-        endTime = System.currentTimeMillis();
+        long nanoTime = System.nanoTime();
+        endTime = TimeUnit.MILLISECONDS.convert(nanoTime, TimeUnit.NANOSECONDS);
 
         if (state == State.STARTED) {
             state = State.STOPPED;
@@ -32,7 +37,33 @@ public class TicToc {
     }
 
     public long peek() {
-        return (state == State.STARTED) ? System.currentTimeMillis() - startTime : 0;
+        long nanoTime = System.nanoTime();
+        long endTime = TimeUnit.MILLISECONDS.convert(nanoTime, TimeUnit.NANOSECONDS);
+        return (state == State.STARTED) ? endTime - startTime : 0;
+    }
+
+    protected long getStartTime() {
+        return startTime;
+    }
+
+    protected void setStartTime(long startTime) {
+        this.startTime = startTime;
+    }
+
+    protected long getEndTime() {
+        return endTime;
+    }
+
+    protected void setEndTime(long endTime) {
+        this.endTime = endTime;
+    }
+
+    protected State getState() {
+        return state;
+    }
+
+    protected void setState(State state) {
+        this.state = state;
     }
 
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/stats/TicTocTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/stats/TicTocTest.java
@@ -1,0 +1,75 @@
+package com.newrelic.agent.android.stats;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TicTocTest {
+
+    @Test
+    public void validateValues() {
+        TicToc timer = new TicToc();
+
+        timer.tic();
+        long startTime = timer.getStartTime();
+        Assert.assertEquals(timer.getState(), TicToc.State.STARTED);
+
+        long calculatedTime = timer.toc();
+        long endTime = timer.getEndTime();
+        Assert.assertEquals(timer.getState(), TicToc.State.STOPPED);
+
+        Assert.assertEquals(calculatedTime, endTime - startTime);
+    }
+
+    @Test
+    public void validateStartEndTime() throws InterruptedException {
+        TicToc timer = new TicToc();
+        timer.tic();
+        long startTime = timer.getStartTime();
+        Thread.sleep(3000);
+        timer.toc();
+        long endTime = timer.getEndTime();
+        Assert.assertTrue(endTime > startTime);
+    }
+
+    @Test
+    public void validatePeek() throws InterruptedException {
+        TicToc timer = new TicToc();
+        timer.tic();
+        Thread.sleep(3000);
+        Assert.assertTrue(timer.peek() > 0);
+        timer.toc();
+        Assert.assertTrue(timer.peek() == 0);
+    }
+
+    @Test
+    public void validateTic() {
+        TicToc timer = new TicToc();
+        Assert.assertTrue(timer.tic() != null);
+        Assert.assertEquals(timer.getState(), TicToc.State.STARTED);
+    }
+
+    @Test
+    public void validateToc() throws InterruptedException {
+        TicToc timer = new TicToc();
+        Assert.assertEquals(timer.getState(), null);
+        Assert.assertEquals(timer.toc(), -1);
+
+        timer.tic();
+        Assert.assertEquals(timer.getState(), TicToc.State.STARTED);
+        Thread.sleep(3000);
+        Assert.assertTrue(timer.toc() > 0);
+        Assert.assertEquals(timer.getState(), TicToc.State.STOPPED);
+    }
+
+    @Test
+    public void testAgainstMillis() throws InterruptedException {
+        long mStart = System.currentTimeMillis();
+        TicToc ticToc = new TicToc().tic();
+        Thread.sleep(3000);
+        ticToc.toc();
+        long mEnd = System.currentTimeMillis();
+        long nStart = ticToc.getStartTime();
+        long nEnd = ticToc.getEndTime();
+        Assert.assertTrue((mEnd - mStart) - (nEnd - nStart) < 5);
+    }
+}


### PR DESCRIPTION
Ticket: https://new-relic.atlassian.net/browse/NR-59017

What's changed:
1. Use nanoTime() but covert to millionSeconds due to agent is using ms as default calculation.
2. Add unit tests