### PR TITLE
NR-409074 Log ANRs Fix

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
@@ -14,7 +14,6 @@ import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.TaskQueue;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfiguration;
 import com.newrelic.agent.android.activity.config.ActivityTraceConfigurationDeserializer;
-import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.logging.AgentLog;
@@ -470,10 +469,10 @@ public class Harvester implements HarvestConfigurable {
 
     private void configureHarvester(final HarvestConfiguration newConfiguration) {
         harvestConfiguration.updateConfiguration(newConfiguration);
-        agentConfiguration.updateConfiguration(harvestConfiguration);
-        harvestData.updateConfiguration(harvestConfiguration);
+        agentConfiguration.updateConfiguration(newConfiguration);
+        harvestData.updateConfiguration(newConfiguration);
 
-        Harvest.setHarvestConfiguration(harvestConfiguration);
+        Harvest.setHarvestConfiguration(newConfiguration);
     }
 
     // Change states and mark that the state has been changed.

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -89,7 +89,7 @@ public class LogReporter extends PayloadReporter {
 
     static final String LOG_REPORTS_DIR = "newrelic/logReporting";      // root dir for local data files
     static final String LOG_FILE_MASK = "logdata%s.%s";                 // log data file name. suffix will indicate working state
-    static final Pattern LOG_FILE_REGEX = Pattern.compile("^(?<path>.*\\/" + LOG_REPORTS_DIR + ")\\/(?<file>logdata.*)\\.(?<extension>.*)$");
+    static final Pattern LOG_FILE_REGEX = Pattern.compile("^(.*\\/" + LOG_REPORTS_DIR + ")\\/(logdata.*)\\.(.*)$");
 
     static final AtomicReference<LogReporter> instance = new AtomicReference<>(null);
     static final ReentrantLock workingFileLock = new ReentrantLock();

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -516,7 +516,7 @@ public class LogReporter extends PayloadReporter {
      * This sweep should only be run once in a while.
      */
     Set<File> cleanup() {
-        Set<File> expiredFiles = getCachedLogReports(LogReportState.CLOSED);
+        Set<File> expiredFiles = getCachedLogReports(LogReportState.EXPIRED);
         expiredFiles.forEach(logReport -> {
             if (logReport.delete()) {
                 log.debug("LogReporter: Log data [" + logReport.getName() + "] removed.");

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -623,10 +623,8 @@ public class LogReporter extends PayloadReporter {
      */
     public void appendToWorkingLogfile(Map<String, Object> logDataMap) throws IOException {
         try {
-            String logJsonData = gson.toJson(logDataMap, gtype);
-
             workingFileLock.lock();
-
+            String logJsonData = gson.toJson(logDataMap, gtype);
             if (null != workingLogfileWriter.get()) {
                 workingLogfileWriter.get().append(logJsonData);
                 workingLogfileWriter.get().newLine();

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -437,9 +437,9 @@ public class LogReporter extends PayloadReporter {
     boolean safeDelete(File fileToDelete) {
         // Potential race condition here so rename the file rather than deleting it.
         // Expired files will be removed during an expiration sweep.
+        // 5/8/25 Delete expired file due to memory issues
         if (!isLogfileTypeOf(fileToDelete, LogReportState.EXPIRED)) {
-            fileToDelete.setReadOnly();
-            fileToDelete.renameTo(new File(fileToDelete.getAbsolutePath() + LogReportState.EXPIRED.asExtension()));
+            fileToDelete.delete();
         }
 
         return !fileToDelete.exists();
@@ -625,23 +625,6 @@ public class LogReporter extends PayloadReporter {
         });
 
         return expiredFiles;
-    }
-
-    /**
-     * Restore closed log files. This is for testing at the moment and will unlikely be included
-     * in GA, unless early adoption testing exposes a need for it.
-     *
-     * @return Set contain the File instance af call recovered log files.
-     */
-    Set<File> recover() {
-        Set<File> recoveredFiles = getCachedLogReports(LogReportState.EXPIRED);
-        recoveredFiles.forEach(logReport -> {
-            logReport.setWritable(true);
-            logReport.renameTo(new File(logReport.getAbsolutePath().replace(LogReportState.EXPIRED.asExtension(), "")));
-        });
-
-        return recoveredFiles;
-
     }
 
     /**

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -628,12 +628,6 @@ public class LogReporter extends PayloadReporter {
             workingFileLock.lock();
             String logJsonData = gson.toJson(logDataMap, gtype);
 
-            try {
-                JsonObject messageAsJson = LogReporter.gson.fromJson(logJsonData, JsonObject.class);
-            } catch (JsonSyntaxException e) {
-                log.error("Invalid Json entry skipped [" + logJsonData + "]");
-            }
-
             if (null != workingLogfileWriter.get()) {
                 workingLogfileWriter.get().append(logJsonData);
                 workingLogfileWriter.get().newLine();

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/RemoteLogger.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/RemoteLogger.java
@@ -6,10 +6,7 @@
 package com.newrelic.agent.android.logging;
 
 
-import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
-import com.newrelic.agent.android.ApplicationFramework;
-import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.harvest.HarvestLifecycleAware;
 import com.newrelic.agent.android.util.NamedThreadFactory;
 
@@ -20,14 +17,12 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 
 
 public class RemoteLogger implements HarvestLifecycleAware, Logger {
     static int POOL_SIZE = Math.max(2, Runtime.getRuntime().availableProcessors() / 4); // Buffer up this this number of requests
     static long QUEUE_THREAD_TTL = 1000;
     static MessageValidator validator = LogReporting.validator;
-    static final ReentrantLock workingFileLock = new ReentrantLock();
 
     // TODO enforce log message constraints
     static int MAX_ATTRIBUTES_PER_EVENT = 255;

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/RemoteLogger.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/RemoteLogger.java
@@ -112,8 +112,6 @@ public class RemoteLogger implements HarvestLifecycleAware, Logger {
         final LogReporter logReporter = LogReporter.getInstance();
 
         Callable<Boolean> callable = () -> {
-            final Map<String, Object> logDataMap = new HashMap<>();
-
             try {
                 /**
                  * Some specific attributes have additional restrictions:
@@ -128,7 +126,9 @@ public class RemoteLogger implements HarvestLifecycleAware, Logger {
                  *
                  * @link reserved attributes: https://source.datanerd.us/agents/agent-specs/blob/main/Application-Logging.md#log-record-attributes
                  */
-                workingFileLock.lock();
+
+                LogReporter.workingFileLock.lock();
+                final Map<String, Object> logDataMap = new HashMap<>();
                 logDataMap.put(LogReporting.LOG_TIMESTAMP_ATTRIBUTE, String.valueOf(System.currentTimeMillis()));
                 logDataMap.put(LogReporting.LOG_LEVEL_ATTRIBUTE, logLevel.name().toUpperCase());
 
@@ -160,7 +160,7 @@ public class RemoteLogger implements HarvestLifecycleAware, Logger {
                     logDataMap.put(LogReporting.LOG_ATTRIBUTES_ATTRIBUTE, attributes);
                 }
 
-                workingFileLock.unlock();
+                LogReporter.workingFileLock.unlock();
                 if (null == logReporter) {
                     return false;
                 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReporterTest.java
@@ -286,20 +286,6 @@ public class LogReporterTest extends LoggingTests {
     }
 
     @Test
-    public void recover() throws Exception {
-        seedLogData(3);
-
-        logReporter.getCachedLogReports(LogReporter.LogReportState.CLOSED).forEach(file -> logReporter.safeDelete(file));
-        Assert.assertTrue(logReporter.getCachedLogReports(LogReporter.LogReportState.CLOSED).isEmpty());
-
-        logReporter.getCachedLogReports(LogReporter.LogReportState.EXPIRED).forEach(file -> Assert.assertFalse(file.canWrite()));
-        Assert.assertEquals(3, logReporter.getCachedLogReports(LogReporter.LogReportState.EXPIRED).size());
-
-        logReporter.recover();
-        logReporter.getCachedLogReports(LogReporter.LogReportState.CLOSED).forEach(file -> Assert.assertTrue(file.canWrite()));
-    }
-
-    @Test
     public void expire() {
         Set<File> allFiles = logReporter.getCachedLogReports(LogReporter.LogReportState.CLOSED);
         allFiles.forEach(file -> Assert.assertTrue(file.setLastModified(System.currentTimeMillis() - TimeUnit.MILLISECONDS.convert(4, TimeUnit.DAYS))));

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/RemoteLoggerTest.java
@@ -366,7 +366,6 @@ public class RemoteLoggerTest extends LoggingTests {
             logReporter.resetWorkingLogfile();
             agentLog.warn("Run[" + testRun + "] File finalization[" + fileIOTimer.peek() + "] ms");
 
-            logReporter.expire(0);
             logReporter.cleanup();
             agentLog.warn("Run[" + testRun + "] File cleanup[" + fileIOTimer.toc() + "] ms");
 

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -892,6 +892,7 @@ public class AndroidAgentImpl implements
 
         if (FeatureFlag.featureEnabled(FeatureFlag.LogReporting)) {
             if (LogReporting.isRemoteLoggingEnabled()) {
+                startLogReporter(context, agentConfiguration);
                 StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_LOG_SAMPLED + agentConfiguration.getLogReportingConfiguration().isSampled());
             }
         }

--- a/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
+++ b/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
@@ -50,9 +50,11 @@ public class OfflineStorage {
                 setOfflineFilePath(offlineFile.getAbsolutePath());
             }
 
-            BufferedWriter buf = new BufferedWriter(new FileWriter(offlineFile, true));
+            FileWriter fw = new FileWriter(offlineFile, true);
+            BufferedWriter buf = new BufferedWriter(fw);
             buf.write(data);
             buf.close();
+            fw.close();
             isSaved = true;
         } catch (Exception e) {
             log.error("OfflineStorage: ", e);

--- a/agent/src/main/java/com/newrelic/agent/android/util/PersistentUUID.java
+++ b/agent/src/main/java/com/newrelic/agent/android/util/PersistentUUID.java
@@ -222,10 +222,15 @@ public class PersistentUUID {
     protected void putUUIDToFileStore(final String uuid) {
         JSONObject jsonObject = new JSONObject();
 
-        try (BufferedWriter out = new BufferedWriter(new FileWriter(UUID_FILE))) {
+
+        try {
+            FileWriter fw = new FileWriter(UUID_FILE);
+            BufferedWriter out = new BufferedWriter(fw);
             jsonObject.put(UUID_KEY, uuid);
             out.write(jsonObject.toString());
             out.flush();
+            out.close();
+            fw.close();
         } catch (Exception e) {
             log.error(e.getMessage());
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.6.6_LOGFIX
+newrelic.agent.version = 7.6.7
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.6.6
+newrelic.agent.version = 7.6.6_LOGFIX
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 


### PR DESCRIPTION
Ticket: [NR-409074](https://new-relic.atlassian.net/browse/NR-409074)

What's changed:
1. Log reporting files are backed up instead of deleting, could be the potential cause of ANRs, changing it to a deletion process.
2. We are only using two files at time to write into data and upload to the server.
3. Remove the size checking of 1MB because we are using gzip when uploading.
4. Added cleanup process onHarvestStart
5. Truncated messages issues: partially fixed, still need to fix the race condition issue on every harvest cycle with background reporting on/off.
6. Warning message: resources may not be closed? - this is our logwriter, we need to leave it open for log writing but will see how we can improve it.

[NR-409074]: https://new-relic.atlassian.net/browse/NR-409074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ