### PR TITLE
Support Windows for external builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 /*
  * Copyright (c) 2022 - present. New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -106,7 +108,8 @@ project.afterEvaluate {
         group "test"
         workingDir rootProject.rootDir
         environment "M2_REPO", mavenLocal
-        commandLine "./gradlew", "-Pnewrelic.agent.version=$project.versions.agent", "publish"
+        def gradlew = Os.isFamily(Os.FAMILY_WINDOWS) ? "gradlew.bat" : "./gradlew"
+        commandLine gradlew, "-Pnewrelic.agent.version=$project.versions.agent", "publish"
     }
 
     project.tasks.register("integrationTest", Exec) {
@@ -115,7 +118,8 @@ project.afterEvaluate {
         group "test"
         workingDir "$rootProject.rootDir/samples/agent-test-app"
         environment "M2_REPO", mavenLocal
-        commandLine "./gradlew", "-Pnewrelic.agent.version=$project.versions.agent", "-PagentRepo=${mavenLocal}", "clean", "build"
+        def gradlew = Os.isFamily(Os.FAMILY_WINDOWS) ? "gradlew.bat" : "./gradlew"
+        commandLine gradlew, "-Pnewrelic.agent.version=$project.versions.agent", "-PagentRepo=${mavenLocal}", "clean", "build"
         enabled prepareIntegration.enabled
     }
 


### PR DESCRIPTION
Fixes

```
P:\projects\contrib\github-newrelic-android-agent>gradlew build
Picked up JAVA_TOOL_OPTIONS: -Xms32M -Xmx256M -D-XX:+UseG1GC -D-XX:+PrintCommandLineFlags
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.6/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build

> Configure project :instrumentation
[newrelic] [instrumentation] Recompiling [P:\projects\contrib\github-newrelic-android-agent\instrumentation\build/tmp/compileJava/src/main/java/com/newrelic/agent/InstrumentationAgent.java]
[newrelic] [instrumentation] Stamping [P:\projects\contrib\github-newrelic-android-agent\instrumentation\src\main\java/com/newrelic/agent/InstrumentationAgent.java] into [P:\projects\contrib\github-newrelic-android-agent\instrumentation\build/tmp/compileJava/src/main/java/com/newrelic/agent]
IncrementalTaskInputs has been deprecated. This is scheduled to be removed in Gradle 8.0. On method 'IncrementalTask.taskAction$gradle_core' use 'org.gradle.work.InputChanges' instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_7.html#incremental_task_inputs_deprecation
[newrelic] [agent-core] Version[7.6.2]
[newrelic] [agent-core] MonoEnabled[false]

> Task :prepareIntegration FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':prepareIntegration'.
> A problem occurred starting process 'command './gradlew''

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 26s
1 actionable task: 1 executed
```