### PR TITLE
Allow set custom build id when variantMapsEnabled is false

### DIFF
--- a/instrumentation/src/main/java/com/newrelic/agent/util/BuildId.java
+++ b/instrumentation/src/main/java/com/newrelic/agent/util/BuildId.java
@@ -22,6 +22,7 @@ public class BuildId {
     private static AtomicReference<Map<String, String>> variantBuildIds = new AtomicReference<>(null);
     private static Logger log = InstrumentationAgent.LOGGER;
     private static boolean variantMapsEnabled = true;
+    private static String customBuildId = "";
 
     static {
         invalidate();
@@ -51,7 +52,11 @@ public class BuildId {
         String buildId = variantBuildIds.get().get(DEFAULT_VARIANT);
         if (Strings.isNullOrEmpty(buildId)) {
             // cache the value for later use, such as uploading maps after Dexguard
-            buildId = autoBuildId();
+            if (Strings.isNullOrEmpty(customBuildId)) {
+                buildId = autoBuildId();
+            } else {
+                buildId = customBuildId;
+            }
             variantBuildIds.get().put(DEFAULT_VARIANT, buildId);
         }
 
@@ -104,4 +109,10 @@ public class BuildId {
         log.debug("Variant buildIds have been " + (BuildId.variantMapsEnabled ? "enabled" : "disabled"));
     }
 
+    public static void setCustomBuildId(String customBuildId) {
+        if (!Strings.isNullOrEmpty(customBuildId) && !variantMapsEnabled) {
+            BuildId.customBuildId = customBuildId;
+            log.debug("Project's buildId has been set to " + BuildId.customBuildId);
+        }
+    }
 }

--- a/instrumentation/src/test/java/com/newrelic/agent/util/BuildIdTest.java
+++ b/instrumentation/src/test/java/com/newrelic/agent/util/BuildIdTest.java
@@ -75,6 +75,15 @@ public class BuildIdTest {
     }
 
     @Test
+    public void getCustomBuildIdVariantMapEnabled() {
+        String customBuildId = "test build id";
+        BuildId.setCustomBuildId(customBuildId);
+        String buildId = BuildId.getBuildId("variant");
+        Assert.assertNotNull(buildId);
+        Assert.assertNotEquals(buildId, customBuildId);
+    }
+
+    @Test
     public void disableVariantIds() {
         String buildId = BuildId.getDefaultBuildId();
         String variantBuildId = BuildId.getBuildId("variant");
@@ -85,5 +94,20 @@ public class BuildIdTest {
         buildId = BuildId.getDefaultBuildId();
         variantBuildId = BuildId.getBuildId("variant");
         Assert.assertEquals(buildId, variantBuildId);
+    }
+
+    @Test
+    public void getCustomBuildIdVariantMapDisabled() {
+
+        BuildId.setVariantMapsEnabled(false);
+        String customBuildId = "test build id";
+        BuildId.setCustomBuildId(customBuildId);
+
+        BuildId.invalidate();
+
+        String buildId = BuildId.getDefaultBuildId();
+        String variantBuildId = BuildId.getBuildId("variant");
+        Assert.assertEquals(buildId, variantBuildId);
+        Assert.assertEquals(buildId, customBuildId);
     }
 }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicExtension.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicExtension.groovy
@@ -31,6 +31,7 @@ abstract class NewRelicExtension {
     Property<Boolean> enabled
     Property<Boolean> instrumentTests
     Property<Boolean> variantMapsEnabled
+    Property<String> buildId
 
     NamedDomainObjectContainer<VariantConfiguration> variantConfigurations
 
@@ -52,6 +53,7 @@ abstract class NewRelicExtension {
         this.variantConfigurations = objectFactory.domainObjectContainer(VariantConfiguration, { name ->
             objectFactory.newInstance(VariantConfiguration.class, name)
         })
+        this.buildId = objectFactory.property(String.class).convention("")
     }
 
     boolean setEnabled(boolean state) {

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicGradlePlugin.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicGradlePlugin.groovy
@@ -54,6 +54,9 @@ class NewRelicGradlePlugin implements Plugin<Project> {
                     // set global enable flag
                     BuildId.setVariantMapsEnabled(pluginExtension.variantMapsEnabled.get())
 
+                    // set global build id
+                    BuildId.setCustomBuildId(pluginExtension.buildId.get())
+
                     logBuildMetrics()
 
                     try {

--- a/samples/agent-test-app/android.gradle
+++ b/samples/agent-test-app/android.gradle
@@ -112,6 +112,9 @@ if (project.applyPlugin && Boolean.valueOf(project.applyPlugin)) {
             // use a common buildId for all variants (default: true)
             variantMapsEnabled = true
 
+            // when variantMapsEnabled is false, set this for custom build id instead of UUID
+            buildId = "1234-5678-91011"
+
             // Tag and report Proguard/DexGuard maps for these build types:
             if (withProductFlavors && withProductFlavors.toBoolean()) {
                 uploadMapsForVariant 'googleQa', 'amazonQa'


### PR DESCRIPTION
Hi there,

Recently, we encountered a problem with integration with Shorebird CodePush, the reason is the BUILD_ID keep changing when we perform code patching.

This entails cleaning the Flutter project, causing the generate NewRelicConfig gradle task to be run and generate a new config with new BUILD_ID.

This is a problem for codepush, because changing in this generated file is considered native change.

Please refer to these issue for more information:

https://github.com/newrelic/newrelic-flutter-agent/issues/123
https://github.com/shorebirdtech/shorebird/issues/755

I have also filed a feature request ticket in newrelic support:  NR-334435

Nevertheless, this PR will allow for specify custom build id inside app/build.gradle file, along with original newrelic config.

Currently, in our Flutter app, I use it like this:

```
// app/build.gradle file

newrelic {
    variantMapsEnabled = false
    buildId = "${flutterVersionName}.${flutterVersionCode}"
}
```