### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,9 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/17](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/17)

Add an explicit `permissions` block at the workflow root (right after `on:` is a clean location) so all jobs inherit least-privilege token scopes unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves existing functionality (`github.repos.get`, checkout, and running repolinter) while preventing accidental write access if repository defaults are broad.

File to change: `.github/workflows/repolinter.yml`  
Region: between the `on:` declaration and `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
