### PR TITLE
fix: serialize data-nr-masked as top-level rrweb attribute

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplayImageViewThingy.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplayImageViewThingy.java
@@ -281,7 +281,7 @@ public class SessionReplayImageViewThingy implements SessionReplayViewThingyInte
     public RRWebElementNode generateRRWebNode() {
         Attributes attributes = new Attributes(viewDetails.getCssSelector());
         if (isMasked) {
-            attributes.getMetadata().put("data-nr-masked", "image");
+            attributes.dataNrMasked = "image";
         }
         return new RRWebElementNode(attributes, RRWebElementNode.TAG_TYPE_DIV, viewDetails.getViewId(), new ArrayList<>());
     }
@@ -311,15 +311,15 @@ public class SessionReplayImageViewThingy implements SessionReplayViewThingyInte
             styleDifferences.put("background-image"," url(" + ((SessionReplayImageViewThingy) other).getImageDataUrl() + ")");
         }
 
-        SessionReplayImageViewThingy otherImage = (SessionReplayImageViewThingy) other;
-        if (otherImage.isMasked) {
-            styleDifferences.put("data-nr-masked", "image");
-        } else if (this.isMasked) {
-            styleDifferences.put("data-nr-masked", "");
-        }
-
         Attributes attributes = new Attributes(viewDetails.getCSSSelector());
         attributes.setMetadata(styleDifferences);
+
+        SessionReplayImageViewThingy otherImage = (SessionReplayImageViewThingy) other;
+        if (otherImage.isMasked) {
+            attributes.dataNrMasked = "image";
+        } else if (this.isMasked) {
+            attributes.dataNrMasked = "";
+        }
         List<MutationRecord> mutations = new ArrayList<>();
         mutations.add(new RRWebMutationData.AttributeRecord(viewDetails.getViewId(), attributes));
         return mutations;

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/models/Attributes.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/models/Attributes.java
@@ -12,6 +12,7 @@ public class Attributes{
     public String inputType;
     public String value;
     public Boolean checked;
+    public String dataNrMasked;
     public Map<String, String> metadata = new HashMap<>();
 
     public Map<String, String> getMetadata() {

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/models/AttributesSerializer.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/models/AttributesSerializer.java
@@ -25,7 +25,7 @@ public class AttributesSerializer implements JsonSerializer<Attributes> {
                 // Handle style separately - add it as a nested object
                 jsonObject.addProperty(entry.getKey(), entry.getValue());
             } else {
-                // Add all other metadata entries directly to the root JSON object
+                // All other metadata entries become inline style properties
                 metadataObject.addProperty(entry.getKey(), entry.getValue());
             }
         }
@@ -49,6 +49,9 @@ public class AttributesSerializer implements JsonSerializer<Attributes> {
         }
         if (src.checked != null && src.checked) {
             jsonObject.addProperty("checked", true);
+        }
+        if (src.dataNrMasked != null) {
+            jsonObject.addProperty("data-nr-masked", src.dataNrMasked);
         }
 
         return jsonObject;

--- a/agent/src/main/kotlin/com/newrelic/agent/android/sessionReplay/compose/ComposeImageThingy.kt
+++ b/agent/src/main/kotlin/com/newrelic/agent/android/sessionReplay/compose/ComposeImageThingy.kt
@@ -463,7 +463,7 @@ open class ComposeImageThingy(
     override fun generateRRWebNode(): RRWebElementNode {
         val attributes = Attributes(viewDetails.cssSelector)
         if (isMasked) {
-            attributes.metadata["data-nr-masked"] = "image"
+            attributes.dataNrMasked = "image"
         }
         return RRWebElementNode(
             attributes,
@@ -505,18 +505,18 @@ open class ComposeImageThingy(
             )
         }
 
-        if (other.isMasked) {
-            styleDifferences["data-nr-masked"] = "image"
-        } else if (this.isMasked) {
-            styleDifferences["data-nr-masked"] = ""
-        }
-
-        if (styleDifferences.isEmpty()) {
+        if (styleDifferences.isEmpty() && other.isMasked == this.isMasked) {
             return emptyList()
         }
 
         val attributes = Attributes(viewDetails.cssSelector)
         attributes.metadata = styleDifferences
+
+        if (other.isMasked) {
+            attributes.dataNrMasked = "image"
+        } else if (this.isMasked) {
+            attributes.dataNrMasked = ""
+        }
         return listOf(RRWebMutationData.AttributeRecord(viewDetails.viewId, attributes))
     }
 


### PR DESCRIPTION
## [NR-529779](https://new-relic.atlassian.net/browse/NR-529779)

fix: serialize data-nr-masked as top-level rrweb attribute

## What & Why

The `data-nr-masked` attribute (added in NR-533692) was being placed inside the rrweb
node's `style` object via the metadata map. During replay, rrweb applies style properties
via `element.style.setProperty()`, and the browser silently drops `data-nr-masked` as an
invalid CSS property — making it invisible to the player plugin.

This fix adds a dedicated `dataNrMasked` field on `Attributes` and serializes it as a
top-level attribute in `AttributesSerializer`, so rrweb applies it via `setAttribute()`
and the player plugin can detect it with `element.getAttribute('data-nr-masked')`.

## Callouts

- Affects both `SessionReplayImageViewThingy` (traditional views) and `ComposeImageThingy` (Compose)
- Both full snapshot and incremental mutation paths are updated

## Test plan

- Verified via rrweb-live-streaming that `data-nr-masked` appears as a top-level attribute
  in the rrweb JSON (not nested inside `style`)
- Verified on-device replay data files contain `"data-nr-masked":"image"` at the attribute level
- Player plugin successfully detects and replaces masked images in NR1 staging

[NR-529779]: https://new-relic.atlassian.net/browse/NR-529779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ