### PR TITLE
fix: no need to delare Kotlin plugin in agent module

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -9,7 +9,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     id("com.github.johnrengelman.shadow")
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 apply from: "$project.rootDir/jacoco.gradle"


### PR DESCRIPTION
The builds on GH were resulting in duplicate Kotlin definitions. Should not have been, but were for some reason.