### PR TITLE
[NR-235235] Only clear metrics when onHarvestComplete

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/measurement/consumer/MetricMeasurementConsumer.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/measurement/consumer/MetricMeasurementConsumer.java
@@ -96,12 +96,12 @@ public abstract class MetricMeasurementConsumer extends BaseMeasurementConsumer 
 
     @Override
     public void onHarvestError() {
-        metrics.clear();
+
     }
 
     @Override
     public void onHarvestSendFailed() {
-        metrics.clear();
+
     }
 
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/measurement/MetricMeasurementTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/measurement/MetricMeasurementTests.java
@@ -116,7 +116,7 @@ public class MetricMeasurementTests {
 
         metricMeasurementConsumer.consumeMeasurement(measurementFactory());
         metricMeasurementConsumer.onHarvestError();
-        Assert.assertTrue(metricMeasurementConsumer.getMetricStore().getAll().isEmpty());
+        Assert.assertTrue(!metricMeasurementConsumer.getMetricStore().getAll().isEmpty());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class MetricMeasurementTests {
 
         metricMeasurementConsumer.consumeMeasurement(measurementFactory());
         metricMeasurementConsumer.onHarvestSendFailed();
-        Assert.assertTrue(metricMeasurementConsumer.getMetricStore().getAll().isEmpty());
+        Assert.assertTrue(!metricMeasurementConsumer.getMetricStore().getAll().isEmpty());
     }
 
     private BaseMeasurement measurementFactory() {

--- a/agent-core/src/test/java/com/newrelic/agent/android/measurement/consumer/MetricMeasurementTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/measurement/consumer/MetricMeasurementTest.java
@@ -112,7 +112,7 @@ public class MetricMeasurementTest extends MeasurementTest {
         Assert.assertEquals(3, consumer.metrics.getAll().size());
 
         consumer.onHarvestError();
-        Assert.assertEquals(0, consumer.metrics.getAll().size());
+        Assert.assertEquals(3, consumer.metrics.getAll().size());
     }
 
     @Test
@@ -123,6 +123,6 @@ public class MetricMeasurementTest extends MeasurementTest {
         Assert.assertEquals(3, consumer.metrics.getAll().size());
 
         consumer.onHarvestSendFailed();
-        Assert.assertEquals(0, consumer.metrics.getAll().size());
+        Assert.assertEquals(3, consumer.metrics.getAll().size());
     }
 }


### PR DESCRIPTION
Ticket: https://new-relic.atlassian.net/browse/NR-235235

What's changed:
1. Remove metrics.clear() from onHarvestError and onHarvestSendFailure
2. Double checked all the .clear() functions
3. Unit tests updated