### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "develop", "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   integration-plugin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/14](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/14)

Add an explicit `permissions` block in `.github/workflows/integrationTests.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe setting is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI behavior while restricting token capabilities. No imports, methods, or additional definitions are needed (YAML config only). Place it after the `on:` section (or before `jobs:`) to keep structure clear and preserve current functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
