### PR TITLE
fix: Newrelic Agent is not starting when app comes in foreground from…

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataController.java
@@ -54,7 +54,7 @@ public class AgentDataController {
         handledException.put(HexAttribute.HEX_ATTR_APP_BUILD_ID, applicationInfo.getApplicationBuild());
         handledException.put(HexAttribute.HEX_ATTR_SESSION_ID, agentConfiguration.getSessionID());
         handledException.put(HexAttribute.HEX_ATTR_TIMESTAMP_MS, System.currentTimeMillis());
-        handledException.put(HexAttribute.HEX_ATTR_MESSAGE, e.getMessage().length() > 4096 ? e.getMessage().substring(0, 4096) : e.getMessage());
+        handledException.put(HexAttribute.HEX_ATTR_MESSAGE, (e.getMessage() != null && e.getMessage().length() > 4096 ) ? e.getMessage().substring(0, 4096) : e.getMessage());
         String cause = getRootCause(e).toString();
         handledException.put(HexAttribute.HEX_ATTR_CAUSE, cause.length() > 4096 ? cause.substring(0, 4096) : cause);
         handledException.put(HexAttribute.HEX_ATTR_NAME, e.getClass().toString());

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -135,7 +135,7 @@ public class AndroidAgentImpl implements
                         if (context.getApplicationContext() instanceof Application) {
                             Application application = (Application) context.getApplicationContext();
                             application.registerActivityLifecycleCallbacks((Application.ActivityLifecycleCallbacks) backgroundListener);
-                            if (agentConfiguration.getApplicationFramework() == ApplicationFramework.Xamarin || agentConfiguration.getApplicationFramework() == ApplicationFramework.MAUI) {
+                            if (agentConfiguration.getApplicationFramework() == ApplicationFramework.Xamarin) {
                                 ApplicationStateMonitor.getInstance().activityStarted();
                             }
                         }


### PR DESCRIPTION
… the background

Maui agent is initiating the applicationMontinor activity from multiple locations, causing the activity count values to increase multiple times. Additionally, when the app transitions to the background, the count is not reset to 0. Consequently, the agent fails to restart when the app returns to the foreground.