### PR TITLE
[NR-276058] Modify when to clear supportability metrics

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/stats/StatsEngine.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/stats/StatsEngine.java
@@ -190,6 +190,10 @@ public class StatsEngine extends HarvestAdapter {
     public void onHarvest() {
         calculateMetricsDataUseage();
         populateMetrics();
+    }
+
+    @Override
+    public void onHarvestComplete() {
         reset();
     }
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/stats/StatsEngineTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/stats/StatsEngineTest.java
@@ -143,6 +143,17 @@ public class StatsEngineTest {
 
         StatsEngine.get().onHarvest();
         Assert.assertEquals(4, TaskQueue.size());
+        Assert.assertEquals(4, StatsEngine.get().getStatsMap().size());
+    }
+
+    @Test
+    public void onHarvestComplete() {
+        StatsEngine.get().lazyGet("metric1");
+        StatsEngine.get().lazyGet("metric2");
+        StatsEngine.get().lazyGet("metric3");
+        Assert.assertEquals(3, StatsEngine.get().getStatsMap().size());
+
+        StatsEngine.get().onHarvestComplete();
         Assert.assertEquals(0, StatsEngine.get().getStatsMap().size());
     }
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/stats/StatsEngineTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/stats/StatsEngineTest.java
@@ -204,6 +204,9 @@ public class StatsEngineTest {
         StatsEngine.get().onHarvest();
 
         Assert.assertEquals(4, TaskQueue.size());
+        Assert.assertEquals(4, StatsEngine.get().getStatsMap().size());
+
+        StatsEngine.get().onHarvestComplete();
         Assert.assertEquals(0, StatsEngine.get().getStatsMap().size());
     }
 

--- a/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
+++ b/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
@@ -95,12 +95,12 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
                     || (agentConfiguration.getLaunchActivityClassName().equalsIgnoreCase(activity.getLocalClassName())))) {
                 firstActivityResumed = true;
                 if (tracer.isColdStart()) {
-                    StatsEngine.notice().sample(MetricNames.APP_LAUNCH_COLD, metrics.getColdStartTime() / 1000.0f);
+                    StatsEngine.get().sample(MetricNames.APP_LAUNCH_COLD, metrics.getColdStartTime() / 1000.0f);
                 }
             } else {
                 if (isForegrounded) {
                     isForegrounded = false;
-                    StatsEngine.notice().sample(MetricNames.APP_LAUNCH_HOT, metrics.getHotStartTime() / 1000.0f);
+                    StatsEngine.get().sample(MetricNames.APP_LAUNCH_HOT, metrics.getHotStartTime() / 1000.0f);
                 }
             }
             log.debug("App launch time " + metrics.toString());

--- a/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
+++ b/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
@@ -95,12 +95,12 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
                     || (agentConfiguration.getLaunchActivityClassName().equalsIgnoreCase(activity.getLocalClassName())))) {
                 firstActivityResumed = true;
                 if (tracer.isColdStart()) {
-                    StatsEngine.get().sample(MetricNames.APP_LAUNCH_COLD, metrics.getColdStartTime() / 1000.0f);
+                    StatsEngine.notice().sample(MetricNames.APP_LAUNCH_COLD, metrics.getColdStartTime() / 1000.0f);
                 }
             } else {
                 if (isForegrounded) {
                     isForegrounded = false;
-                    StatsEngine.get().sample(MetricNames.APP_LAUNCH_HOT, metrics.getHotStartTime() / 1000.0f);
+                    StatsEngine.notice().sample(MetricNames.APP_LAUNCH_HOT, metrics.getHotStartTime() / 1000.0f);
                 }
             }
             log.debug("App launch time " + metrics.toString());


### PR DESCRIPTION
Ticket: https://new-relic.atlassian.net/browse/NR-276058

What's changed:
1. Move clear action of the supportability metrics from onHarvest to onHarvestComplete