### PR TITLE
[NR-340755] fix: checking network connection before sending AgentData…

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -10,7 +10,6 @@ import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.harvest.Harvest;
-import com.newrelic.agent.android.harvest.HarvestLifecycleAware;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.Payload;
 import com.newrelic.agent.android.payload.PayloadController;
@@ -107,16 +106,18 @@ public class AgentDataReporter extends PayloadReporter {
 
     // upload any cached agent data posts
     protected void reportCachedAgentData() {
-        if (isInitialized()) {
-            if (payloadStore != null) {
-                for (Payload payload : payloadStore.fetchAll()) {
-                    if (!isPayloadStale(payload)) {
-                        reportAgentData(payload);
+        if(Agent.hasReachableNetworkConnection(null)) {
+            if (isInitialized()) {
+                if (payloadStore != null) {
+                    for (Payload payload : payloadStore.fetchAll()) {
+                        if (!isPayloadStale(payload)) {
+                            reportAgentData(payload);
+                        }
                     }
                 }
+            } else {
+                log.error("AgentDataReporter not initialized");
             }
-        } else {
-            log.error("AgentDataReporter not initialized");
         }
     }
 


### PR DESCRIPTION
… to server.

The agent currently attempts to send data even when there is no internet connection, leading to memory issues if the app remains offline for an extended period. This update addresses the problem by preventing data transmission attempts without a network connection, thereby mitigating memory concerns.