### PR TITLE
fix: LogReporter not started with default config

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/ForwardingAgentLog.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/ForwardingAgentLog.java
@@ -113,7 +113,7 @@ public class ForwardingAgentLog implements AgentLog {
     Map<String, Object> asAttributes(LogLevel level, String message) {
         Map<String, Object> attributes = new HashMap<>();
 
-        attributes.put(LogReporting.logLevel.name(), level);
+        attributes.put(LogReporting.LOG_LEVEL_ATTRIBUTE, level);
         attributes.put(LogReporting.LOG_MESSAGE_ATTRIBUTE, message);
         attributes.put(LogReporting.LOG_LOGGER_ATTRIBUTE, "Android agent " + Agent.getVersion());
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
@@ -43,15 +43,14 @@ public abstract class LogReporting {
     };
 
     public static void initialize(File cacheDir, AgentConfiguration agentConfiguration) throws IOException {
-        LogReporting.setLogLevel(agentConfiguration.getLogReportingConfiguration().getLogLevel());
-        LogReporter.initialize(cacheDir, agentConfiguration);
-
-        if (LogReporter.getInstance().isEnabled()) {
+        if (agentConfiguration.getLogReportingConfiguration().getLoggingEnabled()) {
+            LogReporting.setLogLevel(agentConfiguration.getLogReportingConfiguration().getLogLevel());
+            LogReporter.initialize(cacheDir, agentConfiguration);
             LogReporter.getInstance().start();
-        }
 
-        if (!LogReporter.getInstance().isStarted()) {
-            agentLogger.log(LogLevel.ERROR, "LogReporting failed to initialize!");
+            if (!LogReporter.getInstance().isStarted()) {
+                agentLogger.log(LogLevel.ERROR, "LogReporting failed to initialize!");
+            }
         }
     }
 
@@ -119,7 +118,8 @@ public abstract class LogReporting {
     }
 
     public static class AgentLogger implements Logger {
-        MessageValidator validator = new MessageValidator() {};
+        MessageValidator validator = new MessageValidator() {
+        };
 
         /**
          * Writes a message to the current agent log using the provided log level.

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -295,22 +295,6 @@ public final class NewRelic {
             AgentLogManager.setAgentLog(loggingEnabled ? new AndroidAgentLog() : new NullAgentLog());
             log.setLevel(logLevel);
 
-            if (FeatureFlag.featureEnabled(FeatureFlag.LogReporting)) {
-                try {
-                    /**
-                     *  LogReports are stored in the apps cache directory, rather than the persistent files directory. The o/s _may_
-                     *  remove the oldest files when storage runs low, offloading some of the maintenance work from the reporter,
-                     *  but potentially resulting in unreported log file deletions.
-                     *
-                     * @see <a href="https://developer.android.com/reference/android/content/Context#getCacheDir()">getCacheDir()</a>
-                     **/
-                    LogReporting.initialize(context.getCacheDir(), agentConfiguration);
-
-                } catch (IOException e) {
-                    AgentLogManager.getAgentLog().error("Log reporting failed to initialize: " + e);
-                }
-            }
-
             boolean instantApp = InstantApps.isInstantApp(context);
 
             if (instantApp || isInstrumented()) {


### PR DESCRIPTION
Initialized too early, before the remote logging state was valid.

* fixed ForwardingLog level attribute