### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradlePluginPortalDeployment.yml
+++ b/.github/workflows/gradlePluginPortalDeployment.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   assemble_project:
     name: Assemble project


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/16](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/16)

Add an explicit `permissions` block at the workflow root so it applies to all jobs in `.github/workflows/gradlePluginPortalDeployment.yml` unless overridden. The minimal safe baseline here is:

- `contents: read`

This preserves existing behavior while constraining `GITHUB_TOKEN` access. Place the block near the top level (for example, after the `on:` section and before `jobs:`). No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
