### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/11](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/11)

Add an explicit `permissions` block to the workflow so the token is constrained by default.  
Best fix here (without changing behavior) is to add a top-level workflow permission:

- `contents: read`

This satisfies checkout needs and enforces least privilege for all jobs unless overridden later.  
Edit `.github/workflows/codecov.yml` near the top-level keys, inserting `permissions` between `on:` and `jobs:` (or any top-level location).

No imports, methods, or dependencies are required—just YAML key insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
