### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/smokeTests.yml
+++ b/.github/workflows/smokeTests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "develop", "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test-jdk11:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/19](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/19)

Add an explicit top-level `permissions` block in `.github/workflows/smokeTests.yml` so all jobs inherit least-privilege token access by default.

Best fix here (without changing workflow behavior): define:

- `permissions:`
  - `contents: read`

at the workflow root, just after `on:` (or before `jobs:`). This is sufficient for checkout and artifact upload in this workflow and directly addresses the CodeQL finding. No job logic, steps, or triggers need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
