### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/functionalTests.yml
+++ b/.github/workflows/functionalTests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "develop", "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   functional-plugin-jdk17:
     if: ${{ false }}  # disable for until tests are resolved


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/20](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/20)

Add a top-level `permissions` block to `.github/workflows/functionalTests.yml` so all jobs inherit minimal token access by default.

Best single fix (without changing functionality): insert:

```yml
permissions:
  contents: read
```

directly under the `on:` triggers (or directly under `name:`), before `jobs:`.  
This keeps current workflow behavior while explicitly constraining `GITHUB_TOKEN` for all jobs in this workflow. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
