### PR TITLE
[NR-331312] Add AEI session mapper

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/SessionMapper.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/SessionMapper.java
@@ -51,6 +51,7 @@ public class SessionMapper {
         return sessionId.isEmpty() ? defaultSessionId : sessionId;
     }
 
+    @SuppressWarnings("unchecked")
     public SessionMapper load() {
         if (mapStore.exists() && mapStore.canRead()) {
             try {
@@ -82,7 +83,7 @@ public class SessionMapper {
         return mapStore.exists() && mapStore.canRead();
     }
 
-    void clear() {
+    public void clear() {
         mapper.clear();
     }
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/SessionMapper.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/SessionMapper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.aei;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.util.Streams;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SessionMapper {
+
+    static final Gson gson = new GsonBuilder().create();
+
+    final File mapStore;
+    final Map<Integer, String> mapper;
+
+    public SessionMapper(File mapStore) {
+        this.mapStore = mapStore;
+        this.mapper = new HashMap<>();
+        if (mapStore.exists()) {
+            load();
+        }
+    }
+
+    public SessionMapper put(int pid, String sessionId) {
+        if (!(sessionId == null || sessionId.isEmpty() || 0 == pid)) {
+            mapper.put(pid, sessionId);
+        } else {
+            AgentLogManager.getAgentLog().debug("Refusing to store null or empty sessionId[" + sessionId + "] for pid[" + pid + "]");
+        }
+
+        return this;
+    }
+
+    public String get(int pid) {
+        return mapper.getOrDefault(pid, "");
+    }
+
+    public String getOrDefault(int pid, String defaultSessionId) {
+        String sessionId = get(pid);
+        return sessionId.isEmpty() ? defaultSessionId : sessionId;
+    }
+
+    public SessionMapper load() {
+        if (mapStore.exists() && mapStore.canRead()) {
+            try {
+                String storeData = Streams.slurpString(mapStore, StandardCharsets.UTF_8.toString());
+                mapper.putAll(gson.fromJson(storeData, Map.class));
+
+            } catch (IOException e) {
+                AgentLogManager.getAgentLog().error("Cannot read session ID mapper: " + e);
+            }
+        } else {
+            AgentLogManager.getAgentLog().debug("Cannot read session ID mapper: file does not exist or is unreadable");
+        }
+
+        return this;
+    }
+
+    public boolean flush() {
+        if (mapper.isEmpty()) {
+            mapStore.delete();
+        } else {
+            try (BufferedWriter os = Streams.newBufferedFileWriter(mapStore)) {
+                os.write(gson.toJson(mapper));
+                os.flush();
+
+            } catch (IOException e) {
+                AgentLogManager.getAgentLog().error("Cannot write session ID mapping file: " + e);
+            }
+        }
+        return mapStore.exists() && mapStore.canRead();
+    }
+
+    void clear() {
+        mapper.clear();
+    }
+
+    public void delete() {
+        if (mapStore.exists()) {
+            mapStore.delete();
+        }
+    }
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/SessionMapper.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/SessionMapper.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class SessionMapper {
 
@@ -43,12 +45,12 @@ public class SessionMapper {
     }
 
     public String get(int pid) {
-        return mapper.getOrDefault(pid, "");
+        return mapper.getOrDefault(pid, null);
     }
 
     public String getOrDefault(int pid, String defaultSessionId) {
         String sessionId = get(pid);
-        return sessionId.isEmpty() ? defaultSessionId : sessionId;
+        return (sessionId == null || sessionId.isEmpty()) ? defaultSessionId : sessionId;
     }
 
     @SuppressWarnings("unchecked")
@@ -92,4 +94,20 @@ public class SessionMapper {
             mapStore.delete();
         }
     }
+
+    public void erase(int pid) {
+        mapper.remove(pid);
+    }
+
+    /**
+     * Remove any elements whose key's are *not* in the passed set
+     */
+    synchronized public void erase(Set<Integer> pidSet) {
+        Set<Integer> currentKeySet = mapper.keySet();
+        currentKeySet.stream()
+                .filter(pid -> !pidSet.contains(pid))
+                .collect(Collectors.toSet())
+                .forEach(pid -> mapper.remove(pid));
+    }
+
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsAttribute.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsAttribute.java
@@ -107,6 +107,8 @@ public class AnalyticsAttribute {
     public static final String APP_EXIT_IMPORTANCE_STRING_ATTRIBUTE = "importanceAsString";
     public static final String APP_EXIT_PROCESS_NAME_ATTRIBUTE = "processName";
     public static final String APP_EXIT_APP_STATE_ATTRIBUTE = "appState";
+    public static final String APP_EXIT_SESSION_ID_ATTRIBUTE = "aeiSessionId";
+
 
     public static final int ATTRIBUTE_NAME_MAX_LENGTH = 255;
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
@@ -180,9 +180,8 @@ public class AnalyticsEvent extends HarvestableObject {
      *
      * @return a mutable set of the attributes bound to this event.
      */
-    Collection<AnalyticsAttribute> getMutableAttributeSet() {
+    public Collection<AnalyticsAttribute> getMutableAttributeSet() {
         Set<AnalyticsAttribute> collection = Collections.checkedSet(attributeSet, AnalyticsAttribute.class);
-        collection.add(new AnalyticsAttribute(AnalyticsAttribute.MUTABLE, true));
         return collection;
     }
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/SessionMapperTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/SessionMapperTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.aei;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.logging.AgentLog;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.ConsoleAgentLog;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.UUID;
+
+public class SessionMapperTest {
+
+    private static File reportsDir;
+    private File sessionMapperFile;
+    private SessionMapper mapper;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        reportsDir = Files.createTempDirectory("LogReporting-").toFile();
+        reportsDir.mkdirs();
+
+        AgentLogManager.setAgentLog(new ConsoleAgentLog());
+        AgentLogManager.getAgentLog().setLevel(AgentLog.DEBUG);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        sessionMapperFile = new File(reportsDir, "sessionMapper");
+        mapper = new SessionMapper(sessionMapperFile);
+
+        mapper.put(123, UUID.randomUUID().toString());
+        mapper.put(234, UUID.randomUUID().toString());
+        mapper.put(345, UUID.randomUUID().toString());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        sessionMapperFile.delete();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        Assert.assertTrue(reportsDir.delete());
+    }
+
+    @Test
+    public void put() {
+        mapper.put(6661, AgentConfiguration.getInstance().getSessionID());
+        Assert.assertEquals(AgentConfiguration.getInstance().getSessionID(), mapper.get(6661));
+    }
+
+    @Test
+    public void get() {
+        Assert.assertNotEquals("", mapper.get(234));
+        Assert.assertEquals("", mapper.get(456));
+    }
+
+    @Test
+    public void getOrDefault() {
+        Assert.assertEquals("", mapper.get(456));
+    }
+
+    @Test
+    public void load() {
+        Assert.assertEquals(0, sessionMapperFile.length());
+        mapper.flush();
+        Assert.assertNotEquals(0, sessionMapperFile.length());
+        mapper.clear();
+        Assert.assertTrue(mapper.mapper.isEmpty());
+        mapper.load();
+        Assert.assertFalse(mapper.mapper.isEmpty());
+    }
+
+    @Test
+    public void flush() {
+        Assert.assertEquals(0, sessionMapperFile.length());
+        mapper.flush();
+        ;
+        Assert.assertNotEquals(0, sessionMapperFile.length());
+    }
+
+    @Test
+    public void clear() {
+        Assert.assertFalse(mapper.mapper.isEmpty());
+        mapper.clear();
+        Assert.assertTrue(mapper.mapper.isEmpty());
+    }
+
+    @Test
+    public void delete() {
+        mapper.flush();
+        Assert.assertTrue(sessionMapperFile.exists() && sessionMapperFile.length() > 0);
+        mapper.delete();
+        Assert.assertFalse(sessionMapperFile.exists());
+    }
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/SessionMapperTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/SessionMapperTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Set;
 import java.util.UUID;
 
 public class SessionMapperTest {
@@ -64,13 +65,13 @@ public class SessionMapperTest {
 
     @Test
     public void get() {
-        Assert.assertNotEquals("", mapper.get(234));
-        Assert.assertEquals("", mapper.get(456));
+        Assert.assertNotNull(mapper.get(234));
+        Assert.assertNull(mapper.get(456));
     }
 
     @Test
     public void getOrDefault() {
-        Assert.assertEquals("", mapper.get(456));
+        Assert.assertNotNull(mapper.getOrDefault(456, UUID.randomUUID().toString()));
     }
 
     @Test
@@ -88,7 +89,6 @@ public class SessionMapperTest {
     public void flush() {
         Assert.assertEquals(0, sessionMapperFile.length());
         mapper.flush();
-        ;
         Assert.assertNotEquals(0, sessionMapperFile.length());
     }
 
@@ -105,5 +105,24 @@ public class SessionMapperTest {
         Assert.assertTrue(sessionMapperFile.exists() && sessionMapperFile.length() > 0);
         mapper.delete();
         Assert.assertFalse(sessionMapperFile.exists());
+    }
+
+    @Test
+    public void erase() {
+        Assert.assertNotNull(mapper.get(123));
+        Assert.assertNotNull(mapper.get(234));
+        Assert.assertNotNull(mapper.get(345));
+        Assert.assertNull(mapper.get(456));
+
+        Set<Integer> pidSet = Set.of(123, 234, 456);
+        mapper.erase(pidSet);
+
+        Assert.assertNotNull(mapper.get(123));
+        Assert.assertNotNull(mapper.get(234));
+        Assert.assertNull(mapper.get(345));
+
+        mapper.put(456, UUID.randomUUID().toString());
+        mapper.erase(pidSet);
+        Assert.assertNotNull(mapper.get(456));
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsEventTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsEventTests.java
@@ -136,7 +136,7 @@ public class AnalyticsEventTests {
         Collection<AnalyticsAttribute> mutableAttrs = analyticsEvents.get(0).getMutableAttributeSet();
 
         Assert.assertTrue(analyticsEvents.get(0).getAttributeSet().size() == mutableAttrs.size());
-        Assert.assertNotNull(getAttributeByName(mutableAttrs, AnalyticsAttribute.MUTABLE));
+        Assert.assertNull(getAttributeByName(mutableAttrs, AnalyticsAttribute.MUTABLE));
 
         try {
             getAttributeByName(immutableAttrs, "name").setStringValue("mutated");


### PR DESCRIPTION
Acceptance criteria:

* a PID-to-session map will be created and persisted in local AEI cache
* for AEI events gathered during the first agent run, the sessionID of the event will be the one that recorded the event
* for AEI events gathered in successive sessions, a new attribute will be added to provide the session ID in which the AEI occurred 
  * in this case session ID will never match recorded session ID
* session ID map will be updated each time the agent starts
* session ID map will be updated each time the agent restarts
* session ID map will be pruned when the set of AEI records returned by the ART no longer includes elements in the map
* an attribute with the historic session ID will be inserted into the event as `sessionId`.

Tests will be created to reflect this criteria.