### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflowCleanup.yml
+++ b/.github/workflows/workflowCleanup.yml
@@ -40,6 +40,10 @@ on:
     # run second day of the month
     - cron: '0 0 2 * *'
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   actions-cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/24](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/24)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained by least privilege and behavior is stable across repositories/org defaults.

Best single fix here (without changing existing behavior) is to add workflow-level permissions directly under `on:`/before `jobs:`:
- `contents: read` (needed for `actions/checkout`)
- `actions: write` (likely needed by cleanup script deleting workflow runs)

File to change:
- `.github/workflows/workflowCleanup.yml`
- Insert new `permissions:` block between the trigger section and `jobs:`.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
