### PR TITLE
[NR-308026] Fix Null pointer exception while shutting down harvester

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvest.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvest.java
@@ -114,7 +114,9 @@ public class Harvest implements HarvestConfigurable {
     }
 
     public void shutdownHarvester() {
-        harvestTimer.shutdown();
+        if (harvestTimer != null) {
+            harvestTimer.shutdown();
+        }
         harvestTimer = null;
         harvester = null;
         harvestConnection = null;


### PR DESCRIPTION
While calling Harvest's `shutdown` method, the current checks only consider the nullability of the Harvest instance and it's harvester. But, the  `harvestTimer` is also accessed during the method execution. If the `harvestTimer` is null due to some reason, for instance, a back to back call to the  `shutdown` method, we get a null pointer exception.

Added a null check to prevent this.

This Null pointer exception is one of the top crashes happening in our application. Also attached the stacktrace below.
```

Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void com.newrelic.agent.android.harvest.HarvestTimer.shutdown()' on a null object reference
  at com.newrelic.agent.android.harvest.Harvest.shutdownHarvester (Harvest.java:119)
  at com.newrelic.agent.android.harvest.Harvest.shutdown (Harvest.java:129)
  at com.newrelic.agent.android.AndroidAgentImpl.stop (AndroidAgentImpl.java:548)
  at com.newrelic.agent.android.AndroidAgentImpl.stop (AndroidAgentImpl.java:473)
  at com.newrelic.agent.android.AndroidAgentImpl.applicationBackgrounded (AndroidAgentImpl.java:629)
  at com.newrelic.agent.android.background.ApplicationStateMonitor.notifyApplicationInBackground (ApplicationStateMonitor.java:108)
  at com.newrelic.agent.android.background.ApplicationStateMonitor$1.run (ApplicationStateMonitor.java:65)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:644)
  at java.lang.Thread.run (Thread.java:1012)
```