### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/functionalTests.yml
+++ b/.github/workflows/functionalTests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "develop", "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   functional-plugin-jdk17:
     if: ${{ false }}  # disable for until tests are resolved


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/10](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/10)

Add an explicit top-level `permissions` block in `.github/workflows/functionalTests.yml` so all jobs inherit least-privilege token access by default.

Best single fix without changing functionality:
- Insert at workflow root (after `on:` triggers and before `jobs:`):
  - `permissions:`
  - `contents: read`

Why here:
- A root-level block applies to all jobs in this workflow consistently.
- None of the shown steps require write access to repository contents.
- This satisfies CodeQL’s requirement and documents intended minimal token scope.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
