### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/smokeTests.yml
+++ b/.github/workflows/smokeTests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "develop", "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test-jdk11:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/21](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/21)

Add an explicit top-level `permissions` block in `.github/workflows/smokeTests.yml` (right after the `on:` triggers and before `jobs:`) so all jobs inherit least-privilege defaults.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current functionality for checkout/build/test/artifact upload while documenting and enforcing restricted token access regardless of repository default settings. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
