### PR TITLE
[NR-251338] Add supportability metrics for important AEI operations

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/ApplicationExitConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/ApplicationExitConfiguration.java
@@ -6,14 +6,12 @@
 package com.newrelic.agent.android;
 
 import com.google.gson.annotations.SerializedName;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
 
 public class ApplicationExitConfiguration {
     @SerializedName("enabled")
     boolean enabled;
-
-    public ApplicationExitConfiguration() {
-        this.enabled = true;
-    }
 
     public ApplicationExitConfiguration(boolean enabled) {
         this.enabled = enabled;
@@ -24,7 +22,19 @@ public class ApplicationExitConfiguration {
     }
 
     public void setConfiguration(ApplicationExitConfiguration applicationExitConfiguration) {
-        this.enabled = applicationExitConfiguration.enabled;
+        if (!applicationExitConfiguration.equals(this)) {
+            if (!enabled) {
+                if (applicationExitConfiguration.enabled) {
+                    StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_REMOTE_CONFIG + "enabled");
+                }
+            } else {
+                if (!applicationExitConfiguration.enabled) {
+                    StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_REMOTE_CONFIG + "disabled");
+                }
+            }
+        }
+
+        enabled = applicationExitConfiguration.enabled;
     }
 
     @Override

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -85,6 +85,12 @@ public class MetricNames {
     public static final String SUPPORTABILITY_LOG_UNCOMPRESSED = SUPPORTABILITY_LOG_REPORTING + "Size/Uncompressed";
     public static final String SUPPORTABILITY_LOG_EXPIRED = SUPPORTABILITY_LOG_REPORTING + "Expired";
 
+    public static final String SUPPORTABILITY_AEI = SUPPORTABILITY_AGENT + "ApplicationExitInfo/";
+    public static final String SUPPORTABILITY_AEI_UNSUPPORTED_OS = SUPPORTABILITY_AEI + "unsupportedOS/";
+    public static final String SUPPORTABILITY_AEI_EXIT_STATUS = SUPPORTABILITY_AEI + "status/";
+    public static final String SUPPORTABILITY_AEI_EXIT_BY_REASON = SUPPORTABILITY_AEI + "reason/";
+    public static final String SUPPORTABILITY_AEI_EXIT_BY_IMPORTANCE = SUPPORTABILITY_AEI + "importance/";
+    public static final String SUPPORTABILITY_AEI_REMOTE_CONFIG = SUPPORTABILITY_AEI + "remoteConfiguration/";
 
     public static final String SUPPORTABILITY_DATA_TOKEN = SUPPORTABILITY_AGENT + "DataToken/";
     public static final String SUPPORTABILITY_INVALID_DATA_TOKEN = SUPPORTABILITY_DATA_TOKEN + "Invalid";

--- a/agent-core/src/test/java/com/newrelic/agent/android/ApplicationExitConfigurationTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/ApplicationExitConfigurationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ApplicationExitConfigurationTest {
+
+    private ApplicationExitConfiguration applicationExitConfiguration;
+    private Gson gson = new GsonBuilder().create();
+
+    @Before
+    public void setUp() throws Exception {
+        applicationExitConfiguration = new ApplicationExitConfiguration(false);
+        FeatureFlag.disableFeature(FeatureFlag.ApplicationExitReporting);
+    }
+
+    @Test
+    public void isEnabled() {
+        Assert.assertFalse(applicationExitConfiguration.isEnabled());
+
+        applicationExitConfiguration.enabled = true;
+        Assert.assertFalse("Requires feature flag", applicationExitConfiguration.isEnabled());
+
+        FeatureFlag.enableFeature(FeatureFlag.ApplicationExitReporting);
+        Assert.assertTrue(applicationExitConfiguration.isEnabled());
+    }
+
+    @Test
+    public void setConfiguration() {
+        applicationExitConfiguration = new ApplicationExitConfiguration(true);
+
+        Assert.assertFalse(applicationExitConfiguration.isEnabled());
+        FeatureFlag.enableFeature(FeatureFlag.ApplicationExitReporting);
+        Assert.assertTrue(applicationExitConfiguration.isEnabled());
+
+        ApplicationExitConfiguration aeiConfig = new ApplicationExitConfiguration(false);
+
+        applicationExitConfiguration.setConfiguration(aeiConfig);
+        Assert.assertFalse(applicationExitConfiguration.isEnabled());
+        Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap().keySet().contains(MetricNames.SUPPORTABILITY_AEI_REMOTE_CONFIG + "disabled"));
+
+        aeiConfig = new ApplicationExitConfiguration(true);
+        applicationExitConfiguration.setConfiguration(aeiConfig);
+        Assert.assertTrue(applicationExitConfiguration.isEnabled());
+        Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap().keySet().contains(MetricNames.SUPPORTABILITY_AEI_REMOTE_CONFIG + "enabled"));
+    }
+
+    @Test
+    public void testEquals() {
+        ApplicationExitConfiguration lhs = new ApplicationExitConfiguration(true);
+        ApplicationExitConfiguration rhs = new ApplicationExitConfiguration(true);
+
+        Assert.assertFalse(lhs == rhs);
+        Assert.assertTrue(lhs.equals(rhs));
+        Assert.assertEquals(lhs, rhs);
+
+        rhs = new ApplicationExitConfiguration(false);
+        Assert.assertFalse(lhs.equals(rhs));
+        Assert.assertNotEquals(lhs, rhs);
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals("{\"enabled\"=false}", applicationExitConfiguration.toString());
+
+        applicationExitConfiguration.enabled = true;
+        Assert.assertEquals("{\"enabled\"=true}", applicationExitConfiguration.toString());
+    }
+
+    @Test
+    public void testToJson() {
+        Assert.assertEquals("{\"enabled\":false}", gson.toJson(applicationExitConfiguration));
+
+        applicationExitConfiguration.enabled = true;
+        Assert.assertEquals("{\"enabled\":true}", gson.toJson(applicationExitConfiguration));
+    }
+}

--- a/agent/src/main/java/com/newrelic/agent/android/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ApplicationExitMonitor.java
@@ -19,6 +19,8 @@ import com.newrelic.agent.android.analytics.AnalyticsEventCategory;
 import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.util.Streams;
 
 import java.io.File;
@@ -47,7 +49,7 @@ public class ApplicationExitMonitor {
 
     /**
      * Gather application exist status reports for this process
-     * <p>
+     *
      * Application process could die for many reasons, for example REASON_LOW_MEMORY when it
      * was killed by the system because it was running low on memory. Reason of the death can be
      * retrieved via getReason(). Besides the reason, there are a few other auxiliary APIs like
@@ -132,13 +134,17 @@ public class ApplicationExitMonitor {
                                 AnalyticsEventCategory.ApplicationExit,
                                 EVENT_TYPE_MOBILE_APPLICATION_EXIT,
                                 eventAttributes);
+
+                        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_EXIT_STATUS + exitInfo.getStatus());
+                        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_EXIT_BY_REASON + exitInfo.getReason());
+                        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_EXIT_BY_IMPORTANCE + exitInfo.getImportance());
                     }
                 }
             });
         } else {
-            log.warn("ApplicationExitMonitor: exit info will not be reported (unsupported OS level)");
+            log.warn("ApplicationExitMonitor: exit info reproting was enabled, but not supported by the current OS");
+            StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_UNSUPPORTED_OS + Build.VERSION.SDK_INT);
         }
-
     }
 
     protected String toValidAttributeValue(String attributeValue) {

--- a/agent/src/test/java/com/newrelic/agent/android/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/ApplicationExitMonitorTest.java
@@ -24,6 +24,8 @@ import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.logging.ConsoleAgentLog;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.test.stub.StubAnalyticsAttributeStore;
 import com.newrelic.agent.android.util.Streams;
 
@@ -89,6 +91,7 @@ public class ApplicationExitMonitorTest {
         Streams.list(applicationExitMonitor.reportsDir).forEach(file -> {
             Assert.assertTrue(file.delete());
         });
+        FeatureFlag.disableFeature(FeatureFlag.ApplicationExitReporting);
     }
 
     @Test
@@ -169,15 +172,15 @@ public class ApplicationExitMonitorTest {
         Assert.assertEquals("Should not create AppExit events for Android 10 and below", 0, pendingEvents.size());
 
         Mockito.verify(logger, times(1)).warn(anyString());
+
+        Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_AEI_UNSUPPORTED_OS + Build.VERSION.SDK_INT));
     }
 
     @Test
     public void userShouldNotCreateCustomAppExitEvents() throws IOException {
         final ApplicationExitInfo exitInfo = provideApplicationExitInfo(ApplicationExitInfo.REASON_ANR);
         final HashMap<String, Object> eventAttributes = new HashMap<>();
-        final String traceReport = Streams.slurpString(exitInfo.getTraceInputStream());
 
-        // should these be reserved attribute names for this event?
         eventAttributes.put(AnalyticsAttribute.APP_EXIT_TIMESTAMP_ATTRIBUTE, exitInfo.getTimestamp());
         eventAttributes.put(AnalyticsAttribute.APP_EXIT_REASON_ATTRIBUTE, exitInfo.getReason());
         eventAttributes.put(AnalyticsAttribute.APP_EXIT_IMPORTANCE_ATTRIBUTE, exitInfo.getImportance());
@@ -276,6 +279,23 @@ public class ApplicationExitMonitorTest {
         agentConfiguration.getApplicationExitConfiguration().enabled = true;
         Assert.assertTrue(agentConfiguration.getApplicationExitConfiguration().isEnabled());
     }
+
+    @Test
+    public void testSupportabilityMetrics() throws InterruptedException {
+        FeatureFlag.enableFeature(FeatureFlag.ApplicationExitReporting);
+
+        applicationExitMonitor.harvestApplicationExitInfo();
+        ApplicationStateMonitor.getInstance().getExecutor().shutdown();
+        ApplicationStateMonitor.getInstance().getExecutor().awaitTermination(3, TimeUnit.SECONDS);
+
+        Assert.assertNotNull(StatsEngine.SUPPORTABILITY.getStatsMap());
+        for (ApplicationExitInfo aei : applicationExitInfos) {
+            Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_AEI_EXIT_STATUS + aei.getStatus()));
+            Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_AEI_EXIT_BY_REASON + aei.getReason()));
+            Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_AEI_EXIT_BY_IMPORTANCE + aei.getImportance()));
+        }
+    }
+
 
     private ApplicationExitInfo provideApplicationExitInfo(int reasonCode) throws IOException {
         return provideApplicationExitInfo(reasonCode, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND);


### PR DESCRIPTION
Adds the standard feature flag API metrics:
* Supportability/Mobile/Android/<framework>/<frameworkVersion>/API/enableFeature/ApplicationExitReporting
* Supportability/Mobile/Android/<framework>/<frameworkVersion>/API/disableFeature/ApplicationExitReporting

And those specific to AEI data:
* Supportability/AgentHealth/ApplicationExitInfo/unsupportedOS/{sdkVersion}
* Supportability/AgentHealth/ApplicationExitInfo/status/{status code}
* Supportability/AgentHealth/ApplicationExitInfo/reason/{reason code}
* Supportability/AgentHealth/ApplicationExitInfo/importance/{importance code}

And those specific to AEI configuration:
* Supportability/AgentHealth/ApplicationExitInfo/remoteConfiguration/{enabled|disabled}
