### PR TITLE
[NR-303822] crash ingest fix

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/Crash.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/Crash.java
@@ -262,19 +262,15 @@ public class Crash extends HarvestableObject {
     protected Throwable getRootCause(Throwable throwable) {
         try {
             if (throwable != null) {
-                final Throwable cause = throwable.getCause();
-
-                if (cause == null) {
-                    return throwable;
+                if (throwable.getCause() != null) {
+                    return throwable.getCause();
                 } else {
-                    return getRootCause(cause);
+                    return throwable;
                 }
             }
         } catch (Exception e) {
             // RuntimeException thrown on: Duplicate found in causal chain so cropping to prevent loop
-            if (throwable != null) {
-                return throwable;       // return the last known throwable
-            }
+            return throwable;
         }
 
         return new Throwable("Unknown cause");

--- a/agent/src/test/java/com/newrelic/agent/android/ndk/NativeReportingTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/ndk/NativeReportingTest.java
@@ -215,7 +215,8 @@ public class NativeReportingTest {
     public void flushPendingReports() {
         Assert.assertEquals(6, Streams.list(agentNDK.getManagedContext().getReportsDir()).count());
         agentNDK.flushPendingReports();
-        counters.entrySet().forEach(c -> Assert.assertEquals(c.getKey(), 2, c.getValue().get()));
+//        counters.entrySet().forEach(c -> Assert.assertEquals(c.getKey(), 2, c.getValue().get()));
+        counters.forEach((key, value) -> Assert.assertEquals(key, 2, value.get()));
         Assert.assertEquals(0, Streams.list(agentNDK.getManagedContext().getReportsDir()).count());
     }
 


### PR DESCRIPTION
<h1><b>DO NOT MERGE</b></h1>

Ticket: https://new-relic.atlassian.net/browse/NR-303822

What's changed:
1. strip out Nisarg's fix in v7.5.1 version due to v7.6.0 version is having publishing issue.