### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/functionalTests.yml
+++ b/.github/workflows/functionalTests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "develop", "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   functional-plugin-jdk17:
     if: ${{ false }}  # disable for until tests are resolved


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/18](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/18)

Add a top-level `permissions` block in `.github/workflows/functionalTests.yml` so all jobs inherit least-privilege token access.  
Best single fix here: insert, near the top (after `on:` block and before `jobs:`),:

- `permissions:`
- `contents: read`

This satisfies CodeQL’s recommendation and keeps current functionality unchanged, since these jobs primarily check out code and run Gradle/tests. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
