### PR TITLE
[NR-485690] Add NR API for jetpack compose testTag

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -1418,4 +1418,37 @@ public final class NewRelic {
         return false;
     }
 
+    /**
+     * Adds a Jetpack Compose testTag to be masked during session replay.
+     * All Composables with the specified testTag will have their text content masked.
+     * <p>
+     * Example: In Compose, use `Modifier.testTag("sensitive_user_data")`.
+     * Then call `NewRelic.addSessionReplayMaskComposeTestTag("sensitive_user_data")`.
+     *
+     * @param testTag The testTag value used in `Modifier.testTag()` to mask.
+     * @return true if the testTag was successfully added to the mask list.
+     */
+    public static boolean addSessionReplayMaskComposeTestTag(String testTag) {
+        StatsEngine.notice().inc(MetricNames.SUPPORTABILITY_API
+                .replace(MetricNames.TAG_NAME, "addSessionReplayMaskComposeTestTag"));
+        // Under the hood, a testTag is implemented as a view tag, so we can reuse the existing logic.
+        return addSessionReplayMaskViewTag(testTag);
+    }
+
+    /**
+     * Adds a Jetpack Compose testTag to be explicitly unmasked during session replay.
+     * This is useful for excluding specific Composables from a broader masking rule.
+     * <p>
+     * Example: In Compose, use `Modifier.testTag("public_info")`.
+     * Then call `NewRelic.addSessionReplayUnmaskComposeTestTag("public_info")`.
+     *
+     * @param testTag The testTag value used in `Modifier.testTag()` to unmask.
+     * @return true if the testTag was successfully added to the unmask list.
+     */
+    public static boolean addSessionReplayUnmaskComposeTestTag(String testTag) {
+        StatsEngine.notice().inc(MetricNames.SUPPORTABILITY_API
+                .replace(MetricNames.TAG_NAME, "addSessionReplayUnmaskComposeTestTag"));
+        // Reusing the existing view tag logic for unmasking.
+        return addSessionReplayUnmaskViewTag(testTag);
+    }
 }

--- a/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
@@ -1527,4 +1527,40 @@ public class NewRelicTest {
                 .findFirst()
                 .orElse(null);
     }
+
+    @Test
+    public void testAddSessionReplayMaskComposeTestTag() {
+        final String testTag = "sensitive_compose_view";
+        Assert.assertTrue(NewRelic.addSessionReplayMaskComposeTestTag(testTag));
+
+        // Verify the tag was added to the configuration
+        Assert.assertTrue(agentConfiguration
+                .getSessionReplayLocalConfiguration()
+                .getMaskedViewTags()
+                .contains(testTag));
+    }
+
+    @Test
+    public void testAddSessionReplayUnmaskComposeTestTag() {
+        final String testTag = "public_compose_view";
+        Assert.assertTrue(NewRelic.addSessionReplayUnmaskComposeTestTag(testTag));
+
+        // Verify the tag was added to the unmask configuration
+        Assert.assertTrue(agentConfiguration
+                .getSessionReplayLocalConfiguration()
+                .getUnmaskedViewTags()
+                .contains(testTag));
+    }
+
+    @Test
+    public void testAddSessionReplayMaskComposeTestTagWithInvalidInput() {
+        Assert.assertFalse(NewRelic.addSessionReplayMaskComposeTestTag(null));
+        Assert.assertFalse(NewRelic.addSessionReplayMaskComposeTestTag(""));
+    }
+
+    @Test
+    public void testAddSessionReplayUnmaskComposeTestTagWithInvalidInput() {
+        Assert.assertFalse(NewRelic.addSessionReplayUnmaskComposeTestTag(null));
+        Assert.assertFalse(NewRelic.addSessionReplayUnmaskComposeTestTag(""));
+    }
 }


### PR DESCRIPTION
Ticket: https://new-relic.atlassian.net/browse/NR-485690

What's changed:
1. Add two new NR API specifically for the usage of masking/unmasking jetpack compose testTag modifiers
2. All the underlying remote and local configuration can be reused based on the exiting functionalities
3. Add unit tests