### PR TITLE
fix android build issue

### DIFF
--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -56,7 +56,7 @@ class DexGuardHelperTest extends PluginTest {
         buildHelper.variantAdapter.getVariantValues().each { variant ->
             def mapPath = dexGuardHelper.getMappingFileProvider(variant.name)
             Assert.assertNotNull(mapPath)
-            Assert.assertTrue(mapPath.getAsFile().get().getAbsolutePath().contains("/${variant.dirName}/"))
+            Assert.assertTrue(mapPath.getAsFile().get().getAbsolutePath().contains("/${variant.name}/"))
             if (dexGuardHelper.isDexGuard9()) {
                 Assert.assertTrue(mapPath.getAsFile().get().getAbsolutePath().contains("/dexguard/"))
             }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
@@ -95,7 +95,7 @@ class AGP4Adapter extends VariantAdapter {
         try {
             def buildConfigProvider = variant.getGenerateBuildConfigProvider()
             if (buildConfigProvider?.isPresent()) {
-                def genSrcFolder = buildHelper.project.layout.buildDirectory.dir("generated/source/newrelicConfig/${variant.dirName}")
+                def genSrcFolder = buildHelper.project.layout.buildDirectory.dir("generated/source/newrelicConfig/${variant.name}")
 
                 try {
                     variant.registerJavaGeneratingTask(configTaskProvider, genSrcFolder.get().asFile)
@@ -162,7 +162,7 @@ class AGP4Adapter extends VariantAdapter {
         if (variantConfiguration && variantConfiguration?.mappingFile) {
             def variantMappingFilePath = variantConfiguration.mappingFile.getAbsolutePath()
                     .replace("<name>", variant.name)
-                    .replace("<dirName>", variant.dirName)
+                    .replace("<dirName>", variant.name)
 
             return objectFactory.fileProperty().fileValue(buildHelper.project.file(variantMappingFilePath))
         }
@@ -177,7 +177,7 @@ class AGP4Adapter extends VariantAdapter {
         }
 
         // If all else fails, default to default map locations
-        def f = buildHelper.project.layout.buildDirectory.file("outputs/mapping/${variant.dirName}/mapping.txt")
+        def f = buildHelper.project.layout.buildDirectory.file("outputs/mapping/${variant.name}/mapping.txt")
         return objectFactory.fileProperty().value(f)
     }
 

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP70Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP70Adapter.groovy
@@ -104,7 +104,7 @@ class AGP70Adapter extends VariantAdapter {
         if (variantConfiguration && variantConfiguration.mappingFile) {
             def variantMappingFilePath = variantConfiguration.mappingFile.getAbsolutePath()
                     .replace("<name>", variant.name)
-                    .replace("<dirName>", variant.dirName)
+                    .replace("<dirName>", variant.name)
 
             return objectFactory.fileProperty().fileValue(buildHelper.project.file(variantMappingFilePath))
         }


### PR DESCRIPTION
android clean build command is failed because of variant dirname missing from the newer agp api.