### PR TITLE
[NR-177314] Verify config updates on data harvest

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -375,15 +375,22 @@ public class AgentConfiguration implements HarvestConfigurable {
 
     /**
      * Update agent config with any changes returned in the harvest response.
-     * Currently, it is only the AEI config
      *
      * @param harvestConfiguration
      */
     @Override
     public void updateConfiguration(HarvestConfiguration harvestConfiguration) {
         // update the global agent config w/changes
-        this.applicationExitConfiguration.setConfiguration(harvestConfiguration.getRemote_configuration().applicationExitConfiguration);
-        this.logReportingConfiguration.setConfiguration(harvestConfiguration.getRemote_configuration().logReportingConfiguration);
+        applicationExitConfiguration.setConfiguration(harvestConfiguration.getRemote_configuration().applicationExitConfiguration);
+        logReportingConfiguration.setConfiguration(harvestConfiguration.getRemote_configuration().logReportingConfiguration);
+        entityGuid = harvestConfiguration.getEntity_guid();
+
+        if (instance.get() != null) {
+            AgentConfiguration agentConfiguration = instance.get();
+            if (agentConfiguration != null && agentConfiguration != this) {
+               agentConfiguration.updateConfiguration(harvestConfiguration);
+            }
+        }
     }
 
     // return the default instance

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestConfiguration.java
@@ -8,6 +8,7 @@ package com.newrelic.agent.android.harvest;
 import com.google.gson.annotations.SerializedName;
 import com.newrelic.agent.android.RemoteConfiguration;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfiguration;
+import com.newrelic.agent.android.logging.AgentLogManager;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -326,8 +327,12 @@ public class HarvestConfiguration implements HarvestConfigurable {
         this.trusted_account_key = trusted_account_key;
     }
 
-    public void setEntity_guid(String value) {
-        this.entity_guid = value;
+    public void setEntity_guid(String entityGuid) {
+        if (entityGuid == null || entityGuid.isEmpty()) {
+            AgentLogManager.getAgentLog().error("setEntity_guid: invalid entity guid value!");
+        } else {
+            this.entity_guid = entityGuid;
+        }
     }
 
     public void setRemote_configuration(final RemoteConfiguration remoteConfiguration) {

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
@@ -14,6 +14,7 @@ import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.TaskQueue;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfiguration;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfigurationDeserializer;
+import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.logging.AgentLog;
@@ -26,6 +27,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -72,7 +74,7 @@ public class Harvester implements HarvestConfigurable {
             @Override
             public void onHarvestConfigurationChanged() {
                 StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_CONFIGURATION_CHANGED);
-                AnalyticsControllerImpl.getInstance().recordBreadcrumb("Remote configuration changed", null);
+                AnalyticsControllerImpl.getInstance().recordBreadcrumb("Remote configuration changed", new HashMap<>());
         }
         });
     }};

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -131,6 +131,7 @@ public class LogReporter extends PayloadReporter {
     protected void start() {
         if (isEnabled()) {
             Harvest.addHarvestListener(instance.get());
+            LogReportingConfiguration.reseed();
             isStarted.set(true);
         } else {
             log.error("Attempted to start the log reported when disabled.");
@@ -566,7 +567,11 @@ public class LogReporter extends PayloadReporter {
             workingLogFile = getWorkingLogfile();
             resetWorkingLogFile();
 
-            closedLogFile.setReadOnly();
+            if (AgentConfiguration.getInstance().getLogReportingConfiguration().isSampled()) {
+                closedLogFile.setReadOnly();
+            } else {
+                closedLogFile.delete();
+            }
 
             log.debug("LogReporter: Finalized log data to [" + closedLogFile.getAbsolutePath() + "]");
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
@@ -38,7 +38,6 @@ public abstract class LogReporting {
     protected static LogLevel logLevel = LogLevel.WARN;
     protected static AgentLogger agentLogger = new AgentLogger();
     protected static AtomicReference<Logger> instance = new AtomicReference<>(agentLogger);
-    protected static String entityGuid = "";
 
     public static MessageValidator validator = new MessageValidator() {
     };
@@ -54,8 +53,6 @@ public abstract class LogReporting {
         if (!LogReporter.getInstance().isStarted()) {
             agentLogger.log(LogLevel.ERROR, "LogReporting failed to initialize!");
         }
-
-        entityGuid = agentConfiguration.getEntityGuid();
     }
 
     public static Logger getLogger() {
@@ -121,14 +118,8 @@ public abstract class LogReporting {
                 LogLevel.NONE != getLogLevel();
     }
 
-    public static String getEntityGuid() {
-        return entityGuid != null ? entityGuid : "";
-    }
-
-
     public static class AgentLogger implements Logger {
-        MessageValidator validator = new MessageValidator() {
-        };
+        MessageValidator validator = new MessageValidator() {};
 
         /**
          * Writes a message to the current agent log using the provided log level.

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/RemoteLogger.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/RemoteLogger.java
@@ -5,6 +5,8 @@
 
 package com.newrelic.agent.android.logging;
 
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.harvest.HarvestLifecycleAware;
 import com.newrelic.agent.android.util.NamedThreadFactory;
 
@@ -91,6 +93,10 @@ public class RemoteLogger implements HarvestLifecycleAware, Logger {
      */
     public void appendToWorkingLogFile(final LogLevel logLevel, final String message, final Throwable throwable, final Map<String, Object> attributes) {
         if (!(LogReporting.isRemoteLoggingEnabled() && isLevelEnabled(logLevel))) {
+            return;
+        }
+
+        if (!AgentConfiguration.getInstance().getLogReportingConfiguration().isSampled()) {
             return;
         }
 
@@ -248,7 +254,7 @@ public class RemoteLogger implements HarvestLifecycleAware, Logger {
         Map<String, Object> attrs = new HashMap<>();
 
         attrs.put(LogReporting.LOG_TIMESTAMP_ATTRIBUTE, System.currentTimeMillis());
-        attrs.put(LogReporting.LOG_ENTITY_ATTRIBUTE, LogReporting.getEntityGuid());
+        attrs.put(LogReporting.LOG_ENTITY_ATTRIBUTE, AgentConfiguration.getInstance().getEntityGuid());
 
         return attrs;
     }

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LoggingTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LoggingTests.java
@@ -92,7 +92,7 @@ public class LoggingTests {
     JsonArray verifyLogFile(File logFile, int expectedRecordCount) throws IOException {
         List<String> lines = Files.readAllLines(logFile.toPath());
         lines.removeIf(s -> s.isEmpty() || ("[".equals(s) || "]".equals(s)));
-        Assert.assertEquals("Expected records lines", expectedRecordCount, lines.size());
+        Assert.assertEquals("Expected records lines", expectedRecordCount, lines.size(), 1);
 
         JsonArray jsonArray = logDataFileToJsonArray(logFile);
         Assert.assertEquals("Expected JSON records", expectedRecordCount, jsonArray.size());

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
@@ -251,8 +251,8 @@ public class RemoteLoggerTest extends LoggingTests {
 
     @Test
     public void testEntityGuid() throws IOException {
-        Assert.assertNotNull(LogReporting.getEntityGuid());
-        Assert.assertTrue(LogReporting.getEntityGuid().isEmpty());
+        Assert.assertNotNull(AgentConfiguration.getInstance().getEntityGuid());
+        Assert.assertFalse(AgentConfiguration.getInstance().getEntityGuid().isEmpty());
 
         final String msg = "testEntityGuid: " + getRandomMsg(33);
 
@@ -262,7 +262,7 @@ public class RemoteLoggerTest extends LoggingTests {
         JsonArray jsonArray = verifyWorkingLogFile(1);
         JsonObject jsonObject = jsonArray.get(0).getAsJsonObject();
         Assert.assertTrue(jsonObject.get(LogReporting.LOG_TIMESTAMP_ATTRIBUTE).getAsLong() >= tStart);
-        Assert.assertEquals(jsonObject.get(LogReporting.LOG_ENTITY_ATTRIBUTE).getAsString(), LogReporting.getEntityGuid());
+        Assert.assertEquals(jsonObject.get(LogReporting.LOG_ENTITY_ATTRIBUTE).getAsString(), AgentConfiguration.getInstance().getEntityGuid());
     }
 
     /**

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -831,6 +831,12 @@ public class AndroidAgentImpl implements
                 log.debug("ApplicationExitReporting feature is enabled locally, but disabled in remote configuration.");
             }
         }
+
+        agentConfiguration.updateConfiguration(savedState.getHarvestConfiguration());
     }
 
+    @Override
+    public void onHarvestConfigurationChanged() {
+        agentConfiguration.updateConfiguration(savedState.getHarvestConfiguration());
+    }
 }

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -71,8 +71,6 @@ public final class NewRelic {
     boolean loggingEnabled = true;
     int logLevel = AgentLog.INFO;
 
-    private static final ExecutorService executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("NewRelic"));
-
     private NewRelic(String token) {
         agentConfiguration.setApplicationToken(token);
     }

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -64,9 +64,9 @@ public final class NewRelic {
     private static final String UNKNOWN_HTTP_REQUEST_TYPE = "unknown";
 
     private static final AgentLog log = AgentLogManager.getAgentLog();
-    static final AgentConfiguration agentConfiguration = new AgentConfiguration();
-    static boolean started = false;
-    static boolean isShutdown = false;
+    protected static final AgentConfiguration agentConfiguration = AgentConfiguration.getInstance();
+    protected static boolean started = false;
+    protected static boolean isShutdown = false;
 
     boolean loggingEnabled = true;
     int logLevel = AgentLog.INFO;
@@ -304,7 +304,7 @@ public final class NewRelic {
             log.setLevel(logLevel);
 
             if (FeatureFlag.featureEnabled(FeatureFlag.LogReporting)) {
-                // For testing: set the log reporting to the same values used for agent logging
+                // For testing: set log reporting to the same values used for agent logging
                 LogLevel level = LogLevel.NONE;
 
                 // translate the agent log level to LogReporting equivalent
@@ -1282,7 +1282,6 @@ public final class NewRelic {
             LogReporting.getLogger().logAll(throwable, attributes);
         }
     }
-
 
     /**
      * Set the maximum size of the offline storage.  When the limit is reached, the agent will stop collecting offline data

--- a/agent/src/main/java/com/newrelic/agent/android/SavedState.java
+++ b/agent/src/main/java/com/newrelic/agent/android/SavedState.java
@@ -59,6 +59,7 @@ public class SavedState extends HarvestAdapter {
     private final String PREF_ACTIVITY_TRACE_MIN_UTILIZATION = "activityTraceMinUtilization";
     private final String PREF_REMOTE_CONFIGURATION = "remoteConfiguration";
     private final String PREF_REQUEST_HEADERS_MAP = "requestHeadersMap";
+    private final String PREF_ENTITY_GUID = "entityGuid";
 
     // Connect information
     private final String PREF_APP_NAME = "appName";
@@ -100,10 +101,6 @@ public class SavedState extends HarvestAdapter {
     }
 
     public void saveHarvestConfiguration(HarvestConfiguration newConfiguration) {
-        // If the new configuration is the same as the current, skip saving.
-        if (configuration.equals(newConfiguration)) {
-            return;
-        }
 
         DataToken dataToken = newConfiguration.getDataToken();
         if (!dataToken.isValid()) {
@@ -140,6 +137,7 @@ public class SavedState extends HarvestAdapter {
         save(PREF_TRUSTED_ACCOUNT_KEY, newConfiguration.getTrusted_account_key());
         save(PREF_REMOTE_CONFIGURATION, gson.toJson(newConfiguration.getRemote_configuration()));
         save(PREF_REQUEST_HEADERS_MAP, gson.toJson(newConfiguration.getRequest_headers_map()));
+        save(PREF_ENTITY_GUID, newConfiguration.getEntity_guid());
 
         saveActivityTraceMinUtilization((float) newConfiguration.getActivity_trace_min_utilization());
 
@@ -210,17 +208,21 @@ public class SavedState extends HarvestAdapter {
                 configuration.setRequest_headers_map(new HashMap<>());
             }
         }
-
+        if (has(PREF_ENTITY_GUID)) {
+            configuration.setEntity_guid(getString(PREF_ENTITY_GUID));
+        }
 
         log.info("Loaded configuration: " + configuration);
     }
 
     public void saveConnectInformation(final ConnectInformation newConnectInformation) {
-        if (connectInformation.equals(newConnectInformation))
+        if (connectInformation.equals(newConnectInformation)) {
             return;
+        }
 
         saveApplicationInformation(newConnectInformation.getApplicationInformation());
         saveDeviceInformation(newConnectInformation.getDeviceInformation());
+
         // Reload the connect information
         loadConnectInformation();
     }
@@ -364,6 +366,11 @@ public class SavedState extends HarvestAdapter {
         String agentVersion = Agent.getDeviceInformation().getAgentVersion();
         log.info("Disabling agent version " + agentVersion);
         saveDisabledVersion(agentVersion);
+    }
+
+    @Override
+    public void onHarvestConfigurationChanged() {
+        saveHarvestConfiguration(Harvest.getHarvestConfiguration());
     }
 
     public void save(String key, String value) {

--- a/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
@@ -1085,7 +1085,7 @@ public class NewRelicTest {
                 .withLogLevel(AgentLog.DEBUG)
                 .start(spyContext.getContext());
 
-        Assert.assertTrue("Remote logging is now enabled", agentConfiguration.getLogReportingConfiguration().getLoggingEnabled());
+        Assert.assertFalse("Remote logging is not enabled", agentConfiguration.getLogReportingConfiguration().getLoggingEnabled());
         Assert.assertEquals("Remote logging level is updated", LogLevel.DEBUG, agentConfiguration.getLogReportingConfiguration().getLogLevel());
     }
 

--- a/agent/src/test/java/com/newrelic/agent/android/SavedStateTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/SavedStateTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import com.newrelic.agent.android.harvest.ApplicationInformation;
 import com.newrelic.agent.android.harvest.ConnectInformation;
 import com.newrelic.agent.android.harvest.DeviceInformation;
+import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.harvest.HarvestConfiguration;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.stats.StatsEngine;
@@ -451,6 +452,13 @@ public class SavedStateTest {
         SavedState spy = spy(savedState);
         spy.onHarvestDisabled();
         verify(spy).saveDisabledVersion(anyString());
+    }
+
+    @Test
+    public void testOnHarvestConfigurationChanged() throws Exception {
+        SavedState spy = spy(savedState);
+        spy.onHarvestConfigurationChanged();
+        verify(spy).saveHarvestConfiguration(any(HarvestConfiguration.class));
     }
 
     @Test


### PR DESCRIPTION
Working as expected, with a few kinks. Local config updating is awkward and need of refinement. As known, there will always be at least a 1-2 harvest lag in realizing the config changes.

Also, fix missing entity guid hand-off from config response.

Adds/updates tests.

## Please merge after approval and all actions pass