### PR TITLE
[NR-247779] Connect remote config to AEI feature

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -11,6 +11,7 @@ import com.newrelic.agent.android.crash.CrashStore;
 import com.newrelic.agent.android.harvest.HarvestConfiguration;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.LogLevel;
 import com.newrelic.agent.android.logging.LogReportingConfiguration;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.NullPayloadStore;
@@ -66,13 +67,15 @@ public class AgentConfiguration {
     private ApplicationFramework applicationFramework = ApplicationFramework.Native;
     private String applicationFrameworkVersion = Agent.getVersion();
     private String deviceID;
-    private LogReportingConfiguration logReportingConfiguration = new LogReportingConfiguration();
+
+    // Support remote configuration
+    private LogReportingConfiguration logReportingConfiguration = new LogReportingConfiguration(false, LogLevel.NONE);
+    private ApplicationExitConfiguration applicationExitConfiguration = new ApplicationExitConfiguration(false);
 
     public String getApplicationToken() {
         return applicationToken;
     }
-
-
+    
     public void setApplicationToken(String applicationToken) {
         this.applicationToken = applicationToken;
         this.region = parseRegionFromApplicationToken(applicationToken);
@@ -358,6 +361,14 @@ public class AgentConfiguration {
         this.logReportingConfiguration = logReportingConfiguration;
     }
 
+    public ApplicationExitConfiguration getApplicationExitConfiguration() {
+        return applicationExitConfiguration;
+    }
+
+    public void getApplicationExitConfiguration(ApplicationExitConfiguration applicationExitConfiguration) {
+        this.applicationExitConfiguration = applicationExitConfiguration;
+    }
+
     /**
      * Update agent config with any changes returned in the harvest response.
      * Currently, it is only log reporting config
@@ -366,7 +377,7 @@ public class AgentConfiguration {
      */
     public void reconfigure(HarvestConfiguration harvestConfiguration) {
         // update the global agent config w/changes
-        this.setLogReportingConfiguration(harvestConfiguration.getLog_reporting());
+        this.applicationExitConfiguration.setConfiguration(harvestConfiguration.getRemote_configuration().applicationExitConfiguration);
     }
 
     // return the default instance

--- a/agent-core/src/main/java/com/newrelic/agent/android/ApplicationExitConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/ApplicationExitConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.beans.FeatureDescriptor;
+
+public class ApplicationExitConfiguration {
+    @SerializedName("enabled")
+    boolean enabled;
+
+    public ApplicationExitConfiguration() {
+        this.enabled = false;
+    }
+
+    public ApplicationExitConfiguration(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled && FeatureFlag.featureEnabled(FeatureFlag.ApplicationExitReporting);
+    }
+
+    public void setConfiguration(ApplicationExitConfiguration applicationExitConfiguration) {
+        this.enabled = applicationExitConfiguration.enabled;
+    }
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/ApplicationExitConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/ApplicationExitConfiguration.java
@@ -7,14 +7,12 @@ package com.newrelic.agent.android;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.beans.FeatureDescriptor;
-
 public class ApplicationExitConfiguration {
     @SerializedName("enabled")
     boolean enabled;
 
     public ApplicationExitConfiguration() {
-        this.enabled = false;
+        this.enabled = true;
     }
 
     public ApplicationExitConfiguration(boolean enabled) {
@@ -28,4 +26,22 @@ public class ApplicationExitConfiguration {
     public void setConfiguration(ApplicationExitConfiguration applicationExitConfiguration) {
         this.enabled = applicationExitConfiguration.enabled;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ApplicationExitConfiguration) {
+            ApplicationExitConfiguration rhs = (ApplicationExitConfiguration) obj;
+            return this.enabled == rhs.enabled;
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "{"
+                + "\"enabled\"=" + enabled
+                + "}";
+    }
+
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/RemoteConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/RemoteConfiguration.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2021-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android;
+
+import com.google.gson.annotations.SerializedName;
+import com.newrelic.agent.android.harvest.HarvestLifecycleAware;
+import com.newrelic.agent.android.logging.LogReportingConfiguration;
+import com.newrelic.agent.android.logging.LoggingConfiguration;
+
+/**
+ * Data model for agent configuration Json data returned in the Collector connect response.
+ *
+ * Includes:
+ *  . FeatureFlag.ApplicationExitReporting
+ *
+ **/
+public class RemoteConfiguration implements HarvestLifecycleAware {
+
+    @SerializedName("logging")
+    protected LogReportingConfiguration logReportingConfiguration;
+
+    @SerializedName("application_exit_info")
+    protected ApplicationExitConfiguration applicationExitConfiguration;
+
+    public RemoteConfiguration() {
+        this.logReportingConfiguration = new LogReportingConfiguration();
+        this.applicationExitConfiguration = new ApplicationExitConfiguration();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof RemoteConfiguration) {
+            RemoteConfiguration rhs = (RemoteConfiguration) obj;
+            return this == rhs;
+        }
+
+        return false;
+    }
+
+    public LogReportingConfiguration getLogReportingConfiguration() {
+        return logReportingConfiguration;
+    }
+
+    public ApplicationExitConfiguration getApplicationExitConfiguration() {
+        return applicationExitConfiguration;
+    }
+
+    public void setLogReportingConfiguration(LogReportingConfiguration logReportingConfiguration) {
+        this.logReportingConfiguration = logReportingConfiguration;
+    }
+
+    public void setApplicationExitConfiguration(ApplicationExitConfiguration applicationExitConfiguration) {
+        this.applicationExitConfiguration = applicationExitConfiguration;
+    }
+
+    @Override
+    public void onHarvestConfigurationChanged() {
+        // noop
+    }
+
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/RemoteConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/RemoteConfiguration.java
@@ -19,37 +19,25 @@ import com.newrelic.agent.android.logging.LoggingConfiguration;
  **/
 public class RemoteConfiguration implements HarvestLifecycleAware {
 
-    @SerializedName("logging")
-    protected LogReportingConfiguration logReportingConfiguration;
-
     @SerializedName("application_exit_info")
     protected ApplicationExitConfiguration applicationExitConfiguration;
 
     public RemoteConfiguration() {
-        this.logReportingConfiguration = new LogReportingConfiguration();
-        this.applicationExitConfiguration = new ApplicationExitConfiguration();
+        this.applicationExitConfiguration = new ApplicationExitConfiguration(true);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof RemoteConfiguration) {
             RemoteConfiguration rhs = (RemoteConfiguration) obj;
-            return this == rhs;
+            return this.applicationExitConfiguration.equals(rhs.applicationExitConfiguration);
         }
 
         return false;
     }
 
-    public LogReportingConfiguration getLogReportingConfiguration() {
-        return logReportingConfiguration;
-    }
-
     public ApplicationExitConfiguration getApplicationExitConfiguration() {
         return applicationExitConfiguration;
-    }
-
-    public void setLogReportingConfiguration(LogReportingConfiguration logReportingConfiguration) {
-        this.logReportingConfiguration = logReportingConfiguration;
     }
 
     public void setApplicationExitConfiguration(ApplicationExitConfiguration applicationExitConfiguration) {

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConfiguration.java
@@ -5,12 +5,10 @@
 
 package com.newrelic.agent.android.harvest;
 
-import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
+import com.newrelic.agent.android.RemoteConfiguration;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfiguration;
-import com.newrelic.agent.android.logging.LogLevel;
 import com.newrelic.agent.android.logging.LogReporting;
-import com.newrelic.agent.android.logging.LogReportingConfiguration;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -73,8 +71,8 @@ public class HarvestConfiguration {
     private String trusted_account_key;
     @SerializedName("entity_guid")
     private String entity_guid = NO_VALUE;
-    @SerializedName("log_reporting")
-    private LogReportingConfiguration log_reporting;
+    @SerializedName("configuration")
+    private RemoteConfiguration remote_configuration;
 
     private static HarvestConfiguration defaultHarvestConfiguration;
 
@@ -101,7 +99,7 @@ public class HarvestConfiguration {
         setApplication_id(DEFAULT_APP_ID);
         setTrusted_account_key(DEFAULT_TRUSTED_ACCOUNT_KEY);
         setEntity_guid(LogReporting.getEntityGuid());
-        setLog_reporting(new LogReportingConfiguration(false, LogLevel.INFO));
+        setRemote_configuration(new RemoteConfiguration());
     }
 
     public static HarvestConfiguration getDefaultHarvestConfiguration() {
@@ -144,7 +142,7 @@ public class HarvestConfiguration {
         setApplication_id(configuration.getApplication_id());
         setTrusted_account_key(configuration.getTrusted_account_key());
         setEntity_guid(configuration.getEntity_guid());
-        setLog_reporting(configuration.getLog_reporting());
+        setRemote_configuration(configuration.getRemote_configuration());
     }
 
     public void setCollect_network_errors(boolean collect_network_errors) {
@@ -296,6 +294,11 @@ public class HarvestConfiguration {
         return account_id;
     }
 
+    public RemoteConfiguration getRemote_configuration() {
+        return this.remote_configuration;
+    }
+
+
     public void setAccount_id(String account_id) {
         this.account_id = account_id;
     }
@@ -315,24 +318,17 @@ public class HarvestConfiguration {
         this.entity_guid = value;
     }
 
-    public void setLog_reporting(final LogReportingConfiguration loggingConfiguration) {
-        this.log_reporting = loggingConfiguration;
+    public void setRemote_configuration(final RemoteConfiguration remoteConfiguration) {
+        this.remote_configuration = remoteConfiguration;
     }
 
     /**
      * Returns the Mobile entity guid synthesized by the Mobile Connect service.
+     *
      * @return Entity GUID
      */
     public String getEntity_guid() {
         return entity_guid;
-    }
-
-    /**
-     * Returns the current Log reporting config, if enabled;
-     * @return LogReporting configuraition returns by NerdGraph
-     */
-    public LogReportingConfiguration getLog_reporting() {
-        return log_reporting;
     }
 
 
@@ -411,7 +407,8 @@ public class HarvestConfiguration {
         if (entity_guid != null && !entity_guid.equals(that.entity_guid)) {
             return false;
         }
-        if (log_reporting != null && !log_reporting.toString().equals(that.log_reporting.toString())) {
+        if (remote_configuration != null &&
+            !remote_configuration.getApplicationExitConfiguration().equals(that.remote_configuration.getApplicationExitConfiguration())) {
             return false;
         }
 
@@ -451,7 +448,7 @@ public class HarvestConfiguration {
         result = 31 * result + (priority_encoding_key != null ? priority_encoding_key.hashCode() : 0);
         result = 31 * result + (trusted_account_key != null ? trusted_account_key.hashCode() : 0);
         result = 31 * result + (entity_guid != null ? entity_guid.hashCode() : 0);
-        result = 31 * result + (log_reporting != null ? log_reporting.hashCode() : 0);
+        result = 31 * result + (remote_configuration != null ? remote_configuration.hashCode() : 0);
         return result;
     }
 
@@ -477,7 +474,7 @@ public class HarvestConfiguration {
                 ", application_id=" + application_id +
                 ", trusted_account_key=" + trusted_account_key +
                 ", entity_guid=" + entity_guid +
-                ", log_reporting=" + log_reporting +
+                ", remote_configuration=" + remote_configuration.toString() +
                 '}';
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
@@ -70,7 +70,7 @@ public class Harvester {
         add(new HarvestAdapter() {
             @Override
             public void onHarvestConfigurationChanged() {
-                StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_HARVEST_CONFIGURATION_CHANGED);
+                StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_CONFIGURATION_CHANGED);
                 AnalyticsControllerImpl.getInstance().recordBreadcrumb("FIXME harvestConfiguration", new HashMap<>() {{
                     put("changed", true);
                 }});

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -40,7 +40,7 @@ public class MetricNames {
     public static final String SUPPORTABILITY_TRACES_HEALTHY = SUPPORTABILITY_AGENT + "HealthyActivityTraces";
     public static final String SUPPORTABILITY_TRACES_UNHEALTHY = SUPPORTABILITY_AGENT + "UnhealthyActivityTraces";
     public static final String SUPPORTABILITY_HARVEST_ON_MAIN_THREAD = SUPPORTABILITY_AGENT + "HarvestOnMainThread";
-    public static final String SUPPORTABILITY_HARVEST_CONFIGURATION_CHANGED = SUPPORTABILITY_AGENT + "Configuration/Updated";
+    public static final String SUPPORTABILITY_CONFIGURATION_CHANGED = SUPPORTABILITY_AGENT + "Configuration/Updated";
     public static final String SUPPORTABILITY_PAYLOAD_REMOVED_STALE = SUPPORTABILITY_AGENT + "Payload/Removed/Stale";
     public static final String SUPPORTABILITY_SESSION_INVALID_DURATION = SUPPORTABILITY_AGENT + "Session/InvalidDuration";
     public static final String SUPPORTABILITY_RESPONSE_TIME_INVALID_DURATION = SUPPORTABILITY_AGENT + "Network/Request/ResponseTime/InvalidDuration";

--- a/agent-core/src/test/java/com/newrelic/agent/android/RemoteConfigurationTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/RemoteConfigurationTest.java
@@ -27,13 +27,9 @@ public class RemoteConfigurationTest {
     @Before
     public void setUp() throws Exception {
         remoteConfig = new RemoteConfiguration();
-        remoteConfig.setApplicationExitConfiguration(new ApplicationExitConfiguration());
-    }
+        remoteConfig.setApplicationExitConfiguration(new ApplicationExitConfiguration(false));
 
-    @Test
-    public void getLogReportingConfiguration() {
-        Assert.assertNotNull(remoteConfig.getApplicationExitConfiguration());
-        Assert.assertFalse(remoteConfig.getApplicationExitConfiguration().isEnabled());
+        FeatureFlag.enableFeature(FeatureFlag.ApplicationExitReporting);
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/RemoteConfigurationTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/RemoteConfigurationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android;
+
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.ConsoleAgentLog;
+import com.newrelic.agent.android.logging.LogLevel;
+import com.newrelic.agent.android.logging.LogReportingConfiguration;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RemoteConfigurationTest {
+
+    private RemoteConfiguration remoteConfig;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AgentLogManager.setAgentLog(new ConsoleAgentLog());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        remoteConfig = new RemoteConfiguration();
+        remoteConfig.setApplicationExitConfiguration(new ApplicationExitConfiguration());
+    }
+
+    @Test
+    public void getLogReportingConfiguration() {
+        Assert.assertNotNull(remoteConfig.getApplicationExitConfiguration());
+        Assert.assertFalse(remoteConfig.getApplicationExitConfiguration().isEnabled());
+    }
+
+    @Test
+    public void setApplicationExitConfiguration() {
+        Assert.assertNotNull(remoteConfig.getApplicationExitConfiguration());
+        Assert.assertFalse(remoteConfig.getApplicationExitConfiguration().isEnabled());
+
+        remoteConfig.setApplicationExitConfiguration(new ApplicationExitConfiguration(true));
+        Assert.assertNotNull(remoteConfig.getApplicationExitConfiguration());
+        Assert.assertTrue(remoteConfig.getApplicationExitConfiguration().isEnabled());
+    }
+
+    @Test
+    public void testEquals() {
+        RemoteConfiguration lhs = new RemoteConfiguration();
+        RemoteConfiguration rhs = new RemoteConfiguration();
+
+        Assert.assertFalse(lhs == rhs);
+        Assert.assertTrue(lhs.equals(rhs));
+        Assert.assertEquals(lhs, rhs);
+    }
+
+    @Test
+    public void onHarvestConfigurationChanged() {
+        remoteConfig.onHarvestConfigurationChanged();
+    }
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestConfigurationTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestConfigurationTests.java
@@ -7,8 +7,7 @@ package com.newrelic.agent.android.harvest;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.newrelic.agent.android.logging.LogLevel;
-import com.newrelic.agent.android.logging.LogReportingConfiguration;
+import com.newrelic.agent.android.RemoteConfiguration;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -18,11 +17,13 @@ import org.junit.runners.JUnit4;
 import java.util.UUID;
 
 @RunWith(JUnit4.class)
-public class HarvesterConfigurationTests {
+public class HarvestConfigurationTests {
     String entityGuid = UUID.randomUUID().toString();
 
+    Gson gson = new GsonBuilder().create();
+
     @Test
-    public void testHarvesterConfigurationSerialize() {
+    public void testHarvestConfigurationSerialize() {
         String cross_process_id = "VgMPV1ZTGwIGUFdWAQk=";
         int data_report_period = 60;
         int[] data_token = {1646468, 1997527};
@@ -57,9 +58,8 @@ public class HarvesterConfigurationTests {
         config.setApplication_id("100");
         config.setTrusted_account_key("33");
         config.setEntity_guid(entityGuid);
-        config.setLog_reporting(new LogReportingConfiguration(true, LogLevel.WARN));
+        config.setRemote_configuration(new RemoteConfiguration());
 
-        Gson gson = new Gson();
         String configJson = gson.toJson(config);
 
         String expectedJson = "{\"collect_network_errors\":true,\"cross_process_id\":\"VgMPV1ZTGwIGUFdWAQk\\u003d\"," +
@@ -69,14 +69,14 @@ public class HarvesterConfigurationTests {
                 "\"activity_trace_max_report_attempts\":1,\"activity_trace_min_utilization\":0.3,\"at_capture\":{\"maxTotalTraceCount\":1}," +
                 "\"priority_encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\",\"account_id\":\"1\",\"application_id\":\"100\",\"trusted_account_key\":\"33\"," +
                 "\"entity_guid\":\"" + entityGuid + "\"," +
-                "\"log_reporting\":{\"data_report_period\":30,\"expiration_period\":172800,\"enabled\":true,\"level\":\"WARN\"}" +
+                "\"configuration\":{\"application_exit_info\":{\"enabled\":true}}" +
                 "}";
 
         Assert.assertEquals(expectedJson, configJson);
     }
 
     @Test
-    public void testHarvesterConfigurationDeserialize() {
+    public void testHarvestConfigurationDeserialize() {
         String cross_process_id = "VgMPV1ZTGwIGUFdWAQk=";
         int data_report_period = 60;
         int[] data_token = {1646468, 1997527};
@@ -108,6 +108,7 @@ public class HarvesterConfigurationTests {
         expectedConfig.setApplication_id(application_id);
         expectedConfig.setTrusted_account_key(trusted_account_key);
         expectedConfig.setEntity_guid(entityGuid);
+        expectedConfig.setRemote_configuration(new RemoteConfiguration());
 
         String expectedJson = "{\"collect_network_errors\":true,\"cross_process_id\":\"VgMPV1ZTGwIGUFdWAQk\\u003d\"," +
                 "\"data_report_period\":60,\"data_token\":[1646468,1997527],\"error_limit\":50," +
@@ -115,18 +116,17 @@ public class HarvesterConfigurationTests {
                 "\"server_timestamp\":1365724800,\"stack_trace_limit\":100," +
                 "\"priority_encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\",\"account_id\":\"1\"," +
                 "\"application_id\":\"100\",\"trusted_account_key\":\"33\"," +
-                "\"entity_guid\":\""+entityGuid+"\"," +
-                "\"log_reporting\":{\"data_report_period\":30,\"expiration_period\":172800,\"enabled\":false,\"level\":\"INFO\"}" +
+                "\"entity_guid\":\"" + entityGuid + "\"," +
+                "\"configuration\":{\"application_exit_info\":{\"enabled\":true}}" +
                 "}";
 
-        Gson gson = new Gson();
         HarvestConfiguration config = gson.fromJson(expectedJson, HarvestConfiguration.class);
 
         Assert.assertEquals(expectedConfig, config);
     }
 
     @Test
-    public void testHarvesterConfigurationDeserializeWithExtraFields() {
+    public void testHarvestConfigurationDeserializeWithExtraFields() {
         String cross_process_id = "VgMPV1ZTGwIGUFdWAQk=";
         int data_report_period = 60;
         int[] data_token = {1646468, 1997527};
@@ -165,28 +165,25 @@ public class HarvesterConfigurationTests {
                 "\"server_timestamp\":1365724800,\"stack_trace_limit\":100," +
                 "\"priority_encoding_key\":\"d67afc830dab717fd163bfcb0b8b88423e9a1a3b\",\"account_id\":\"1\"," +
                 "\"application_id\":\"100\",\"trusted_account_key\":\"33\"," +
-                "\"entity_guid\":\""+entityGuid+"\"" +
+                "\"entity_guid\":\"" + entityGuid + "\"" +
                 "}";
 
-        Gson gson = new Gson();
         HarvestConfiguration config = gson.fromJson(serializedJson, HarvestConfiguration.class);
 
         Assert.assertEquals(expectedConfig, config);
     }
 
     @Test
-    public void testHarvesterConfigurationLogReporting() {
+    public void testHarvestConfigurationRemoteConfig() {
         HarvestConfiguration config = new HarvestConfiguration();
-        LogReportingConfiguration loggingConfig = new LogReportingConfiguration(true, LogLevel.VERBOSE);
-        config.setLog_reporting(loggingConfig);
+        RemoteConfiguration remoteConfiguration = new RemoteConfiguration();
+        config.setRemote_configuration(remoteConfiguration);
 
-        Gson gson = new GsonBuilder().create();
-
-        String configJson = gson.toJson(config.getLog_reporting());
+        String configJson = gson.toJson(config.getRemote_configuration());
         Assert.assertTrue(configJson.matches("^\\{.*\\}$"));
 
-        String expectedJson = "{\"data_report_period\":30,\"expiration_period\":172800,\"enabled\":true,\"level\":\"VERBOSE\"}";
-        Assert.assertTrue(expectedJson.equals(configJson));
+        String expectedJson = "{\"application_exit_info\":{\"enabled\":false}}";
+        Assert.assertFalse(expectedJson.equals(configJson));
     }
 
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestableCacheTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestableCacheTest.java
@@ -54,8 +54,8 @@ public class HarvestableCacheTest {
             Assert.assertEquals(0, Harvest.getActivityTraceCacheSize());
             Harvest.addActivityTrace(new TestActivityTrace());
             Assert.assertEquals(1, Harvest.getActivityTraceCacheSize());
-            Harvest.initialize(new AgentConfiguration());
             Harvest.setHarvestConfiguration(new HarvestConfiguration());
+            Harvest.initialize(new AgentConfiguration());
             Harvest.start();
             Assert.assertEquals(0, Harvest.getActivityTraceCacheSize());
         } finally {

--- a/agent-core/src/test/resources/Connect-Spec-PORTED.json
+++ b/agent-core/src/test/resources/Connect-Spec-PORTED.json
@@ -1,5 +1,8 @@
 {
-  "data_token": [1646468, 2018235],
+  "data_token": [
+    1646468,
+    2018235
+  ],
   "collect_network_errors": true,
   "cross_process_id": "VgMPV1ZTGwIGUFdWAQk=",
   "server_timestamp": 1365724800,
@@ -16,12 +19,22 @@
   "encoding_key": "d67afc830dab717fd163bfcb0b8b88423e9a1a3b",
   "account_id": "1",
   "application_id": "601359369",
-  "trusted_account_key":"1",
+  "trusted_account_key": "1",
   "entity_guid": "a4d39d21-588b-4342-ad87-967243533949",
-  "log_reporting": {
-    "enabled": true,
-    "level": "VERBOSE",
-    "data_report_period": 30,
-    "expiration_period": 3600
+  "request_headers_map": {
+    "NR-Session": "AFBE4546FEADDEAD1243",
+    "NR-AgentConfiguration": "12BAED78FC89BAFE1243"
+  },
+  "configuration": {
+    "logs": {
+      "enabled": true,
+      "level": "verbose",
+      "sample_rate": 0.11,
+      "data_report_period": 15,
+      "expiration_period": 7200
+    },
+    "application_exit_info": {
+      "enabled": true
+    }
   }
 }

--- a/agent-core/src/test/resources/Connect-Spec-PORTED.json
+++ b/agent-core/src/test/resources/Connect-Spec-PORTED.json
@@ -1,8 +1,5 @@
 {
-  "data_token": [
-    1646468,
-    2018235
-  ],
+  "data_token": [1646468, 2018235],
   "collect_network_errors": true,
   "cross_process_id": "VgMPV1ZTGwIGUFdWAQk=",
   "server_timestamp": 1365724800,
@@ -19,7 +16,7 @@
   "encoding_key": "d67afc830dab717fd163bfcb0b8b88423e9a1a3b",
   "account_id": "1",
   "application_id": "601359369",
-  "trusted_account_key": "1",
+  "trusted_account_key":"1",
   "entity_guid": "a4d39d21-588b-4342-ad87-967243533949",
   "request_headers_map": {
     "NR-Session": "AFBE4546FEADDEAD1243",

--- a/agent-core/src/test/resources/Connect-Spec-v1.json
+++ b/agent-core/src/test/resources/Connect-Spec-v1.json
@@ -1,0 +1,22 @@
+{
+  "data_token": [
+    1646468,
+    2018235
+  ],
+  "account_id": 1,
+  "trusted_account_key": "1",
+  "entity_guid": "MXxNT0JJTEV8QVBQTElDQVRJT058OTg0OTU",
+  "request_headers_map": {
+    "NR-Session": "AFBE4546FEADDEAD1243",
+    "NR-AgentConfiguration": "12BAED78FC89BAFE1243"
+  },
+  "configuration": {
+    "logs": {
+      "enabled": true,
+      "level": "verbose"
+    },
+    "application_exit_info": {
+      "enabled": true
+    }
+  }
+}

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -195,11 +195,6 @@ public class AndroidAgentImpl implements
             }
         }
 
-        // Feature enabled and RT >= SDK 30?
-        if (FeatureFlag.featureEnabled(FeatureFlag.ApplicationExitReporting)) {
-            // must be called after application information was gathered and AnalyticsController has been initialized
-            new ApplicationExitMonitor(context).harvestApplicationExitInfo();
-        }
     }
 
     protected void setupSession() {
@@ -475,6 +470,15 @@ public class AndroidAgentImpl implements
                 // assume a user action caused the agent to start or return to foreground
                 UserActionFacade.getInstance().recordUserAction(UserActionType.AppLaunch);
             }
+
+            // Feature enabled and RT >= SDK 30?
+            if (FeatureFlag.featureEnabled(FeatureFlag.ApplicationExitReporting)) {
+                // must be called after application information was gathered and AnalyticsController has been initialized
+                if (agentConfiguration.getApplicationExitConfiguration().isEnabled()) {
+                    new ApplicationExitMonitor(context).harvestApplicationExitInfo();
+                }
+            }
+
         } else {
             stop(false);
         }

--- a/agent/src/main/java/com/newrelic/agent/android/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ApplicationExitMonitor.java
@@ -38,7 +38,7 @@ public class ApplicationExitMonitor {
     protected ActivityManager am;
 
     public ApplicationExitMonitor(final Context context) {
-        this.reportsDir = new File(context.getCacheDir(), "newrelic/appexitinfo");
+        this.reportsDir = new File(context.getCacheDir(), "newrelic/applicationExitInfo");
         this.am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         this.packageName = context.getPackageName();
 

--- a/agent/src/main/java/com/newrelic/agent/android/SavedState.java
+++ b/agent/src/main/java/com/newrelic/agent/android/SavedState.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.newrelic.agent.android.harvest.ApplicationInformation;
 import com.newrelic.agent.android.harvest.ConnectInformation;
@@ -20,7 +21,6 @@ import com.newrelic.agent.android.harvest.HarvestAdapter;
 import com.newrelic.agent.android.harvest.HarvestConfiguration;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
-import com.newrelic.agent.android.logging.LogReportingConfiguration;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.stats.StatsEngine;
 
@@ -36,6 +36,7 @@ public class SavedState extends HarvestAdapter {
     private static final AgentLog log = AgentLogManager.getAgentLog();
 
     private final String PREFERENCE_FILE_PREFIX = "com.newrelic.android.agent.v1_";
+    private final Gson gson = new GsonBuilder().create();
 
     // Harvest configuration
     private final String PREF_MAX_TRANSACTION_COUNT = "maxTransactionCount";
@@ -56,7 +57,7 @@ public class SavedState extends HarvestAdapter {
     private final String PREF_ERROR_LIMIT = "errorLimit";
     private final String NEW_RELIC_AGENT_DISABLED_VERSION_KEY = "NewRelicAgentDisabledVersion";
     private final String PREF_ACTIVITY_TRACE_MIN_UTILIZATION = "activityTraceMinUtilization";
-    private final String PREF_LOG_REPORTING = "logReporting";
+    private final String PREF_REMOTE_CONFIGURATION = "remoteConfiguration";
 
     // Connect information
     private final String PREF_APP_NAME = "appName";
@@ -138,11 +139,11 @@ public class SavedState extends HarvestAdapter {
         save(PREF_ACCOUNT_ID, newConfiguration.getAccount_id());
         save(PREF_APPLICATION_ID, newConfiguration.getApplication_id());
         save(PREF_TRUSTED_ACCOUNT_KEY, newConfiguration.getTrusted_account_key());
-        save(PREF_LOG_REPORTING, newConfiguration.getLog_reporting().toString());
+        save(PREF_REMOTE_CONFIGURATION, gson.toJson(newConfiguration.getRemote_configuration()));
 
         saveActivityTraceMinUtilization((float) newConfiguration.getActivity_trace_min_utilization());
 
-        // Reload the configuration
+        // Reload the configuration(s)
         loadHarvestConfiguration();
     }
 
@@ -198,14 +199,15 @@ public class SavedState extends HarvestAdapter {
         if (has(PREF_TRUSTED_ACCOUNT_KEY)) {
             configuration.setTrusted_account_key(getTrustedAccountKey());
         }
-        if (has(PREF_LOG_REPORTING)) {
-            String logReportingConfig = getString(PREF_LOG_REPORTING);
+
+        if (has(PREF_REMOTE_CONFIGURATION)) {
+            String remoteConfigAsJson = getString(PREF_REMOTE_CONFIGURATION);
             try {
-                LogReportingConfiguration logReportingConfiguration = new Gson().fromJson(logReportingConfig, LogReportingConfiguration.class);
-                configuration.setLog_reporting(logReportingConfiguration);
+                RemoteConfiguration remoteConfiguration = gson.fromJson(remoteConfigAsJson, RemoteConfiguration.class);
+                configuration.setRemote_configuration(remoteConfiguration);
             } catch (JsonSyntaxException e) {
                 log.error("Failed to deserialize log reporting configuration: " + e);
-                configuration.setLog_reporting(new LogReportingConfiguration());
+                configuration.setRemote_configuration(new RemoteConfiguration());
             }
         }
 

--- a/agent/src/test/java/com/newrelic/agent/android/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/ApplicationExitMonitorTest.java
@@ -269,6 +269,16 @@ public class ApplicationExitMonitorTest {
         }
     }
 
+    @Test
+    public void testEnabledStateFromAgentConfiguration() {
+        FeatureFlag.enableFeature(FeatureFlag.ApplicationExitReporting);
+
+        AgentConfiguration agentConfiguration = AgentConfiguration.instance.get();
+        Assert.assertFalse(agentConfiguration.getApplicationExitConfiguration().isEnabled());
+
+        agentConfiguration.getApplicationExitConfiguration().enabled = true;
+        Assert.assertTrue(agentConfiguration.getApplicationExitConfiguration().isEnabled());
+    }
 
     private ApplicationExitInfo provideApplicationExitInfo(int reasonCode) throws IOException {
         return provideApplicationExitInfo(reasonCode, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND);


### PR DESCRIPTION
Based on agent spec, extract the new "configuration" element from the connect request response body (Json) and propagate to runtime agent configuration. 

By default, AEI config will be **enabled** locally but still gated by feature flag so it can be used prior to config UI/ingest  integration.