### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #    type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/12](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/12)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access unless overridden. For this workflow, the best minimal safe setting is:

- `contents: read`

This preserves current functionality (checkout, build, artifact upload) while preventing unnecessary token write scopes.

**Where to change:** `.github/workflows/android.yml`, directly under the workflow triggers (`on:` block) and before `jobs:`.

No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
