### PR TITLE
feat: ignore domains for network tracking (#1)

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -26,6 +26,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.List;
+import java.util.ArrayList;
 
 public class AgentConfiguration implements HarvestConfigurable {
     private static final AgentLog log = AgentLogManager.getAgentLog();
@@ -70,6 +72,7 @@ public class AgentConfiguration implements HarvestConfigurable {
     private String applicationFrameworkVersion = Agent.getVersion();
     private String deviceID;
     private String entityGuid;
+    private List<String> ignoredNetworkDomains = new ArrayList<>();
 
     // Support remote configuration for these features
     private LogReportingConfiguration logReportingConfiguration = new LogReportingConfiguration(false, LogLevel.INFO);
@@ -364,6 +367,14 @@ public class AgentConfiguration implements HarvestConfigurable {
 
     public void setLaunchActivityClassName(String launchActivityClassName) {
         this.launchActivityClassName = launchActivityClassName;
+    }
+
+    public List<String> getIgnoredNetworkDomains() {
+        return ignoredNetworkDomains;
+    }
+
+    public void setIgnoredNetworkDomains(List<String> ignoredDomains) {
+        this.ignoredNetworkDomains = ignoredDomains != null ? new ArrayList<>(ignoredDomains) : new ArrayList<>();
     }
 
     public LogReportingConfiguration getLogReportingConfiguration() {

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/NetworkEventController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/NetworkEventController.java
@@ -17,6 +17,12 @@ public class NetworkEventController {
     public static void createHttpErrorEvent(final HttpTransaction httpTransaction) {
 
         if (FeatureFlag.featureEnabled(FeatureFlag.NetworkErrorRequests)) {
+            // Check if the domain should be ignored
+            if (shouldIgnoreNetworkRequest(httpTransaction.getUrl())) {
+                log.debug("Ignoring network error event to filtered domain: " + httpTransaction.getUrl());
+                return;
+            }
+            
             if (!AnalyticsControllerImpl.getInstance().addEvent(NetworkRequestErrorEvent.createHttpErrorEvent(httpTransaction))) {
                 log.error("Failed to add " + AnalyticsEvent.EVENT_TYPE_MOBILE_REQUEST_ERROR);
             } else {
@@ -27,6 +33,12 @@ public class NetworkEventController {
 
     public static void createNetworkFailureEvent(final HttpTransaction httpTransaction) {
         if (FeatureFlag.featureEnabled(FeatureFlag.NetworkErrorRequests)) {
+            // Check if the domain should be ignored
+            if (shouldIgnoreNetworkRequest(httpTransaction.getUrl())) {
+                log.debug("Ignoring network failure event to filtered domain: " + httpTransaction.getUrl());
+                return;
+            }
+            
             if (!AnalyticsControllerImpl.getInstance().addEvent(NetworkRequestErrorEvent.createNetworkFailureEvent(httpTransaction))) {
                 log.error("Failed to add " + AnalyticsEvent.EVENT_TYPE_MOBILE_REQUEST_ERROR);
             } else {
@@ -37,6 +49,12 @@ public class NetworkEventController {
 
     public static void createNetworkRequestEvent(final HttpTransaction txn) {
         if (FeatureFlag.featureEnabled(FeatureFlag.NetworkRequests)) {
+            // Check if the domain should be ignored
+            if (shouldIgnoreNetworkRequest(txn.getUrl())) {
+                log.debug("Ignoring network request to filtered domain: " + txn.getUrl());
+                return;
+            }
+            
             if (!AnalyticsControllerImpl.getInstance().addEvent(NetworkRequestEvent.createNetworkEvent((txn)))) {
                 log.error("Failed to add " + AnalyticsEvent.EVENT_TYPE_MOBILE_REQUEST);
             } else {
@@ -47,5 +65,41 @@ public class NetworkEventController {
 
     protected NetworkEventController() {
 
+    }
+
+    /**
+     * Check if a network request URL should be ignored based on configured domain filters.
+     *
+     * @param url The URL to check
+     * @return true if the request should be ignored, false otherwise
+     */
+    private static boolean shouldIgnoreNetworkRequest(String url) {
+        if (url == null || url.isEmpty()) {
+            return false;
+        }
+
+        try {
+            java.net.URL urlObj = new java.net.URL(url);
+            String host = urlObj.getHost();
+            
+            if (host == null || host.isEmpty()) {
+                return false;
+            }
+
+            java.util.List<String> ignoredDomains = com.newrelic.agent.android.AgentConfiguration.getInstance().getIgnoredNetworkDomains();
+            
+            for (String ignoredDomain : ignoredDomains) {
+                if (ignoredDomain != null && !ignoredDomain.isEmpty()) {
+                    // Check exact match or subdomain match
+                    if (host.equals(ignoredDomain) || host.endsWith("." + ignoredDomain)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (java.net.MalformedURLException e) {
+            log.debug("Failed to parse URL for domain filtering: " + url);
+        }
+
+        return false;
     }
 }

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -273,6 +273,19 @@ public final class NewRelic {
     }
 
     /**
+     * Configure network domains to ignore during network request tracking.
+     * Network requests to these domains will not be tracked by the agent.
+     *
+     * @param ignoredDomains List of domain names to ignore (e.g., "example.com", "api.thirdparty.com")
+     */
+    public NewRelic withIgnoredNetworkDomains(List<String> ignoredDomains) {
+        StatsEngine.notice().inc(MetricNames.SUPPORTABILITY_API
+                .replace(MetricNames.TAG_NAME, "withIgnoredNetworkDomains"));
+        agentConfiguration.setIgnoredNetworkDomains(ignoredDomains);
+        return this;
+    }
+
+    /**
      * Starts the agent.  Be sure to call this, otherwise the agent won't do anything!
      *
      * @param context The application context


### PR DESCRIPTION
New Relic is capturing network calls from a third-party SDK, but I don't want to track them.

```
private val ignoredDomains = listOf(
        "rudderstack.com",
        "clevertap-prod.com",
        "adjust.com",
        "adjust.io",
        "app-analytics-services.com",
        "app-analytics-services-att.com",
        "googleapis.com",
        "google.com",
        "gstatic.com",
        "crashlytics.com",
        "app-ads-services.com",
        "cloudfront.net",
        "amazonaws.com",
        "b-cdn.net",
        "checkout.com",
        "tap.company",
        "unleash-hosted.com",
        "fpconfig.net"
    )

NewRelic.withApplicationToken("xyz")
            .withLoggingEnabled(true)
            .withApplicationVersion(appVersion)
            .withLogLevel(AgentLog.INFO)
            .withIgnoredNetworkDomains(ignoredDomains)
            .start(context);
```