### PR TITLE
[NR-265384] Implement ingest sampling configuration

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -70,7 +70,7 @@ public class AgentConfiguration implements HarvestConfigurable {
     private String deviceID;
     private String entityGuid;
 
-    // Support remote configuration
+    // Support remote configuration for these features
     private LogReportingConfiguration logReportingConfiguration = new LogReportingConfiguration(true, LogLevel.INFO);
     private ApplicationExitConfiguration applicationExitConfiguration = new ApplicationExitConfiguration(true);
 
@@ -367,10 +367,6 @@ public class AgentConfiguration implements HarvestConfigurable {
 
     public LogReportingConfiguration getLogReportingConfiguration() {
         return logReportingConfiguration;
-    }
-
-    public void setLogReportingConfiguration(LogReportingConfiguration logReportingConfiguration) {
-        this.logReportingConfiguration = logReportingConfiguration;
     }
 
     public ApplicationExitConfiguration getApplicationExitConfiguration() {

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReportingConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReportingConfiguration.java
@@ -10,31 +10,44 @@ import com.google.gson.annotations.SerializedName;
 import java.util.concurrent.TimeUnit;
 
 public class LogReportingConfiguration extends LoggingConfiguration {
+    /**
+     * The sample seed is the coin flip that determines whether logging is enabled during
+     * this app lifetime. It should only be set once. Range is [1...100];
+     */
+    static int sampleSeed = 100;
 
     static final long DEFAULT_HARVEST_PERIOD = TimeUnit.SECONDS.convert(30, TimeUnit.SECONDS);
     static final long DEFAULT_EXPIRATION_PERIOD = TimeUnit.SECONDS.convert(2, TimeUnit.DAYS);
 
     @SerializedName("data_report_period")
-    final Long harvestPeriod;
+    Long harvestPeriod;
 
     @SerializedName("expiration_period")
-    final Long expirationPeriod;
+    Long expirationPeriod;
+
+    @SerializedName("sampling_rate")
+    int sampleRate;
 
     public LogReportingConfiguration() {
         this(false, LogLevel.NONE);
     }
 
     public LogReportingConfiguration(boolean enabled, LogLevel level) {
-        super(enabled, level);
-        this.harvestPeriod = DEFAULT_HARVEST_PERIOD;
-        this.expirationPeriod = DEFAULT_EXPIRATION_PERIOD;
+        this(enabled, level, DEFAULT_HARVEST_PERIOD, DEFAULT_EXPIRATION_PERIOD, sampleSeed);
     }
 
-    public LogReportingConfiguration(boolean enabled, LogLevel level, long harvestPeriod, long expirationPeriod) {
-        this.enabled = enabled;
-        this.level = level;
+    public LogReportingConfiguration(boolean enabled, LogLevel level, long harvestPeriod, long expirationPeriod, int sampleRate) {
+        super(enabled, level);
         this.harvestPeriod = harvestPeriod;
         this.expirationPeriod = expirationPeriod;
+        this.sampleRate = Math.min(100, Math.max(0, sampleRate));
+    }
+
+    public void setConfiguration(LogReportingConfiguration logReportingConfiguration) {
+        super.setConfiguration(logReportingConfiguration);
+        enabled = logReportingConfiguration.enabled;
+        level = logReportingConfiguration.level;
+        sampleRate = logReportingConfiguration.sampleRate;
     }
 
     public long getHarvestPeriod() {
@@ -52,6 +65,7 @@ public class LogReportingConfiguration extends LoggingConfiguration {
                 + ",\"level\"=" + "\"" + level + "\""
                 + ",\"data_report_period\"=" + harvestPeriod
                 + ",\"expiration_period\"=" + expirationPeriod
+                + ",\"sampling_rate\"=" + sampleRate
                 + "}";
     }
 
@@ -61,10 +75,31 @@ public class LogReportingConfiguration extends LoggingConfiguration {
             LogReportingConfiguration rhs = (LogReportingConfiguration) obj;
             return enabled == rhs.enabled &&
                     level.equals(rhs.level) &&
-                    harvestPeriod.equals(rhs.harvestPeriod) &&
-                    expirationPeriod.equals(rhs.expirationPeriod);
+                    sampleRate == rhs.sampleRate;
         }
-
         return false;
+    }
+
+    /**
+     * @return true is remote logging is enabled AND this session is sampling
+     */
+    @Override
+    public boolean getLoggingEnabled() {
+        return enabled && isSampled();
+    }
+
+    /**
+     * @return true if the generated sample seed is less than or equal to the configured sampling rate
+     */
+    public boolean isSampled() {
+        return sampleSeed <= sampleRate;
+    }
+
+    /**
+     * Generate a suitable seed. Range is [1...100];
+     */
+    protected static int reseed() {
+        sampleSeed = (int) (Math.random() * 100.0) + 1;
+        return sampleSeed;
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LoggingConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LoggingConfiguration.java
@@ -9,7 +9,6 @@ import com.google.gson.annotations.SerializedName;
 import com.newrelic.agent.android.AgentConfiguration;
 
 public class LoggingConfiguration {
-    static final AgentLog log = AgentLogManager.getAgentLog();
 
     @SerializedName("enabled")
     boolean enabled = false;

--- a/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestConfigurationTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/harvest/HarvestConfigurationTest.java
@@ -10,10 +10,10 @@ import com.google.gson.GsonBuilder;
 import com.newrelic.agent.android.RemoteConfiguration;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfiguration;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfigurationDeserializer;
+import com.newrelic.agent.android.logging.LogReportingConfiguration;
 import com.newrelic.agent.android.test.mock.Providers;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -69,7 +69,10 @@ public class HarvestConfigurationTest {
         String configJson = gson.toJson(config);
         String expectedJson = "{" +
                 "\"account_id\":\"1\"," +
-                "\"configuration\":{\"application_exit_info\":{\"enabled\":true},\"logs\":{\"data_report_period\":30,\"expiration_period\":172800,\"enabled\":true,\"level\":\"INFO\"}}," +
+                "\"configuration\":{" +
+                    "\"application_exit_info\":{\"enabled\":true}," +
+                    "\"logs\":{\"data_report_period\":30,\"expiration_period\":172800,\"sampling_rate\":100,\"enabled\":true,\"level\":\"INFO\"}" +
+                "}," +
                 "\"data_token\":[1646468,1997527]," +
                 "\"entity_guid\":\"" + entityGuid + "\"," +
                 "\"request_headers_map\":{}," +
@@ -297,6 +300,6 @@ public class HarvestConfigurationTest {
         String connectResponse = Providers.provideJsonObject("/Connect-Spec-v4.json").toString();
         config = gson.fromJson(connectResponse, HarvestConfiguration.class);
         Assert.assertEquals("1646468", config.getApplication_id());
-
     }
+
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingConfigurationTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingConfigurationTest.java
@@ -7,28 +7,49 @@ package com.newrelic.agent.android.logging;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.newrelic.agent.android.activity.config.ActivityTraceConfiguration;
+import com.newrelic.agent.android.activity.config.ActivityTraceConfigurationDeserializer;
+import com.newrelic.agent.android.harvest.HarvestConfiguration;
+import com.newrelic.agent.android.test.mock.Providers;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class LogReportingConfigurationTest {
+    private static AgentLog log = new ConsoleAgentLog();
 
-    private LogReportingConfiguration logReportingConfig;
-    private String entityGuid = UUID.randomUUID().toString();
+    LogReportingConfiguration logReportingConfig;
+    HarvestConfiguration harvestConfiguration;
+
+    final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(ActivityTraceConfiguration.class, new ActivityTraceConfigurationDeserializer())
+            .create();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        log.setLevel(AgentLog.DEBUG);
+        AgentLogManager.setAgentLog(log);
+    }
 
     @Before
     public void setUp() throws Exception {
         this.logReportingConfig = new LogReportingConfiguration(true, LogLevel.DEBUG);
+        this.harvestConfiguration = gson.fromJson(
+                Providers.provideJsonObject("/Connect-Spec-v5.json").toString(),
+                HarvestConfiguration.class);
     }
 
     @Test
     public void testDefaultConfiguration() {
-        Assert.assertTrue(logReportingConfig.getLoggingEnabled());
-        Assert.assertEquals(LogLevel.DEBUG, logReportingConfig.getLogLevel());
+        this.logReportingConfig = new LogReportingConfiguration();
+        Assert.assertFalse(logReportingConfig.getLoggingEnabled());
+        Assert.assertEquals(LogLevel.NONE, logReportingConfig.getLogLevel());
+        Assert.assertTrue(logReportingConfig.isSampled());
     }
 
     @Test
@@ -54,17 +75,108 @@ public class LogReportingConfigurationTest {
                 "  \"enabled\": true," +
                 "  \"level\": VERBOSE," +
                 "  \"data_report_period\": 15," +
-                "  \"expiration_period\": 3600" +
+                "  \"expiration_period\": 3600," +
+                "  \"sampling_rate\": 69" +
                 "}";
 
         Gson gson = new GsonBuilder().create();
 
-        LogReportingConfiguration serialized = new LogReportingConfiguration(true, LogLevel.VERBOSE, 15, 3600);
+        LogReportingConfiguration serialized = new LogReportingConfiguration(true, LogLevel.VERBOSE, 15, 3600, 69);
         LogReportingConfiguration deserialized = gson.fromJson(loggingConfig, LogReportingConfiguration.class);
         Assert.assertTrue(serialized.toString().equals(deserialized.toString()));
 
         String inflated = gson.toJson(deserialized, LogReportingConfiguration.class);
         String deflated = gson.toJson(serialized, LogReportingConfiguration.class);
         Assert.assertTrue(inflated.equals(deflated));
+    }
+
+    @Test
+    public void testSampleRate() {
+        LogReportingConfiguration config = new LogReportingConfiguration(true, LogLevel.VERBOSE, 15, 3600, 33);
+
+        LogReportingConfiguration.sampleSeed = 10;
+        Assert.assertTrue(config.getLoggingEnabled());
+
+        LogReportingConfiguration.sampleSeed = 100;
+        Assert.assertFalse(config.getLoggingEnabled());
+
+        config.enabled = false;
+        Assert.assertFalse(config.getLoggingEnabled());
+    }
+
+    @Test
+    public void testSampleRateValues() {
+        Assert.assertTrue(LogReportingConfiguration.sampleSeed >= 0 && LogReportingConfiguration.sampleSeed <= 100);
+
+        Assert.assertEquals(0, new LogReportingConfiguration(true, LogLevel.VERBOSE, 15, 3600, -330).sampleRate);
+        Assert.assertEquals(100, new LogReportingConfiguration(true, LogLevel.VERBOSE, 15, 3600, 330).sampleRate);
+    }
+
+    /**
+     * Not really a test, but a check on assumptions re: sample randomness.
+     */
+    @Ignore("For analysis")
+    @Test
+    public void testRandomDistribution() {
+        final int SESSIONS = 1000;
+        final int CONFIG_UPDATES = 100;
+        LogReportingConfiguration loggingConfiguration;
+
+        log.debug("Assumed sample rate[" + harvestConfiguration.getRemote_configuration().getLogReportingConfiguration().sampleRate + "]");
+
+        for (int configUpdate = 0; configUpdate < CONFIG_UPDATES; configUpdate++) {
+            int heads = 0;
+            int tails = 0;
+            int variance = 0;
+
+            loggingConfiguration =
+                    new LogReportingConfiguration(true, LogLevel.DEBUG, 10, 10, (int) (Math.random() * 100.) + 1);
+
+            for (int session = 0; session < SESSIONS; session++) {
+                LogReportingConfiguration.reseed();
+                if (loggingConfiguration.isSampled()) {
+                    heads++;
+                } else {
+                    tails++;
+                }
+                variance += (loggingConfiguration.isSampled() ? 1 : -1);
+            }
+
+            log.debug("Sample rate distribution [" + loggingConfiguration.sampleRate + "%] " +
+                    "effective[" + (heads * 100 / SESSIONS) + "%] " +
+                    "enabled[" + heads + "] " +
+                    "disabled[" + tails + "] " +
+                    "variance[" + variance + "]");
+
+            // Assert.assertFalse(loggingConfiguration.sampleRate < (heads * 100 / SESSIONS));
+        }
+    }
+
+    @Ignore("For analysis")
+    @Test
+    public void testReseed() {
+        int sampleRate = LogReportingConfiguration.sampleSeed;
+        int newRate = LogReportingConfiguration.reseed();
+        Assert.assertNotEquals(newRate, sampleRate);
+
+        int timesUntilDuplicate = 1;
+        while (newRate != LogReportingConfiguration.reseed()) {
+            timesUntilDuplicate++;
+            if (timesUntilDuplicate == Integer.MAX_VALUE) {
+                break;
+            }
+        }
+        log.debug("Reseed took [" + timesUntilDuplicate + "] calls to generate a duplicate seed.");
+    }
+
+    @Test
+    public void testEquals() {
+        LogReportingConfiguration remoteConfig = harvestConfiguration.getRemote_configuration().getLogReportingConfiguration();
+        LogReportingConfiguration localConfiguration = new LogReportingConfiguration(true, LogLevel.DEBUG);
+
+        Assert.assertEquals(remoteConfig, remoteConfig);
+        Assert.assertEquals(localConfiguration, localConfiguration);
+        Assert.assertNotEquals(remoteConfig, localConfiguration);
+
     }
 }

--- a/agent-core/src/test/resources/Connect-Spec-v5.json
+++ b/agent-core/src/test/resources/Connect-Spec-v5.json
@@ -12,7 +12,7 @@
     "logs": {
       "enabled": false,
       "level": "WARN",
-      "sampling_rate": 10.0
+      "sampling_rate": 33.0
     },
     "application_exit_info": {
       "enabled": true


### PR DESCRIPTION
Remote logging sampling is assumed to affect the sessioni, so create a random seed at start-up that determines whether this session is sampled. Sampling is enabled when the random seed is less than or equal the configured threshold.

Adds tests.