### PR TITLE
[NR-538746]feat(logging): Coordinate log sampling with Session Replay

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporter.java
@@ -138,7 +138,7 @@ public class LogReporter extends PayloadReporter {
 
     public LogReporter(AgentConfiguration agentConfiguration) {
         super(agentConfiguration);
-        setEnabled((agentConfiguration.getLogReportingConfiguration().getLoggingEnabled()));
+        setEnabled((agentConfiguration.getLogReportingConfiguration().getLoggingEnabledAndSessionSampled()));
         try {
             resetWorkingLogfile();
         } catch (IOException e) {
@@ -231,7 +231,7 @@ public class LogReporter extends PayloadReporter {
     @Override
     public void onHarvestConfigurationChanged() {
         //  Some aspect of logging configuration has changed. Update model...
-        setEnabled(agentConfiguration.getLogReportingConfiguration().getLoggingEnabled());
+        setEnabled(agentConfiguration.getLogReportingConfiguration().getLoggingEnabledAndSessionSampled());
 
         if (agentConfiguration.getLogReportingConfiguration().getExpirationPeriod() != reportTTL) {
             reportTTL = Math.max(agentConfiguration.getLogReportingConfiguration().getExpirationPeriod(),

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReportingConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReportingConfiguration.java
@@ -16,6 +16,13 @@ public class LogReportingConfiguration extends LoggingConfiguration {
      */
     static Double sampleSeed = 100.000000;
 
+    /**
+     * When true, isSampled() returns true regardless of seed/rate.
+     * Set by sampling coordination when Session Replay is active and logging is globally enabled.
+     * This is a runtime-only flag — not serialized from server config.
+     */
+    volatile boolean samplingOverride = false;
+
     static final long DEFAULT_HARVEST_PERIOD = TimeUnit.SECONDS.convert(30, TimeUnit.SECONDS);
     static final long DEFAULT_EXPIRATION_PERIOD = TimeUnit.SECONDS.convert(2, TimeUnit.DAYS);
 
@@ -85,6 +92,10 @@ public class LogReportingConfiguration extends LoggingConfiguration {
      */
     @Override
     public boolean getLoggingEnabled() {
+        return enabled;
+    }
+
+    public boolean getLoggingEnabledAndSessionSampled() {
         return enabled && isSampled();
     }
 
@@ -92,7 +103,22 @@ public class LogReportingConfiguration extends LoggingConfiguration {
      * @return true if the generated sample seed is less than or equal to the configured sampling rate
      */
     public boolean isSampled() {
-        return sampleSeed <= sampleRate;
+        return samplingOverride || sampleSeed <= sampleRate;
+    }
+
+    /**
+     * Enable or disable the sampling override. When enabled, isSampled() returns true
+     * regardless of seed/rate. Used by SR-to-Log coordination.
+     */
+    public void setSamplingOverride(boolean override) {
+        this.samplingOverride = override;
+    }
+
+    /**
+     * @return true if the sampling override is currently active
+     */
+    public boolean isSamplingOverridden() {
+        return samplingOverride;
     }
 
     /**

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -87,6 +87,7 @@ public class MetricNames {
     public static final String SUPPORTABILITY_LOG_UNCOMPRESSED = SUPPORTABILITY_LOG_REPORTING + "Size/Uncompressed";
     public static final String SUPPORTABILITY_LOG_EXPIRED = SUPPORTABILITY_LOG_REPORTING + "Expired";
     public static final String SUPPORTABILITY_LOG_SAMPLED = SUPPORTABILITY_LOG_REPORTING + "Sampled/";
+    public static final String SUPPORTABILITY_LOG_SAMPLING_OVERRIDE = SUPPORTABILITY_LOG_REPORTING + "SamplingOverride";
 
 
     public static final String SUPPORTABILITY_AEI = SUPPORTABILITY_AGENT + "ApplicationExitInfo/";

--- a/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingConfigurationTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/logging/LogReportingConfigurationTest.java
@@ -95,13 +95,13 @@ public class LogReportingConfigurationTest {
         LogReportingConfiguration config = new LogReportingConfiguration(true, LogLevel.VERBOSE, 15, 3600, 33);
 
         LogReportingConfiguration.sampleSeed = 10.0;
-        Assert.assertTrue(config.getLoggingEnabled());
+        Assert.assertTrue(config.getLoggingEnabledAndSessionSampled());
 
         LogReportingConfiguration.sampleSeed = 100.0;
-        Assert.assertFalse(config.getLoggingEnabled());
+        Assert.assertFalse(config.getLoggingEnabledAndSessionSampled());
 
         config.enabled = false;
-        Assert.assertFalse(config.getLoggingEnabled());
+        Assert.assertFalse(config.getLoggingEnabledAndSessionSampled());
     }
 
     @Test
@@ -178,5 +178,66 @@ public class LogReportingConfigurationTest {
         Assert.assertEquals(localConfiguration, localConfiguration);
         Assert.assertNotEquals(remoteConfig, localConfiguration);
 
+    }
+
+    @Test
+    public void testSamplingOverride_isSampledReturnsTrueWhenOverrideSet() {
+        // Config with 0% sample rate — normally not sampled
+        LogReportingConfiguration config = new LogReportingConfiguration(true, LogLevel.DEBUG, 30, 3600, 0);
+        LogReportingConfiguration.sampleSeed = 50.0;
+
+        Assert.assertFalse("Should not be sampled without override", config.isSampled());
+
+        config.setSamplingOverride(true);
+        Assert.assertTrue("Should be sampled with override", config.isSampled());
+        Assert.assertTrue("isSamplingOverridden should return true", config.isSamplingOverridden());
+    }
+
+    @Test
+    public void testSamplingOverride_getLoggingEnabledAndSessionSampledRespectsOverride() {
+        LogReportingConfiguration config = new LogReportingConfiguration(true, LogLevel.DEBUG, 30, 3600, 0);
+        LogReportingConfiguration.sampleSeed = 50.0;
+
+        Assert.assertFalse("Logging+sampling should be disabled (not sampled)", config.getLoggingEnabledAndSessionSampled());
+
+        config.setSamplingOverride(true);
+        Assert.assertTrue("Logging+sampling should be enabled (override active)", config.getLoggingEnabledAndSessionSampled());
+    }
+
+    @Test
+    public void testSamplingOverride_clearOverrideRestoresNormalBehavior() {
+        LogReportingConfiguration config = new LogReportingConfiguration(true, LogLevel.DEBUG, 30, 3600, 0);
+        LogReportingConfiguration.sampleSeed = 50.0;
+
+        config.setSamplingOverride(true);
+        Assert.assertTrue(config.isSampled());
+
+        config.setSamplingOverride(false);
+        Assert.assertFalse("Should revert to normal sampling after override cleared", config.isSampled());
+        Assert.assertFalse(config.isSamplingOverridden());
+    }
+
+    @Test
+    public void testSamplingOverride_setConfigurationDoesNotCopyOverride() {
+        LogReportingConfiguration source = new LogReportingConfiguration(true, LogLevel.DEBUG, 30, 3600, 50);
+        source.setSamplingOverride(true);
+
+        LogReportingConfiguration target = new LogReportingConfiguration(true, LogLevel.DEBUG, 30, 3600, 0);
+        LogReportingConfiguration.sampleSeed = 100.0;
+        target.setConfiguration(source);
+
+        Assert.assertFalse("Override should not be copied via setConfiguration", target.isSamplingOverridden());
+    }
+
+    @Test
+    public void testSamplingOverride_normalSamplingStillWorksWithoutOverride() {
+        LogReportingConfiguration config = new LogReportingConfiguration(true, LogLevel.DEBUG, 30, 3600, 75);
+
+        LogReportingConfiguration.sampleSeed = 50.0;
+        Assert.assertTrue("Should be sampled: seed 50 <= rate 75", config.isSampled());
+        Assert.assertFalse("Override should not be set", config.isSamplingOverridden());
+
+        LogReportingConfiguration.sampleSeed = 80.0;
+        Assert.assertFalse("Should not be sampled: seed 80 > rate 75", config.isSampled());
     }
 }

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -110,6 +110,9 @@ public class AndroidAgentImpl implements
 
     private static final AgentLog log = AgentLogManager.getAgentLog();
 
+    // Stored for use by static API methods (recordReplay → log activation)
+    private static Context savedContext;
+
     private final Context context;
     private SavedState savedState;
 
@@ -179,7 +182,7 @@ public class AndroidAgentImpl implements
     private static void startLogReporter(Context context, AgentConfiguration agentConfiguration) {
             LogReportingConfiguration logReportingConfiguration = agentConfiguration.getLogReportingConfiguration();
             LogReportingConfiguration.reseed();
-             if (logReportingConfiguration.getLoggingEnabled() ) {
+             if (logReportingConfiguration.isSampled()) {
                 try {
                     /*
                        LogReports are stored in the apps cache directory, rather than the persistent files directory. The o/s _may_
@@ -215,8 +218,8 @@ public class AndroidAgentImpl implements
         Harvest.setHarvestConnectInformation(savedState.getConnectInformation());
         Harvest.addHarvestListener(this);
 
-        startLogReporter(context, agentConfiguration);
-        startSessionReplayRecorder(context, agentConfiguration);
+        savedContext = context.getApplicationContext();
+        initializeFeaturesWithCoordination(context, agentConfiguration);
         Measurements.initialize();
         log.info(MessageFormat.format("New Relic Agent v{0}", Agent.getVersion()));
         log.verbose(MessageFormat.format("Application token: {0}", agentConfiguration.getApplicationToken()));
@@ -252,6 +255,8 @@ public class AndroidAgentImpl implements
         //Don't preserve the previous session state!
         TraceMachine.clearActivityHistory();
         agentConfiguration.provideSessionId();
+        // Clear sampling override from previous session; will be re-evaluated during feature init
+        agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
     }
 
     protected void finalizeSession() {
@@ -728,6 +733,7 @@ public class AndroidAgentImpl implements
                 SessionReplayModeManager.getInstance().transitionTo(SessionReplayMode.FULL, "APIRecordReplay");
                 SessionReplay.initSessionReplay(SessionReplayMode.FULL);
                 AnalyticsControllerImpl.getInstance().setAttribute(AnalyticsAttribute.SESSION_REPLAY_ENABLED, true);
+                activateLoggingForSessionReplay();
                 log.info("recordReplay: SessionReplay initialized in FULL mode");
                 return true;
             } catch (Exception e) {
@@ -741,6 +747,7 @@ public class AndroidAgentImpl implements
             case FULL:
                 // Already in FULL mode, idempotent success
                 log.debug("recordReplay: Already recording in FULL mode");
+                activateLoggingForSessionReplay();
                 return true;
 
             case ERROR:
@@ -748,6 +755,7 @@ public class AndroidAgentImpl implements
                 boolean modeChanged = SessionReplay.switchModeOnError();
                 if (modeChanged) {
                     AnalyticsControllerImpl.getInstance().setAttribute(AnalyticsAttribute.SESSION_REPLAY_ENABLED, true);
+                    activateLoggingForSessionReplay();
                     log.info("recordReplay: Transitioned from ERROR to FULL mode");
                     return true;
                 } else {
@@ -770,26 +778,98 @@ public class AndroidAgentImpl implements
     }
 
 
-    private static void startSessionReplayRecorder(Context context, AgentConfiguration agentConfiguration) {
+    /**
+     * Coordinates initialization of Session Replay and Remote Logging.
+     * SR sampling is evaluated first; if SR is active and logging is globally enabled,
+     * the logging sampling override is set so logs are captured even if not independently sampled.
+     */
+    private static void initializeFeaturesWithCoordination(Context context, AgentConfiguration agentConfiguration) {
+        // 1. Determine SR sampling first
+        SessionReplayConfiguration srConfig = agentConfiguration.getSessionReplayConfiguration();
+        SessionReplayConfiguration.reseed();
+        SessionReplayMode srMode = srConfig.isEnabled() ? determineRecordingMode(srConfig) : SessionReplayMode.OFF;
 
+        // 2. Apply SR-to-Log override if SR is active and logging is globally enabled
+        if (agentConfiguration.getLogReportingConfiguration().getLoggingEnabled()) {
+            applyLoggingOverrideIfNeeded(srMode, agentConfiguration);
+            // 3. Start logging (respects override via isSampled())
+            startLogReporter(context, agentConfiguration);
+        }
+
+        // 4. Start SR with pre-computed mode (skip reseed)
+        startSessionReplayRecorderWithMode(context, agentConfiguration, srConfig, srMode);
+    }
+
+    /**
+     * Sets the logging sampling override when SR is active and logging is globally enabled.
+     */
+    private static void applyLoggingOverrideIfNeeded(SessionReplayMode srMode, AgentConfiguration agentConfiguration) {
+        if (srMode == SessionReplayMode.FULL) {
+            LogReportingConfiguration logConfig = agentConfiguration.getLogReportingConfiguration();
+            if (logConfig.getLogLevel() != LogLevel.NONE) {
+                logConfig.setSamplingOverride(true);
+                StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_LOG_SAMPLING_OVERRIDE);
+                log.debug("Sampling coordination: SR FULL mode active, overriding log sampling");
+            }
+        }
+    }
+
+    /**
+     * Re-evaluates the logging sampling override after SR has been reseeded (e.g., on harvest connect).
+     * Sets override if SR is now FULL; clears it if SR is no longer FULL.
+     */
+    private static void reconcileLoggingOverride(SessionReplayMode srMode, AgentConfiguration agentConfiguration) {
+        LogReportingConfiguration logConfig = agentConfiguration.getLogReportingConfiguration();
+        if (srMode == SessionReplayMode.FULL) {
+            applyLoggingOverrideIfNeeded(srMode, agentConfiguration);
+        } else if (logConfig.isSamplingOverridden()) {
+            logConfig.setSamplingOverride(false);
+            log.debug("Sampling coordination: SR no longer FULL after reseed, clearing log sampling override");
+        }
+    }
+
+    /**
+     * Activates logging when SR transitions to FULL mode (via API or error detection).
+     * Called from recordReplay() and SessionReplay.onError() (ERROR→FULL transition).
+     */
+    public static void activateLoggingForSessionReplay() {
+        LogReportingConfiguration logConfig = AgentConfiguration.getInstance().getLogReportingConfiguration();
+        if (logConfig.getLoggingEnabled()
+                && logConfig.getLogLevel() != LogLevel.NONE) {
+            if (!logConfig.isSamplingOverridden()) {
+                logConfig.setSamplingOverride(true);
+                StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_LOG_SAMPLING_OVERRIDE);
+                log.debug("Sampling coordination: SR API activated, overriding log sampling");
+            }
+            if (!LogReporting.isInitialized() && savedContext != null) {
+                startLogReporter(savedContext, AgentConfiguration.getInstance());
+            }
+        }
+    }
+
+    private static void startSessionReplayRecorder(Context context, AgentConfiguration agentConfiguration) {
         SessionReplayConfiguration.reseed();
         SessionReplayConfiguration sessionReplayConfiguration = agentConfiguration.getSessionReplayConfiguration();
+        SessionReplayMode mode = sessionReplayConfiguration.isEnabled()
+                ? determineRecordingMode(sessionReplayConfiguration) : SessionReplayMode.OFF;
+        startSessionReplayRecorderWithMode(context, agentConfiguration, sessionReplayConfiguration, mode);
+    }
+
+    private static void startSessionReplayRecorderWithMode(Context context, AgentConfiguration agentConfiguration,
+                                                           SessionReplayConfiguration sessionReplayConfiguration,
+                                                           SessionReplayMode mode) {
         if(sessionReplayConfiguration.isEnabled()) {
-            // only process masking rules if session replay is enabled
             sessionReplayConfiguration.processCustomMaskingRules();
             AnalyticsControllerImpl.getInstance().setAttribute(AnalyticsAttribute.SESSION_REPLAY_ENABLED, true);
             Handler uiHandler = new Handler(Looper.getMainLooper());
-            SessionReplayMode mode = determineRecordingMode(sessionReplayConfiguration);
             SessionReplay.initialize(((Application) context.getApplicationContext()), uiHandler, agentConfiguration, mode);
-            // Determine the recording mode based on sampling configuration
 
             if(mode != SessionReplayMode.OFF) {
                 SessionReplay.initSessionReplay(mode);
             }
-        } else
-            // if the session replay is not enabled, remove the attribute from the previous session
+        } else {
             AnalyticsControllerImpl.getInstance().removeAttribute(AnalyticsAttribute.SESSION_REPLAY_ENABLED);
-
+        }
     }
 
     /**
@@ -859,7 +939,9 @@ public class AndroidAgentImpl implements
         // BackgroundReporting
         if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting)) {
             start();
-            startLogReporter(context, agentConfiguration);
+            if (agentConfiguration.getLogReportingConfiguration().getLoggingEnabled()) {
+                startLogReporter(context, agentConfiguration);
+            }
             AnalyticsControllerImpl.getInstance().addAttributeUnchecked(new AnalyticsAttribute(AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME,true), false);
         }
     }
@@ -1051,8 +1133,12 @@ public class AndroidAgentImpl implements
             }
         }
 
-        if(agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+        if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
             startSessionReplayRecorder(context, agentConfiguration);
+
+            // Re-coordinate logging override after SR reseed — mode may have changed
+            SessionReplayMode currentSrMode = SessionReplay.getCurrentMode();
+            reconcileLoggingOverride(currentSrMode, agentConfiguration);
         }
 
         if (FeatureFlag.featureEnabled(FeatureFlag.LogReporting)) {

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -1049,6 +1049,7 @@ public final class NewRelic {
 
         // Notify SessionReplay about the error for mode switching (if enabled)
         if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            AndroidAgentImpl.activateLoggingForSessionReplay();
             SessionReplay.onError();
         }
 
@@ -1180,6 +1181,7 @@ public final class NewRelic {
                 .replace(MetricNames.TAG_STATE, LogLevel.ERROR.name()));
 
         if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            AndroidAgentImpl.activateLoggingForSessionReplay();
             SessionReplay.onError();
         }
         LogReporting.getLogger().log(LogLevel.ERROR, message);
@@ -1197,6 +1199,7 @@ public final class NewRelic {
                 .replace(MetricNames.TAG_STATE, logLevel.name()));
 
         if (logLevel.equals(LogLevel.ERROR) && agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            AndroidAgentImpl.activateLoggingForSessionReplay();
             SessionReplay.onError();
         }
         if (LogReporting.isLevelEnabled(logLevel)) {


### PR DESCRIPTION
This commit introduces a sampling override mechanism for log reporting to ensure logs are captured when Session Replay is active, even if the session would not normally be sampled for logging.

Key changes include:

*   **Sampling Override**: Added `samplingOverride` to `LogReportingConfiguration`. When enabled, `isSampled()` returns true regardless of the configured sample rate.
*   **Feature Coordination**: Updated `AndroidAgentImpl` to coordinate the initialization of Session Replay and Log Reporting. If Session Replay is in `FULL` mode, the logging sampling override is automatically activated.
*   **Dynamic Activation**:
    *   Added `activateLoggingForSessionReplay()` to trigger log recording when Session Replay transitions to `FULL` mode via API calls (`recordReplay`) or error detection.
    *   Modified `NewRelic` error logging methods to trigger logging activation if Session Replay is enabled.
*   **State Management**:
    *   Refined `LogReporter` and `LogReportingConfiguration` to distinguish between global "enabled" status and "sampled" status.
    *   Ensured sampling overrides are cleared during session reset and re-evaluated during harvest configuration changes.
*   **Supportability**: Added `Supportability/LogReporting/SamplingOverride` metric to track when the override is applied.
*   **Testing**: Added unit tests in `LogReportingConfigurationTest` to verify override logic, session sampling behavior, and configuration copying.