### PR TITLE
Fix: Prevent PatternSyntaxException in LogReporter on Android 5.0/5.1 (API 21/22)

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -89,7 +89,7 @@ public class LogReporter extends PayloadReporter {
 
     static final String LOG_REPORTS_DIR = "newrelic/logReporting";      // root dir for local data files
     static final String LOG_FILE_MASK = "logdata%s.%s";                 // log data file name. suffix will indicate working state
-    static final Pattern LOG_FILE_REGEX = Pattern.compile("^(?<path>.*\\/" + LOG_REPORTS_DIR + ")\\/(?<file>logdata.*)\\.(?<extension>.*)$");
+    static final Pattern LOG_FILE_REGEX = Pattern.compile("^(.*\\/" + LOG_REPORTS_DIR + ")\\/(logdata.*)\\.(.*)$");
 
     static final AtomicReference<LogReporter> instance = new AtomicReference<>(null);
     static final ReentrantLock workingFileLock = new ReentrantLock();


### PR DESCRIPTION
### Problem:
On devices running Android 5.0 and 5.1 (API levels 21/22), a java.util.regex.PatternSyntaxException can occur during the initialization of the LogReporter class. This lead to application prevent the New Relic Agent from functioning correctly.
The relevant error stack trace is as follows:

```
E/newrelic(29268): Caused by: java.util.regex.PatternSyntaxException: Syntax error in regexp pattern near index 5:
E/newrelic(29268): ^(?<path>.*\/newrelic/logReporting)\/(?<file>logdata.*)\.(?<extension>.*)$
E/newrelic(29268):       ^
E/newrelic(29268):     at java.util.regex.Pattern.compileImpl(Native Method)
E/newrelic(29268):     at java.util.regex.Pattern.compile(Pattern.java:411)
E/newrelic(29268):     at java.util.regex.Pattern.<init>(Pattern.java:394)
E/newrelic(29268):     at java.util.regex.Pattern.compile(Pattern.java:381)
E/newrelic(29268):     at com.newrelic.agent.android.logging.LogReporter.<clinit>(LogReporter.java:37)
E/newrelic(29268):   ... 19 more
```

### Cause:
This exception is caused by the use of named capturing groups `((?<path>...), (?<file>...), (?<extension>...))` within the regular expression `LOG_FILE_REGEX` used in `LogReporter`.
The regular expression engine used in Android 5.0/5.1 does not support the named capturing group syntax `(?<name>)`.1 Consequently, the pattern compilation fails with a syntax error, throwing the PatternSyntaxException.

> `(?<name>X)	X`, as a named-capturing group. Only available for API 26 or above.
> https://developer.android.com/reference/java/util/regex/Pattern

### Solution:
Replace the named capturing groups `(?<name>...)` in LOG_FILE_REGEX with standard numbered (anonymous) capturing groups (...), which are supported across all Android versions.

### Rationale:
While API level 21 might not be officially supported, this issue prevents the agent from initializing correctly on these devices. This fix is straightforward, requires minimal code changes, and enables compatibility without significant refactoring. Furthermore, the affected code path appears to be covered by [unit tests](https://github.com/newrelic/newrelic-android-agent/blob/bd766bd46e39810b152d1741d08794c0b264bc80/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReporterTest.java#L325-L334), increasing confidence that this change won’t introduce regressions.