### PR TITLE
[NR-300843]Fix: OkHttp3 Url updated by interceptors

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3Instrumentation.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3Instrumentation.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -46,6 +47,10 @@ public class OkHttp3Instrumentation {
     public static Call newCall(OkHttpClient client, Request request) {
         TransactionState transactionState = new TransactionState();
         addHeadersAsCustomAttribute(transactionState, request);
+        
+        // Create a new client with New Relic interceptor added after existing interceptors
+        OkHttpClient instrumentedClient = addNewRelicInterceptor(client, transactionState);
+        
         if (FeatureFlag.featureEnabled(FeatureFlag.DistributedTracing)) {
             try {
                 // start the trace with a new call
@@ -53,13 +58,13 @@ public class OkHttp3Instrumentation {
                 transactionState.setTrace(trace);
 
                 Request instrumentedRequest = OkHttp3TransactionStateUtil.setDistributedTraceHeaders(transactionState, request);
-                return new CallExtension(client, instrumentedRequest, client.newCall(instrumentedRequest), transactionState);
+                return new CallExtension(instrumentedClient, instrumentedRequest, instrumentedClient.newCall(instrumentedRequest), transactionState);
 
             } catch (Exception e) {
                 log.error(e.getMessage());
             }
         }
-        return new CallExtension(client, request, client.newCall(request), transactionState);
+        return new CallExtension(instrumentedClient, request, instrumentedClient.newCall(request), transactionState);
     }
 
     private static void addHeadersAsCustomAttribute(TransactionState transactionState, Request request) {
@@ -181,5 +186,56 @@ public class OkHttp3Instrumentation {
         log.error("Unable to resolve method \"" + signature + "\"." + crlf +
                 "This is usually due to building the app with unsupported OkHttp versions." + crlf +
                 "Check your build configuration for compatibility.");
+    }
+    
+    private static OkHttpClient addNewRelicInterceptor(OkHttpClient originalClient, TransactionState transactionState) {
+        try {
+            // Check if our interceptor is already added to avoid duplicates
+            for (okhttp3.Interceptor interceptor : originalClient.interceptors()) {
+                if (interceptor instanceof NewRelicInterceptor) {
+                    log.debug("New Relic interceptor already present");
+                    return originalClient;
+                }
+            }
+            
+            // Create new client builder from existing client
+            OkHttpClient.Builder builder = originalClient.newBuilder();
+            
+            // Add New Relic interceptor after existing application interceptors  and only if there are existing interceptors
+            if(!builder.interceptors().isEmpty()) {
+                builder.addInterceptor(new NewRelicInterceptor(transactionState));
+            }
+            
+            log.debug("Added New Relic interceptor after " + originalClient.interceptors().size() + " existing interceptors");
+            
+            return builder.build();
+        } catch (Exception e) {
+            log.error("Failed to add New Relic interceptor: " + e.getMessage());
+            return originalClient;
+        }
+    }
+
+    // New Relic interceptor class to capture URL changes and in future any such requests modifications
+    private static class NewRelicInterceptor implements okhttp3.Interceptor {
+        private final TransactionState transactionState;
+        
+        public NewRelicInterceptor(TransactionState transactionState) {
+            this.transactionState = transactionState;
+        }
+        
+        @Override
+        public Response intercept(Chain chain) throws java.io.IOException {
+            Request request = chain.request();
+            String finalUrl = request.url().toString();
+            
+            log.debug("New Relic interceptor capturing final URL: " + finalUrl);
+            
+            // Update transaction state with the final URL after all customer interceptors
+            if (transactionState != null) {
+                transactionState.setUrl(finalUrl);
+            }
+
+            return chain.proceed(request);
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.6.8
+newrelic.agent.version = 7.6.9-SNAPSHOT
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 

--- a/gradle/publishing_aar.gradle
+++ b/gradle/publishing_aar.gradle
@@ -18,7 +18,8 @@ publishing {
         libraryProject(MavenPublication) {
             groupId 'com.newrelic.agent.android'
             version project.versions.agent
-
+            artifact javadocJar
+            artifact sourcesJar
             pom {
                 name = 'com.newrelic.agent.android'
                 description = 'The New Relic Android Agent provides run time performance monitoring for Android applications'


### PR DESCRIPTION
When OkHttp3 interceptors modify the request URL, the New Relic Android agent now correctly reports the final, modified URL. This is achieved by adding a New Relic interceptor after all existing client interceptors. This interceptor captures the final URL from the request chain and updates the transaction state accordingly.