### PR TITLE
[NR-145885] Resolve maven publishing

### DIFF
--- a/.github/workflows/gradlePluginPortalDeployment.yml
+++ b/.github/workflows/gradlePluginPortalDeployment.yml
@@ -38,6 +38,6 @@ jobs:
           env:
             GRADLE_PUBLISH_KEY : ${{ secrets.GRADLE_PUBLISH_KEY  }}
             GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET  }}
-          run: ./gradlew clean plugins:gradle:publishPlugins --max-workers 1
+          run: ./gradlew plugins:gradle:publishPlugins --max-workers 1
 
 

--- a/.github/workflows/sonatypeDeployment.yml
+++ b/.github/workflows/sonatypeDeployment.yml
@@ -6,23 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  assemble_project:
-    name: Assemble project
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup JDK 11
-      uses: actions/setup-java@v3
-      with:
-          java-version: '11'
-          distribution: 'temurin'
-          cache: 'gradle'
-    - name: Build with Gradle
-      run: ./gradlew clean assemble --no-daemon
-
   publish_release:
       name: Publish artifacts
-      needs: [assemble_project]
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v3
@@ -43,7 +28,6 @@ jobs:
 
   publish_mono_release:
     name: Publish Mono artifacts
-    needs: [ assemble_project ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -171,22 +171,22 @@ def toFatJarTask(def variant) {
 apply from: "${rootDir}/gradle/publishing.gradle"
 
 publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId 'android-agent'
+            android.libraryVariants.all { variant ->
+                artifact variant.ext.fatJarProvider
+            }
+            artifact javadocJar
+            artifact sourcesJar
 
-        publications {
-            mavenJava(MavenPublication) {
-                android.libraryVariants.all { variant ->
-                    artifact variant.ext.fatJarProvider
-                }
-                artifact javadocJar
-                artifact sourcesJar
-                artifactId 'android-agent'
-                pom {
-                    groupId = 'com.newrelic.agent.android'
-                    artifactId = monoEnabled ? 'android-agent-static':'android-agent'
-                    version = rootProject.version
-                    name = 'New Relic Android Agent'
-                    description = 'The New Relic Android agent provides performance monitoring instrumentation for Android applications'
-                }
+            pom {
+                groupId = 'com.newrelic.agent.android'
+                artifactId = monoEnabled ? 'android-agent-static' : 'android-agent'
+                version = rootProject.version
+                name = 'New Relic Android Agent'
+                description = 'The New Relic Android agent provides performance monitoring instrumentation for Android applications'
             }
         }
     }
+}

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -161,10 +161,12 @@ apply from: "${rootDir}/gradle/publishing.gradle"
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifact shadowJar
+
             artifactId 'instrumentation'
+            artifact shadowJar
             artifact javadocJar
             artifact sourcesJar
+
             pom {
                 artifactId = 'instrumentation'
                 name = 'New Relic Android Instrumentation Agent'

--- a/plugins/gradle/build.gradle
+++ b/plugins/gradle/build.gradle
@@ -6,8 +6,7 @@
 plugins {
     id("groovy")
     id("org.jetbrains.kotlin.jvm")
-    id("com.github.johnrengelman.shadow")
-    id("com.gradle.plugin-publish") version "1.2.1"
+    id("com.gradle.plugin-publish")
 }
 
 apply from: "$project.rootDir/jacoco.gradle"
@@ -59,18 +58,19 @@ compileKotlin {
 classes.dependsOn compileKotlin
 
 dependencies {
-    shadow project(path: ':instrumentation', configuration: 'shadow')
+    implementation project(path: ':instrumentation', configuration: 'shadow')
     implementation files("${System.getProperty('java.home')}/../lib/tools.jar")
 
     compileOnly 'com.android.tools.build:gradle:' + project.versions.agp.plugin
     compileOnly 'com.android.tools.build:gradle-api:' + project.versions.agp.gradleApi
-    shadow gradleApi()
+    compileOnly gradleApi()
 
     implementation 'commons-io:commons-io:' + project.versions.java.commonsIO
+    implementation 'com.guardsquare:proguard-gradle:' + project.versions.java.proguard
     implementation 'org.ow2.asm:asm:' + project.versions.java.asm
     implementation 'org.ow2.asm:asm-util:' + project.versions.java.asm
 
-    shadow localGroovy()
+    compileOnly localGroovy()
     compileOnly 'com.google.guava:guava:' + project.versions.java.guava
 
     testImplementation project(path: ':instrumentation', configuration: 'default')
@@ -128,12 +128,22 @@ tasks.withType(Test).configureEach {
     }
 }
 
-tasks.withType(Copy).all {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+tasks.withType(AbstractPublishToMaven).configureEach {
+    if (name.contains("PluginMavenPublication")) {
+        logger.quiet("Ignoring publish task: $name")
+        enabled(false)
+    }
+
+    if (name.contains("NewrelicPluginPluginMarkerMavenPublication")) {
+        logger.quiet("Ignoring publish task: $name")
+        enabled(false)
+    }
+
+    dependsOn(tasks.named("signPluginMavenPublication"))
 }
 
-tasks.jar.configure {
-    classifier = 'default'
+tasks.withType(Copy).all {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 test {
@@ -166,27 +176,8 @@ tasks.named('check') {
     dependsOn(tasks.named("integrationTests"))
 }
 
-shadowJar {
-    classifier = null
-}
-
 artifacts {
-    archives shadowJar
-}
-
-gradlePlugin {
-    website = 'https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android/'
-    vcsUrl = 'https://github.com/newrelic/newrelic-android-agent'
-    plugins {
-        newrelicPlugin {
-            id = 'com.newrelic.agent.android'
-            implementationClass = 'com.newrelic.agent.android.NewRelicGradlePlugin'
-            displayName = 'New Relic Android Gradle Plugin'
-            description = 'The New Relic Android Gradle plugin instruments classes for Android applications'
-            tags.set(['monitoring', 'mobile', 'newrelic', 'android'])
-
-        }
-    }
+    archives jar
 }
 
 apply from: "${rootDir}/gradle/publishing.gradle"
@@ -204,3 +195,19 @@ publishing {
         }
     }
 }
+
+gradlePlugin {
+    website = 'https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android/'
+    vcsUrl = 'https://github.com/newrelic/newrelic-android-agent'
+    plugins {
+        newrelicPlugin {
+            id = 'com.newrelic.agent.android'
+            implementationClass = 'com.newrelic.agent.android.NewRelicGradlePlugin'
+            displayName = 'New Relic Android Gradle Plugin'
+            description = 'The New Relic Android Gradle plugin instruments classes for Android applications'
+            tags.set(['monitoring', 'mobile', 'newrelic', 'android'])
+        }
+    }
+}
+
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,7 @@ pluginManagement {
                 agp     : '7.1.+',
                 kotlin  : '1.6.+',
                 shadow  : '7.1.2',
-                nexus   : '1.3.0',
+                nexus   : '2.0.0',
                 spotbugs: '5.0.13',
                 gpp     : '1.2.1'
         ]
@@ -25,8 +25,9 @@ pluginManagement {
         id("base")
         id("java")
         id("maven-publish")
+        id("com.gradle.plugin-publish") version "${versions.gpp}"
         id("io.github.gradle-nexus.publish-plugin") version "${versions.nexus}"
-        id("com.gradle.plugin-publish") version "${versions.gpp}" apply false
+        //noinspection GradlePluginVersion
         id("com.android.library") version "${versions.agp}"
         id("com.github.johnrengelman.shadow") version "${versions.shadow}"
         id("com.github.spotbugs") version "${versions.spotbugs}"


### PR DESCRIPTION
... using the Gradle Publishing Plugin.

The new plugin was also publishing the `PluginMavenPublication` and `NewrelicPluginPluginMarkerMavenPublication` publications which did not contain valid POMs (the root cause of the deploy failures).