### PR TITLE
[NR-293384] Implement AEI trace reporting

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -207,7 +207,7 @@ public class AgentConfiguration implements HarvestConfigurable {
         this.applicationFrameworkVersion = applicationFrameworkVersion;
     }
 
-    protected String provideSessionId() {
+    public String provideSessionId() {
         sessionID = UUID.randomUUID().toString();
         return sessionID;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITrace.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITrace.java
@@ -99,7 +99,7 @@ public class AEITrace {
     public String toString() {
         // transform trace data per DEM spec
         String flattenedThreads = threads.stream()
-                .collect(Collectors.joining("\n"));
+                .collect(Collectors.joining("\n\n"));
 
         return flattenedThreads;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceReporter.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.aei;
+
+import com.newrelic.agent.android.Agent;
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.harvest.DeviceInformation;
+import com.newrelic.agent.android.harvest.Harvest;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.payload.PayloadController;
+import com.newrelic.agent.android.payload.PayloadReporter;
+import com.newrelic.agent.android.payload.PayloadSender;
+import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.Constants;
+import com.newrelic.agent.android.util.Streams;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import javax.net.ssl.HttpsURLConnection;
+
+public class AEITraceReporter extends PayloadReporter {
+    protected static AtomicReference<AEITraceReporter> instance = new AtomicReference<>(null);
+
+    static final String TRACE_DATA_DIR = "aeitrace/";
+    static final String FILE_MASK = "threads-%s.dat";
+
+    static long reportTTL = TimeUnit.SECONDS.convert(2, TimeUnit.DAYS); // thread data file expiration period (in MS)
+
+    public static AEITraceReporter getInstance() {
+        return instance.get();
+    }
+
+    File traceStore = new File(System.getProperty("java.io.tmpdir", "/tmp"), TRACE_DATA_DIR).getAbsoluteFile();
+
+    protected final Callable reportCachedAgentDataCallable = () -> {
+        postCachedAgentData();
+
+        // shut down the reporter if all work is done, otherwise try again during the next harvest
+        if (getCachedTraces().isEmpty()) {
+            AEITraceReporter.shutdown();
+        }
+        return null;
+    };
+
+    public static AEITraceReporter initialize(File rootDir, AgentConfiguration agentConfiguration) throws IOException {
+        if (!rootDir.isDirectory() || !rootDir.exists() || !rootDir.canWrite()) {
+            throw new IOException("Trace reports directory [" + rootDir.getAbsolutePath() + "] must exist and be writable!");
+        }
+
+        if (instance.compareAndSet(null, new AEITraceReporter(agentConfiguration))) {
+            AEITraceReporter instance = AEITraceReporter.getInstance();
+
+            instance.traceStore = new File(rootDir, TRACE_DATA_DIR);
+            instance.traceStore.mkdirs();
+
+            if (!(instance.traceStore.exists() && instance.traceStore.canWrite())) {
+                throw new IOException("AEI: Threads directory [" + rootDir.getAbsolutePath() + "] must exist and be writable!");
+            }
+            log.debug("AEI: saving AEI trace data to " + instance.traceStore.getAbsolutePath());
+
+            log.debug("AEI: reporter instance initialized");
+        }
+
+        return instance.get();
+    }
+
+    protected static boolean isInitialized() {
+        return instance.get() != null;
+    }
+
+    protected AEITraceReporter(AgentConfiguration agentConfiguration) {
+        super(agentConfiguration);
+        setEnabled((agentConfiguration.getApplicationExitConfiguration().isEnabled()));
+    }
+
+    /**
+     * Start the reporter: add it as a HarvestAware listener
+     * <p>
+     * Once started, the reporter will run until all artifacts have been uploaded, or the app terminates.
+     */
+    @Override
+    public void start() {
+        if (isInitialized()) {
+            if (isStarted.compareAndSet(false, true)) {
+                Harvest.addHarvestListener(instance.get());
+                isStarted.set(true);
+            } else {
+                log.error("AEITraceReporter: failed to initialize.");
+            }
+        }
+    }
+
+    /**
+     * Stop the reporter: remove it from the Harvester's HarvestAware listeners
+     */
+    @Override
+    protected void stop() {
+        if (isStarted()) {
+            Harvest.removeHarvestListener(instance.get());
+            isStarted.set(false);
+        }
+    }
+
+    public static void shutdown() {
+        if (isInitialized()) {
+            instance.get().stop();
+            instance.set(null);
+        }
+    }
+
+    public AEITrace reportAEITrace(String systrace, int pid) {
+        return reportAEITrace(systrace, generateUniqueDataFilename(pid));
+    }
+
+    public AEITrace reportAEITrace(String systrace, File artifact) {
+        AEITrace trace = new AEITrace(artifact);
+
+        trace.decomposeFromSystemTrace(systrace);
+
+        // store the report prior to upload:
+        try (OutputStream artifactOs = new FileOutputStream(artifact, false)) {
+            artifactOs.write(trace.toString().getBytes(StandardCharsets.UTF_8));
+            artifactOs.flush();
+            artifactOs.close();
+            artifact.setReadOnly();
+
+        } catch (IOException e) {
+            log.debug("AEITraceReporter: AppExitInfo artifact error. " + e);
+        }
+
+        return trace;
+    }
+
+    // upload any cached agent data posts
+    protected void postCachedAgentData() {
+        if (isInitialized()) {
+            getCachedTraces().forEach(traceDataFile -> {
+                if (postAEITrace(traceDataFile)) {
+                    log.info("AEI: Uploaded trace data [" + traceDataFile.getAbsolutePath() + "]");
+                    if (safeDelete(traceDataFile)) {
+                        log.debug("AEI: Trace data artifact[" + traceDataFile.getName() + "] removed from device");
+                    }
+                } else {
+                    log.error("AEITraceReporter: upload failed for trace data [" + traceDataFile.getAbsolutePath() + "]");
+                }
+            });
+        }
+
+        // delete (drop) any traces that have aged out
+        expire(Math.toIntExact(reportTTL));
+    }
+
+
+    /**
+     * Synchronously upload trace data file to Errors ingest endpoint
+     *
+     * @param traceDataFile
+     * @return true
+     */
+    boolean postAEITrace(File traceDataFile) {
+        final boolean hasValidDataToken = Harvest.getHarvestConfiguration().getDataToken().isValid();
+
+        if (hasValidDataToken) {
+            try {
+                if (traceDataFile.exists()) {
+                    AEITraceSender traceSender = new AEITraceSender(traceDataFile, agentConfiguration);
+
+                    switch (traceSender.call().getResponseCode()) {
+                        // Upload timed-out
+                        case HttpURLConnection.HTTP_CLIENT_TIMEOUT:
+                            break;
+
+                        // Payload too large:
+                        case HttpURLConnection.HTTP_ENTITY_TOO_LARGE:
+                            // TODO The payload was too large, despite filtering prior to upload
+                            // Only solution in this case is to compress the file and retry
+                            // threadDataFile = compress(logDataFile, false);
+                            break;
+
+                        // Upload was throttled
+                        case 429:
+                            break;
+
+                        // Payload was rejected
+                        case HttpsURLConnection.HTTP_INTERNAL_ERROR:
+                            break;
+
+                        default:
+                            break;
+                    }
+
+                    return traceSender.isSuccessfulResponse();
+
+                } else {
+                    log.warn("AEI: Trace [" + traceDataFile.getName() + "] vanished before it could be uploaded.");
+                }
+            } catch (Exception e) {
+                AgentLogManager.getAgentLog().error("AEI: Trace upload failed: " + e);
+            }
+        } else {
+            log.warn("AEITraceReporter: agent has not successfully connected and cannot report AEITrace. Will retry later");
+        }
+
+        return false;
+    }
+
+    /**
+     * Asynchronously upload the trace data contained in the passed string.
+     *
+     * @param sysTrace
+     * @return
+     */
+    protected Future postAEITrace(String sysTrace) {
+        final boolean hasValidDataToken = Harvest.getHarvestConfiguration().getDataToken().isValid();
+
+        if (hasValidDataToken) {
+            if (sysTrace != null) {
+                final AEITrace aeiTrace = new AEITrace().decomposeFromSystemTrace(sysTrace);
+                long aeiSize = aeiTrace.toString().getBytes().length;
+
+                if (aeiSize > Constants.Network.MAX_PAYLOAD_SIZE) {
+                    DeviceInformation deviceInformation = Agent.getDeviceInformation();
+
+                    String name = MetricNames.SUPPORTABILITY_MAXPAYLOADSIZELIMIT_ENDPOINT
+                            .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
+                            .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
+                            .replace(MetricNames.TAG_SUBDESTINATION, "errors");
+
+                    StatsEngine.SUPPORTABILITY.inc(name);
+
+                    // delete AEITrace here?
+                    // safeDelete(aeiTraceFile)
+                    // log.error("Unable to upload crashes because payload is larger than 1 MB, trace report is discarded.");
+
+                    return null;
+                }
+
+                final PayloadSender.CompletionHandler completionHandler = new PayloadSender.CompletionHandler() {
+
+                    @Override
+                    public void onResponse(PayloadSender payloadSender) {
+                        if (payloadSender.isSuccessfulResponse()) {
+                            // add supportability metrics
+                            DeviceInformation deviceInformation = Agent.getDeviceInformation();
+                            String name = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
+                                    .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
+                                    .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
+                                    .replace(MetricNames.TAG_SUBDESTINATION, "mobile_crash");
+
+                            StatsEngine.get().sampleMetricDataUsage(name, payloadSender.getPayloadSize(), 0);
+                        }
+                    }
+
+                    @Override
+                    public void onException(PayloadSender payloadSender, Exception e) {
+                        log.error("AEITraceReporter: AEITrace upload failed: " + e);
+                    }
+                };
+
+                final AEITraceSender sender = new AEITraceSender(aeiTrace.toString(), agentConfiguration);
+
+                if (!sender.shouldUploadOpportunistically()) {
+                    log.warn("AEITraceReporter: network is unreachable. AEITrace will be uploaded on next app launch");
+                }
+
+                return PayloadController.submitPayload(sender, completionHandler);
+            } else {
+                log.warn("AEITraceReporter: attempted to report null AEITrace.");
+            }
+
+        } else {
+            log.error("AEITraceReporter: agent has not successfully connected and cannot report AEITrace.");
+        }
+
+        return null;
+    }
+
+    @Override
+    public void onHarvest() {
+        postCachedAgentData();
+
+        // shut down the reporter if all work is done, otherwise try again during the next harvest
+        if (getCachedTraces().isEmpty()) {
+            AEITraceReporter.shutdown();
+        }
+
+        // PayloadController.submitCallable(reportCachedAgentDataCallable);
+    }
+
+    /**
+     * Return the current collection of trace artifacts
+     */
+    protected Set<File> getCachedTraces() {
+        Set<File> reportSet = new HashSet<>();
+
+        try {
+            String fileMask = String.format(Locale.getDefault(), FILE_MASK, "\\d+");
+            reportSet = Streams.list(traceStore)
+                    .filter(file -> file.isFile() && file.getName().matches(fileMask))
+                    .collect(Collectors.toSet());
+
+        } catch (Exception e) {
+            log.error("AEI:Can't query cached log reports: " + e);
+        }
+
+        return reportSet;
+    }
+
+    /**
+     * Give expired thread data file one last chance to upload, then safely delete.
+     * This should be run at least once per session.
+     *
+     * @param expirationTTL Time in milliseconds since the file was last modified
+     */
+    Set<File> expire(long expirationTTL) {
+        FileFilter expirationFilter = traceFile -> (traceFile.exists() &&
+                (traceFile.lastModified() + expirationTTL) < System.currentTimeMillis());
+
+        Set<File> expiredFiles = Streams.list(traceStore, expirationFilter).collect(Collectors.toSet());
+
+        expiredFiles.forEach(threadData -> {
+            log.debug("AEI:Thread data [" + threadData.getName() + "] has expired and will be removed.");
+            safeDelete(threadData);
+        });
+
+        return expiredFiles;
+    }
+
+    boolean safeDelete(File fileToDelete) {
+        fileToDelete.setReadOnly();
+        fileToDelete.delete();
+
+        return !fileToDelete.exists();
+    }
+
+    /**
+     * Create a new filename for the trace data artifacts
+     *
+     * @return Unique filename
+     */
+    File generateUniqueDataFilename(int pid) {
+        File traceFile;
+        int retries = 5;
+        do {
+            traceFile = new File(traceStore, String.format(Locale.getDefault(), FILE_MASK, pid));
+
+        } while (traceFile.exists() && 0 < traceFile.length() && retries-- > 0);
+
+        return traceFile.exists() ? null : traceFile;
+    }
+
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceReporter.java
@@ -301,8 +301,6 @@ public class AEITraceReporter extends PayloadReporter {
         if (getCachedTraces().isEmpty()) {
             AEITraceReporter.shutdown();
         }
-
-        // PayloadController.submitCallable(reportCachedAgentDataCallable);
     }
 
     /**

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceSender.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.aei;
+
+import com.newrelic.agent.android.Agent;
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.payload.FileBackedPayload;
+import com.newrelic.agent.android.payload.PayloadSender;
+import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.Constants;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import javax.net.ssl.HttpsURLConnection;
+
+public class AEITraceSender extends PayloadSender {
+    static final String AEI_COLLECTOR_PATH = "/errors?anr=true";
+
+    public AEITraceSender(String aeiTrace, AgentConfiguration agentConfiguration) {
+        super(aeiTrace.getBytes(), agentConfiguration);
+        setPayload(aeiTrace.getBytes());
+    }
+
+    public  AEITraceSender(File traceDataFile, AgentConfiguration agentConfiguration) {
+        super(traceDataFile.getAbsolutePath().getBytes(StandardCharsets.UTF_8), agentConfiguration);
+        this.payload = new FileBackedPayload(traceDataFile);
+    }
+
+    @Override
+    protected HttpURLConnection getConnection() throws IOException {
+        final HttpURLConnection connection = (HttpURLConnection) getCollectorURI().toURL().openConnection();
+
+        connection.setDoOutput(true);
+        connection.setRequestProperty(Constants.Network.CONTENT_TYPE_HEADER, Constants.Network.ContentType.JSON);
+        connection.setRequestProperty(agentConfiguration.getAppTokenHeader(), agentConfiguration.getApplicationToken());
+        connection.setRequestProperty(agentConfiguration.getDeviceOsNameHeader(), Agent.getDeviceInformation().getOsName());
+        connection.setRequestProperty(agentConfiguration.getAppVersionHeader(), Agent.getApplicationInformation().getAppVersion());
+        connection.setConnectTimeout(COLLECTOR_TIMEOUT);
+        connection.setReadTimeout(COLLECTOR_TIMEOUT);
+
+        return connection;
+    }
+
+    @Override
+    public PayloadSender call() {
+        try {
+            return super.call();
+
+        } catch (Exception e) {
+            onFailedUpload("Unable to report crash to New Relic, will try again later. " + e);
+        }
+
+        return this;
+    }
+
+    /**
+     * Response codes should adhere to the Vortex request spec
+     *
+     * @param connection Passed from the result of the call() operation
+     * @see <a href=""https://source.datanerd.us/agents/agent-specs/blob/main/Collector-Response-Handling.md">Vortex response codes</a>
+     **/
+    @Override
+    protected void onRequestResponse(HttpURLConnection connection) throws IOException {
+        int responseCode = connection.getResponseCode();
+
+        switch (responseCode) {
+            case HttpsURLConnection.HTTP_OK:
+            case HttpsURLConnection.HTTP_ACCEPTED:
+                StatsEngine.get().sampleTimeMs(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_TIME, timer.peek());
+                break;
+
+            case HttpURLConnection.HTTP_CLIENT_TIMEOUT:
+                onFailedUpload("The request to submit the payload [" + payload.getUuid() + "] has timed out - (will try again later) - Response code [" + responseCode + "]");
+                break;
+
+            case 429: // Not defined by HttpURLConnection
+                onFailedUpload("The request to submit the payload [" + payload.getUuid() + "] was has timed out - (will try again later) - Response code [" + responseCode + "]");
+                break;
+
+            case HttpsURLConnection.HTTP_INTERNAL_ERROR:
+                onFailedUpload("The payload was rejected and will be deleted - Response code " + connection.getResponseCode());
+                break;
+
+            default:
+                onFailedUpload("Something went wrong while submitting data (will try again later) - Response code " + connection.getResponseCode());
+                break;
+        }
+
+        log.debug("AEITraceSender: data reporting took " + timer.toc() + "ms");
+    }
+
+    @Override
+    protected void onFailedUpload(String errorMsg) {
+        log.error("AEITraceSender: " + errorMsg);
+        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_LOG_FAILED_UPLOAD);
+    }
+
+    @Override
+    protected void onRequestException(Exception e) {
+        log.error("AEITraceSender: Crash upload failed: " + e);
+        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_LOG_FAILED_UPLOAD);
+    }
+
+    /**
+     * Send the data immediately if there is net connectivity, retry later otherwise
+     */
+    @Override
+    protected boolean shouldUploadOpportunistically() {
+        // send the crash report immediately if there is net connectivity
+        return Agent.hasReachableNetworkConnection(null);
+    }
+
+    @Override
+    protected URI getCollectorURI() {
+        return URI.create(getProtocol() + agentConfiguration.getCollectorHost() + AEI_COLLECTOR_PATH);
+    }
+
+    @Override
+    public boolean shouldRetry() {
+        return true;
+    }
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceSender.java
@@ -9,6 +9,7 @@ import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.FileBackedPayload;
+import com.newrelic.agent.android.payload.PayloadController;
 import com.newrelic.agent.android.payload.PayloadSender;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.util.Constants;
@@ -23,6 +24,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 public class AEITraceSender extends PayloadSender {
     static final String AEI_COLLECTOR_PATH = "/errors?anr=true";
+    private static final int COLLECTOR_TIMEOUT = PayloadController.PAYLOAD_COLLECTOR_TIMEOUT;
 
     public AEITraceSender(String aeiTrace, AgentConfiguration agentConfiguration) {
         super(aeiTrace.getBytes(), agentConfiguration);

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEITraceSender.java
@@ -55,7 +55,7 @@ public class AEITraceSender extends PayloadSender {
             return super.call();
 
         } catch (Exception e) {
-            onFailedUpload("Unable to report crash to New Relic, will try again later. " + e);
+            onFailedUpload("Unable to report AEI trace to New Relic, will try again later. " + e);
         }
 
         return this;

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashSender.java
@@ -8,18 +8,20 @@ package com.newrelic.agent.android.crash;
 import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.payload.PayloadController;
 import com.newrelic.agent.android.payload.PayloadSender;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.util.Constants;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 
 import javax.net.ssl.HttpsURLConnection;
 
 public class CrashSender extends PayloadSender {
-    public static final int CRASH_COLLECTOR_TIMEOUT = 5000; // 5 seconds
+    public static final int CRASH_COLLECTOR_TIMEOUT = PayloadController.PAYLOAD_COLLECTOR_TIMEOUT;
     private static final String CRASH_COLLECTOR_PATH = "/mobile_crash";
 
     private final Crash crash;
@@ -31,9 +33,7 @@ public class CrashSender extends PayloadSender {
 
     @Override
     protected HttpURLConnection getConnection() throws IOException {
-        final String urlString = getProtocol() + agentConfiguration.getCrashCollectorHost() + CRASH_COLLECTOR_PATH;
-        final URL url = new URL(urlString);
-        final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        final HttpURLConnection connection = (HttpURLConnection) getCollectorURI().toURL().openConnection();
 
         connection.setDoOutput(true);
         connection.setRequestProperty(Constants.Network.CONTENT_TYPE_HEADER, Constants.Network.ContentType.JSON);
@@ -114,4 +114,10 @@ public class CrashSender extends PayloadSender {
         // send the crash report immediately if there is net connectivity
         return Agent.hasReachableNetworkConnection(null);
     }
+
+    @Override
+    protected URI getCollectorURI() {
+        return URI.create(getProtocol() + agentConfiguration.getCrashCollectorHost() + CRASH_COLLECTOR_PATH);
+    }
+
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -95,6 +95,19 @@ public class MetricNames {
     public static final String SUPPORTABILITY_AEI_REMOTE_CONFIG = SUPPORTABILITY_AEI + "remoteConfiguration/";
     public static final String SUPPORTABILITY_AEI_VISITED = SUPPORTABILITY_AEI + "visited";
     public static final String SUPPORTABILITY_AEI_SKIPPED = SUPPORTABILITY_AEI + "skipped";
+    public static final String SUPPORTABILITY_AEI_DROPPED = SUPPORTABILITY_AEI + "dropped";
+    public static final String SUPPORTABILITY_AEI_UPLOAD_TIME = SUPPORTABILITY_AEI + "UploadTime";
+    public static final String SUPPORTABILITY_AEI_FAILED_UPLOAD = SUPPORTABILITY_AEI + "FailedUpload";
+
+    public static final String SUPPORTABILITY_OFFLINE_STORAGE = SUPPORTABILITY_AGENT + "OfflineStorage/";
+    public static final String OFFLINE_STORAGE_HANDLED_EXCEPTION_COUNT = SUPPORTABILITY_OFFLINE_STORAGE + "HandledException/Count";
+    public static final String OFFLINE_STORAGE_CRASH_COUNT = SUPPORTABILITY_OFFLINE_STORAGE + "Crash/Count";
+    public static final String OFFLINE_STORAGE_EVENT_COUNT = SUPPORTABILITY_OFFLINE_STORAGE + "Event/Count";
+
+    public static final String SUPPORTABILITY_BACKGROUND = SUPPORTABILITY_AGENT + "Background/";
+    public static final String BACKGROUND_EVENT_COUNT = SUPPORTABILITY_BACKGROUND + "Event/Count";
+    public static final String BACKGROUND_HANDLED_EXCEPTION_COUNT = SUPPORTABILITY_BACKGROUND + "HandledException/Count";
+    public static final String BACKGROUND_CRASH_COUNT = SUPPORTABILITY_BACKGROUND + "Crash/Count";
 
     public static final String SUPPORTABILITY_DATA_TOKEN = SUPPORTABILITY_AGENT + "DataToken/";
     public static final String SUPPORTABILITY_INVALID_DATA_TOKEN = SUPPORTABILITY_DATA_TOKEN + "Invalid";
@@ -118,10 +131,4 @@ public class MetricNames {
     public static final String TAG_FRAMEWORK_VERSION = "<frameworkVersion>";
     public static final String TAG_DESTINATION = "<destination>";
     public static final String TAG_SUBDESTINATION = "<subdestination>";
-    public static final String OFFLINE_STORAGE_HANDLED_EXCEPTION_COUNT = "OfflineStorage/HandledException/Count";
-    public static final String OFFLINE_STORAGE_CRASH_COUNT = "OfflineStorage/Crash/Count";
-    public static final String OFFLINE_STORAGE_EVENT_COUNT = "OfflineStorage/Event/Count";
-    public static final String BACKGROUND_EVENT_COUNT = "Background/Event/Count";
-    public static final String BACKGROUND_HANDLED_EXCEPTION_COUNT = "Background/HandledException/Count";
-    public static final String BACKGROUND_CRASH_COUNT = "Background/Crash/Count";
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/payload/FileBackedPayload.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/payload/FileBackedPayload.java
@@ -111,6 +111,18 @@ public class FileBackedPayload extends Payload {
     /**
      * GZIP compress the payload file.
      *
+     * @param replace Delete the original file, rename the compressed file to the current file name
+     * @return File of new compressed file
+     * @throws IOException
+     */
+    File compress(boolean replace) throws IOException {
+        return compress(payloadFile(), replace);
+
+    }
+
+    /**
+     * GZIP compress the payload file.
+     *
      * @param payloadFile File to be compressed
      * @param replace     Delete the passed file, rename the compressed file to the pass file name
      * @return File of new compressed file

--- a/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadController.java
@@ -35,8 +35,8 @@ public class PayloadController implements HarvestLifecycleAware {
 
     protected static final AgentLog log = AgentLogManager.getAgentLog();
 
-    public static final long PAYLOAD_COLLECTOR_TIMEOUT = 5000;             // 5 seconds
-    public static final long PAYLOAD_REQUEUE_PERIOD_MS = 2 * 60 * 1000;    // requeue failed uploads every 2 minutes
+    public static final int PAYLOAD_COLLECTOR_TIMEOUT = 5000;               // 5 seconds
+    public static final long PAYLOAD_REQUEUE_PERIOD_MS = 2 * 60 * 1000;     // requeue failed uploads every 2 minutes
 
     protected static Lock payloadQueueLock = new ReentrantLock(false);
     protected static AtomicReference<PayloadController> instance = new AtomicReference<>(null);

--- a/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadSender.java
@@ -11,6 +11,8 @@ import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.stats.TicToc;
 import com.newrelic.agent.android.util.Streams;
 
@@ -85,6 +87,10 @@ public abstract class PayloadSender implements Callable<PayloadSender> {
 
             case HttpURLConnection.HTTP_CLIENT_TIMEOUT:
                 onFailedUpload("The request to submit the payload [" + payload.getUuid() + "] has timed out (will try again later) - Response code [" + responseCode + "]");
+                break;
+
+            case HttpURLConnection.HTTP_ENTITY_TOO_LARGE:
+                onFailedUpload("The request was rejected due to payload size limits - Response code [" + responseCode + "]");
                 break;
 
             case 429: // 'Too Many Requests' not defined by HttpURLConnection

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceReporterTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 public class AEITraceReporterTest {
     private static final int NUM_TRACE_FILES = 3;
     protected static File reportsDir;
+
     private AgentConfiguration agentConfiguration;
     private AEITraceReporter traceReporter;
     private String sysTrace;
@@ -71,7 +72,7 @@ public class AEITraceReporterTest {
     }
 
     @AfterClass
-    public static void afterClass() throws Exception {
+    public static void afterClass() {
         Assert.assertTrue(reportsDir.delete());
     }
 
@@ -182,10 +183,10 @@ public class AEITraceReporterTest {
     }
 
     @Test
-    public void getCachedTraces() throws Exception {
+    public void getCachedTraces() {
         Assert.assertEquals(NUM_TRACE_FILES, traceReporter.getCachedTraces().size());
-        seedTraceData(5);
-        Assert.assertEquals(NUM_TRACE_FILES + 5, traceReporter.getCachedTraces().size());
+        Set<File> seededTraces = seedTraceData(5);
+        Assert.assertEquals(NUM_TRACE_FILES + seededTraces.size(), traceReporter.getCachedTraces().size());
     }
 
     @Test
@@ -213,7 +214,7 @@ public class AEITraceReporterTest {
         Assert.assertEquals(0, traceReporter.getCachedTraces().size());
     }
 
-    Set<File> seedTraceData(int numFiles) throws Exception {
+    Set<File> seedTraceData(int numFiles) {
         final HashSet<File> reportSet = new HashSet<>();
 
         for (int file = 0; file < numFiles; file++) {

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceReporterTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.aei;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.FeatureFlag;
+import com.newrelic.agent.android.harvest.Harvest;
+import com.newrelic.agent.android.logging.AgentLog;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.ConsoleAgentLog;
+import com.newrelic.agent.android.util.Streams;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AEITraceReporterTest {
+    private static final int NUM_TRACE_FILES = 3;
+    protected static File reportsDir;
+    private AgentConfiguration agentConfiguration;
+    private AEITraceReporter traceReporter;
+    private String sysTrace;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        reportsDir = Files.createTempDirectory("ApplicationExitInfo-").toFile();
+        reportsDir.mkdirs();
+
+        AgentLogManager.setAgentLog(new ConsoleAgentLog());
+        AgentLogManager.getAgentLog().setLevel(AgentLog.DEBUG);
+
+        Harvest.getHarvestConfiguration().setData_token(new int[]{2, 3});
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        FeatureFlag.enableFeature(FeatureFlag.ApplicationExitReporting);
+
+        sysTrace = Streams.slurpString(AEITraceTest.class.getResource("/applicationExitInfo/systrace").openStream());
+
+        agentConfiguration = new AgentConfiguration();
+        agentConfiguration.setApplicationToken("APP-TOKEN>");
+        agentConfiguration.getApplicationExitConfiguration().setConfiguration(new ApplicationExitConfiguration(true));
+
+        traceReporter = Mockito.spy(AEITraceReporter.initialize(reportsDir, agentConfiguration));
+        AEITraceReporter.instance.set(traceReporter);
+
+        seedTraceData(NUM_TRACE_FILES);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        FeatureFlag.disableFeature(FeatureFlag.ApplicationExitReporting);
+        Streams.list(traceReporter.traceStore).forEach(file -> file.delete());
+        Assert.assertTrue(traceReporter.traceStore.delete());
+        AEITraceReporter.instance.set(null);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        Assert.assertTrue(reportsDir.delete());
+    }
+
+    @Test
+    public void getInstance() {
+        Assert.assertEquals(traceReporter, AEITraceReporter.getInstance());
+    }
+
+    @Test
+    public void initialize() throws IOException {
+        AEITraceReporter.instance.set(null);
+
+        try {
+            AEITraceReporter.initialize(new File("/"), AgentConfiguration.getInstance());
+            Assert.fail("Should fail with missing or un-writable report directory");
+        } catch (Exception e) {
+            Assert.assertNull(AEITraceReporter.instance.get());
+        }
+
+        try {
+            AEITraceReporter.initialize(File.createTempFile("aeiTraceReporting", "tmp"), AgentConfiguration.getInstance());
+            Assert.fail("Should fail with a non-directory file");
+        } catch (Exception e) {
+            Assert.assertNull(AEITraceReporter.instance.get());
+        }
+
+        try {
+            AEITraceReporter.initialize(reportsDir, null);
+            Assert.fail("Should fail with missing agent configuration");
+        } catch (Exception e) {
+            Assert.assertNull(AEITraceReporter.instance.get());
+        }
+
+        AEITraceReporter.initialize(reportsDir, agentConfiguration);
+        Assert.assertNotNull(AEITraceReporter.instance.get());
+        Assert.assertTrue(reportsDir.exists() && reportsDir.canWrite());
+    }
+
+    @Test
+    public void isInitialized() {
+        traceReporter.start();
+        Assert.assertTrue(traceReporter.isEnabled() && traceReporter.isStarted());
+    }
+
+    @Test
+    public void start() {
+        Assert.assertFalse(traceReporter.isStarted());
+        traceReporter.start();
+        Assert.assertTrue(traceReporter.isStarted());
+    }
+
+    @Test
+    public void stop() {
+        traceReporter.start();
+        Assert.assertTrue(traceReporter.isStarted());
+        traceReporter.stop();
+        Assert.assertFalse(traceReporter.isStarted());
+    }
+
+    @Test
+    public void shutdown() {
+        traceReporter.start();
+        Assert.assertTrue(traceReporter.isStarted());
+
+        AEITraceReporter.shutdown();
+        Assert.assertFalse(traceReporter.isStarted());
+        Assert.assertNull(AEITraceReporter.getInstance());
+    }
+
+    @Test
+    public void postCachedAgentData() {
+        Mockito.doReturn(true).when(traceReporter).postAEITrace(Mockito.any(File.class));
+
+        Set<File> cachedReports = traceReporter.getCachedTraces();
+        Assert.assertEquals(NUM_TRACE_FILES, cachedReports.size());
+
+        traceReporter.postCachedAgentData();
+        Mockito.verify(traceReporter, Mockito.times(NUM_TRACE_FILES)).postAEITrace(Mockito.any(File.class));
+    }
+
+    @Test
+    public void reportAEITraceToArtifact() throws Exception {
+        File traceFile = File.createTempFile("aeitrace-", ".dat", traceReporter.traceStore);
+
+        Assert.assertTrue(traceFile.exists());
+        Assert.assertEquals(0, traceFile.length());
+
+        traceReporter.reportAEITrace(sysTrace, traceFile);
+        Assert.assertTrue(traceFile.exists());
+        Assert.assertNotEquals(0, traceFile.length());
+        Assert.assertFalse(traceFile.canWrite());
+    }
+
+    @Test
+    public void postAEITrace() {
+        Mockito.doReturn(true).when(traceReporter).postAEITrace(Mockito.any(File.class));
+
+        Set<File> cachedReports = traceReporter.getCachedTraces();
+        cachedReports.forEach(file -> {
+            try {
+                String traceAsString = Streams.slurpString(file, StandardCharsets.UTF_8.toString());
+                traceReporter.postAEITrace(traceAsString);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        Mockito.verify(traceReporter, Mockito.times(cachedReports.size())).postAEITrace(Mockito.anyString());
+    }
+
+    @Test
+    public void getCachedTraces() throws Exception {
+        Assert.assertEquals(NUM_TRACE_FILES, traceReporter.getCachedTraces().size());
+        seedTraceData(5);
+        Assert.assertEquals(NUM_TRACE_FILES + 5, traceReporter.getCachedTraces().size());
+    }
+
+    @Test
+    public void expire() throws InterruptedException {
+        Assert.assertEquals(NUM_TRACE_FILES, traceReporter.getCachedTraces().size());
+        Thread.sleep(5000);
+        traceReporter.expire(1000);
+        Assert.assertEquals(0, traceReporter.getCachedTraces().size());
+        Mockito.verify(traceReporter, Mockito.times(NUM_TRACE_FILES)).safeDelete(Mockito.any(File.class));
+    }
+
+    @Test
+    public void safeDelete() {
+        Assert.assertEquals(NUM_TRACE_FILES, traceReporter.getCachedTraces().size());
+        traceReporter.getCachedTraces().forEach(file -> traceReporter.safeDelete(file));
+        Assert.assertEquals(0, traceReporter.getCachedTraces().size());
+    }
+
+    @Test
+    public void onHarvest() {
+        Mockito.doReturn(true).when(traceReporter).postAEITrace(Mockito.any(File.class));
+
+        Assert.assertEquals(3, traceReporter.getCachedTraces().size());
+        traceReporter.onHarvest();
+        Assert.assertEquals(0, traceReporter.getCachedTraces().size());
+    }
+
+    Set<File> seedTraceData(int numFiles) throws Exception {
+        final HashSet<File> reportSet = new HashSet<>();
+
+        for (int file = 0; file < numFiles; file++) {
+            File traceFile = traceReporter.generateUniqueDataFilename((int) (Math.random() * 10000) + 1);
+            traceReporter.reportAEITrace(sysTrace, traceFile);
+            reportSet.add(traceFile);
+        }
+
+        return reportSet;
+    }
+
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceSenderTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2024. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.aei;
+
+import static com.newrelic.agent.android.aei.AEITraceSender.AEI_COLLECTOR_PATH;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.FeatureFlag;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.ConsoleAgentLog;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.payload.FileBackedPayload;
+import com.newrelic.agent.android.payload.Payload;
+import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.Streams;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.net.ssl.HttpsURLConnection;
+
+public class AEITraceSenderTest {
+
+    private static File reportsDir;
+    private AEITraceSender traceSender;
+    private File traceDataReport;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        reportsDir = Files.createTempDirectory("ApplicationExitInfo-").toFile();
+        reportsDir.mkdirs();
+
+        AgentLogManager.setAgentLog(new ConsoleAgentLog());
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        StatsEngine.reset();
+
+        FeatureFlag.enableFeature(FeatureFlag.ApplicationExitReporting);
+        AEITraceReporter.initialize(reportsDir, AgentConfiguration.getInstance());
+
+        traceDataReport = seedTraceData(1).iterator().next();
+        traceDataReport.setWritable(true);
+
+        traceSender = Mockito.spy(new AEITraceSender(traceDataReport, AgentConfiguration.getInstance()));
+
+        doReturn(Mockito.spy(traceSender.getConnection())).when(traceSender).getConnection();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        FeatureFlag.disableFeature(FeatureFlag.ApplicationExitReporting);
+        Streams.list(AEITraceReporter.getInstance().traceStore).forEach(file -> file.delete());
+        AEITraceReporter.getInstance().traceStore.delete();
+        AEITraceReporter.instance.set(null);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        Assert.assertTrue(reportsDir.delete());
+    }
+
+    @Test
+    public void aeiSenderFromString() throws IOException {
+        String sysTrace = Streams.slurpString(AEITraceTest.class.getResource("/applicationExitInfo/systrace").openStream());
+        traceSender = new AEITraceSender(sysTrace, AgentConfiguration.getInstance());
+        Assert.assertTrue(traceSender.getPayload() instanceof Payload);
+    }
+
+    @Test
+    public void aeiSenderFromFile() {
+        traceSender = new AEITraceSender(traceDataReport, AgentConfiguration.getInstance());
+        Assert.assertTrue(traceSender.getPayload() instanceof FileBackedPayload);
+    }
+
+    @Test
+    public void getConnection() throws IOException {
+        Assert.assertTrue(traceSender.getConnection() instanceof HttpsURLConnection);
+    }
+
+    @Test
+    public void getPayload() throws IOException {
+        Assert.assertTrue(Arrays.equals(Streams.readAllBytes(traceDataReport), traceSender.getPayload().getBytes()));
+    }
+
+    @Test
+    public void setPayload() {
+        String payloadData = "the part of a vehicle's load, especially an aircraft's, from which revenue is derived; passengers and cargo.";
+        traceSender.setPayload(payloadData.getBytes(StandardCharsets.UTF_8));
+        Assert.assertTrue(Arrays.equals(payloadData.getBytes(StandardCharsets.UTF_8), traceSender.getPayload().getBytes()));
+    }
+    
+    @Test
+    public void getPayloadSize() {
+        Assert.assertTrue(traceSender.getPayload().getBytes().length == traceDataReport.length());
+    }
+    
+    @Test
+    public void call() {
+    }
+
+    @Test
+    public void onRequestResponse() throws IOException {
+        HttpURLConnection connection = traceSender.getConnection();
+
+        Mockito.doReturn(HttpsURLConnection.HTTP_OK).when(connection).getResponseCode();
+        // when(connection.getResponseCode()).thenReturn(HttpsURLConnection.HTTP_OK);
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertTrue("Should contain 200 supportability metric", StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_UPLOAD_TIME));
+*/
+
+        Mockito.reset();
+        StatsEngine.SUPPORTABILITY.getStatsMap().clear();
+        Mockito.doReturn(HttpsURLConnection.HTTP_ACCEPTED).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertTrue("Should contain 202 supportability metric", StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_UPLOAD_TIME));
+*/
+
+        Mockito.reset();
+        StatsEngine.SUPPORTABILITY.getStatsMap().clear();
+        Mockito.doReturn(HttpsURLConnection.HTTP_CREATED).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertFalse("Should not contain 201 success supportability metric", StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_UPLOAD_TIME));
+*/
+
+        traceSender.onFailedUpload("boo");
+/*      FIXME
+        Assert.assertTrue("Should contain 500 supportability metric", StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_FAILED_UPLOAD));
+*/
+        Mockito.verify(traceSender, atLeastOnce()).onFailedUpload(Mockito.anyString());
+    }
+
+    @Test
+    public void onFailedUpload() throws IOException {
+        HttpURLConnection connection = traceSender.getConnection();
+        Mockito.doReturn(503).when(connection).getResponseCode();
+
+        traceSender.onRequestResponse(connection);
+        Assert.assertTrue("Should contain filed upload supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_FAILED_UPLOAD));
+    }
+
+    @Test
+    public void onRequestException() {
+        Exception e = new RuntimeException("Upload failed");
+        traceSender.onRequestException(e);
+        Assert.assertTrue("Should contain filed upload supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_FAILED_UPLOAD));
+    }
+
+    @Test
+    public void uploadRequest() throws Exception {
+        HttpURLConnection connection = traceSender.getConnection();
+
+        Mockito.doReturn(HttpsURLConnection.HTTP_OK).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertTrue("Should contain 200 supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_TIME));
+*/
+
+        Mockito.reset();
+        StatsEngine.SUPPORTABILITY.getStatsMap().clear();
+        Mockito.doReturn(HttpsURLConnection.HTTP_ACCEPTED).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertTrue("Should contain 202 supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_TIME));
+*/
+
+        Mockito.reset();
+        StatsEngine.SUPPORTABILITY.getStatsMap().clear();
+        Mockito.doReturn(HttpsURLConnection.HTTP_CREATED).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertFalse("Should not contain 202 supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_TIME));
+        Assert.assertTrue("Should contain 202 supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_FAILED_UPLOAD));
+*/
+    }
+
+    @Test
+    public void failedUploadRequest() throws Exception {
+        HttpURLConnection connection = traceSender.getConnection();
+
+        Mockito.doReturn(HttpsURLConnection.HTTP_INTERNAL_ERROR).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertTrue("Should contain 500 supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_REMOVED_REJECTED));
+*/
+    }
+
+    @Test
+    public void timedOutUploadRequest() throws Exception {
+        HttpURLConnection connection = traceSender.getConnection();
+
+        Mockito.doReturn(HttpsURLConnection.HTTP_CLIENT_TIMEOUT).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertTrue("Should contain 408 supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_UPLOAD_TIMEOUT));
+*/
+    }
+
+    @Test
+    public void throttledUploadRequest() throws Exception {
+        HttpURLConnection connection = traceSender.getConnection();
+
+        doReturn(429).when(connection).getResponseCode();
+        traceSender.onRequestResponse(connection);
+/*      FIXME
+        Assert.assertTrue("Should contain 429 supportability metric",
+                StatsEngine.SUPPORTABILITY.getStatsMap().containsKey(MetricNames.SUPPORTABILITY_LOG_UPLOAD_THROTTLED));
+*/
+    }
+
+    @Test
+    public void shouldUploadOpportunistically() {
+        Assert.assertTrue(traceSender.shouldUploadOpportunistically());
+        Mockito.doReturn(false).when(traceSender).shouldUploadOpportunistically();
+        Assert.assertFalse(traceSender.shouldUploadOpportunistically());
+        Assert.assertFalse("Should not make upload request", traceSender.call().isSuccessfulResponse());
+    }
+
+    @Test
+    public void getCollectorURI() {
+        Assert.assertEquals("https://" + AgentConfiguration.getInstance().getCollectorHost() + AEI_COLLECTOR_PATH, traceSender.getCollectorURI().toString());
+    }
+
+    @Test
+    public void shouldRetry() {
+        Assert.assertTrue(traceSender.shouldRetry());
+    }
+
+    @Test
+    public void recordSupportabilityMetrics() throws Exception {
+    }
+
+    Set<File> seedTraceData(int numFiles) throws Exception {
+        final HashSet<File> reportSet = new HashSet<>();
+        final AEITraceReporter traceReporter = AEITraceReporter.getInstance();
+        String sysTrace = Streams.slurpString(AEITraceTest.class.getResource("/applicationExitInfo/systrace").openStream());
+
+        for (int file = 0; file < numFiles; file++) {
+            File traceFile = traceReporter.generateUniqueDataFilename((int) (Math.random() * 10000) + 1);
+            traceReporter.reportAEITrace(sysTrace, traceFile);
+            reportSet.add(traceFile);
+        }
+
+        return reportSet;
+    }
+
+
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEITraceSenderTest.java
@@ -5,7 +5,6 @@
 
 package com.newrelic.agent.android.aei;
 
-import static com.newrelic.agent.android.aei.AEITraceSender.AEI_COLLECTOR_PATH;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;
 
@@ -249,7 +248,7 @@ public class AEITraceSenderTest {
 
     @Test
     public void getCollectorURI() {
-        Assert.assertEquals("https://" + AgentConfiguration.getInstance().getCollectorHost() + AEI_COLLECTOR_PATH, traceSender.getCollectorURI().toString());
+        Assert.assertEquals("https://" + AgentConfiguration.getInstance().getCollectorHost() + AEITraceSender.AEI_COLLECTOR_PATH, traceSender.getCollectorURI().toString());
     }
 
     @Test

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -37,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -50,9 +52,8 @@ public class ApplicationExitMonitor {
     protected final File reportsDir;
     protected final String packageName;
     protected final SessionMapper sessionMapper;
-
-    protected AEITraceReporter traceReporter;
-    protected ActivityManager am;
+    protected final ActivityManager am;
+    protected final AEITraceReporter traceReporter;
 
     public ApplicationExitMonitor(final Context context) {
         this.reportsDir = new File(context.getCacheDir(), "newrelic/applicationExitInfo");
@@ -62,20 +63,23 @@ public class ApplicationExitMonitor {
 
         reportsDir.mkdirs();
 
+        AEITraceReporter traceReporter = AEITraceReporter.getInstance();
         try {
-            this.traceReporter = AEITraceReporter.initialize(reportsDir, AgentConfiguration.getInstance());
+            traceReporter = AEITraceReporter.initialize(reportsDir, AgentConfiguration.getInstance());
             if (traceReporter != null) {
                 traceReporter.start();
-            }
-
-            if (!traceReporter.isStarted()) {
-                log.warn("ApplicationExitMonitor: No AEI trace reporter - AEITrace reporting will be disabled.");
+                if (!traceReporter.isStarted()) {
+                    log.warn("ApplicationExitMonitor: AEI trace reporter not started. AEITrace reporting will be disabled.");
+                }
+            } else {
+                log.warn("ApplicationExitMonitor: No AEI trace reporter. AEITrace reporting will be disabled.");
             }
 
         } catch (IOException e) {
             log.error("ApplicationExitMonitor: " + e);
         }
 
+        this.traceReporter = traceReporter;
     }
 
     // a gettor useful in mock tests
@@ -94,8 +98,9 @@ public class ApplicationExitMonitor {
         // Only supported in Android 11+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             boolean eventsAdded = false;
-            int recordsVisited = 0;
-            int recordsSkipped = 0;
+            AtomicInteger recordsVisited = new AtomicInteger(0);
+            AtomicInteger recordsSkipped = new AtomicInteger(0);
+            AtomicInteger recordsDropped = new AtomicInteger(0);
 
             if (null == am) {
                 log.error("harvestApplicationExitInfo: ActivityManager is null! Cannot record ApplicationExitInfo data.");
@@ -115,7 +120,7 @@ public class ApplicationExitMonitor {
                 if (artifact.exists() && (artifact.length() > 0)) {
                     log.debug("ApplicationExitMonitor: skipping exit info for pid[" +
                             exitInfo.getPid() + "]: already recorded.");
-                    recordsSkipped++;
+                    recordsSkipped.incrementAndGet();
                     continue;
                 }
 
@@ -123,6 +128,7 @@ public class ApplicationExitMonitor {
                 String aeiSessionId = sessionMapper.get(exitInfo.getPid());
                 if (aeiSessionId == null || aeiSessionId.isEmpty() || aeiSessionId.equals(AgentConfiguration.getInstance().getSessionID())) {
                     // found a prior session ID
+                    log.debug("ApplicationExitMonitor: Found session id [" + aeiSessionId + "] for AEI pid[" + exitInfo.getPid() + "]");
                 }
 
                 String traceReport = exitInfo.toString();
@@ -150,14 +156,16 @@ public class ApplicationExitMonitor {
                     artifactOs.close();
                     artifact.setReadOnly();
 
-                    recordsVisited++;
+                    recordsVisited.incrementAndGet();
 
                 } catch (IOException e) {
                     log.debug("harvestApplicationExitInfo: AppExitInfo artifact error. " + e);
                 }
 
                 if (aeiSessionId == null || aeiSessionId.isEmpty() || aeiSessionId.equals(AgentConfiguration.getInstance().getSessionID())) {
-                    // ??? continue;
+                    // No previous session ID found in cache. Can't do anything with the event, so drop it
+                    recordsDropped.incrementAndGet();
+                    continue;
                 }
 
                 // finally, emit an event for the record
@@ -170,10 +178,8 @@ public class ApplicationExitMonitor {
                 eventAttributes.put(AnalyticsAttribute.APP_EXIT_DESCRIPTION_ATTRIBUTE, toValidAttributeValue(exitInfo.getDescription()));
                 eventAttributes.put(AnalyticsAttribute.APP_EXIT_PROCESS_NAME_ATTRIBUTE, toValidAttributeValue(exitInfo.getProcessName()));
 
-                // try to map the AEI with the session it occurred in
-                if (!(aeiSessionId == null || aeiSessionId.isEmpty()) && !aeiSessionId.equals(AgentConfiguration.getInstance().getSessionID())) {
-                    eventAttributes.put(AnalyticsAttribute.APP_EXIT_SESSION_ID_ATTRIBUTE, aeiSessionId);
-                }
+                // map the AEI with the session it occurred in (will be translated later)
+                eventAttributes.put(AnalyticsAttribute.APP_EXIT_SESSION_ID_ATTRIBUTE, aeiSessionId);
 
                 // Add fg/bg flag based on inferred importance:
                 switch (exitInfo.getImportance()) {
@@ -199,11 +205,12 @@ public class ApplicationExitMonitor {
                 StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_EXIT_STATUS + exitInfo.getStatus());
                 StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_EXIT_BY_REASON + getReasonAsString(exitInfo.getReason()));
                 StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_EXIT_BY_IMPORTANCE + getImportanceAsString(exitInfo.getImportance()));
-                StatsEngine.SUPPORTABILITY.sample(MetricNames.SUPPORTABILITY_AEI_VISITED, recordsVisited);
-                StatsEngine.SUPPORTABILITY.sample(MetricNames.SUPPORTABILITY_AEI_SKIPPED, recordsSkipped);
+                StatsEngine.SUPPORTABILITY.sample(MetricNames.SUPPORTABILITY_AEI_VISITED, recordsVisited.get());
+                StatsEngine.SUPPORTABILITY.sample(MetricNames.SUPPORTABILITY_AEI_SKIPPED, recordsSkipped.get());
+                StatsEngine.SUPPORTABILITY.sample(MetricNames.SUPPORTABILITY_AEI_DROPPED, recordsSkipped.get());
             }
 
-            log.debug("AEI: inspected " + applicationExitInfoList.size() + " records: new[" + recordsVisited + "] existing [" + recordsSkipped + "]");
+            log.debug("AEI: inspected [" + applicationExitInfoList.size() + "] records: new[" + recordsVisited + "] existing [" + recordsSkipped + "] dropped[" + recordsDropped.get() + "]");
 
             if (eventsAdded) {
                 final EventManager eventMgr = AnalyticsControllerImpl.getInstance().getEventManager();
@@ -243,11 +250,11 @@ public class ApplicationExitMonitor {
     }
 
     @RequiresApi(api = Build.VERSION_CODES.R)
-    public List<Integer> getAEIPidSet(List<ApplicationExitInfo> applicationExitInfoList) {
+    public Set<Integer> currentPidSet(List<ApplicationExitInfo> applicationExitInfoList) {
         return applicationExitInfoList.stream()
                 .mapToInt(applicationExitInfo -> applicationExitInfo.getPid())
                 .boxed()
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -260,7 +267,7 @@ public class ApplicationExitMonitor {
     void reconcileMetadata(List<ApplicationExitInfo> applicationExitInfoList) {
         List<File> artifacts = getArtifacts();
         Pattern regexp = Pattern.compile(String.format(Locale.getDefault(), ARTIFACT_NAME, "(\\d+)"));
-        List<Integer> currentPids = getAEIPidSet(applicationExitInfoList);
+        Set<Integer> currentPids = currentPidSet(applicationExitInfoList);
 
         artifacts.forEach(aeiArtifact -> {
             Matcher matcher = regexp.matcher(aeiArtifact.getName());


### PR DESCRIPTION
Following the existing _store-and-forward_ pattern used by log reporting, add a new reporter and sender component to manage AEI trace uploads.  Traces are cached to disk, uploaded during harvest cycles and removed from disk once the upload is successful or has expired.