### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility-matrix-test.yml
+++ b/.github/workflows/compatibility-matrix-test.yml
@@ -1,5 +1,8 @@
 name: Compatibility Matrix Test
 
+permissions:
+  contents: read
+
 on:
   # Run every morning at 9 AM UTC on the main branch
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/27](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/27)

In general, the fix is to add an explicit `permissions` block that grants only the minimal needed scopes to the `GITHUB_TOKEN`. Since this workflow appears to only need read access to the repository contents (for `actions/checkout`) and does not need to write to the repo or other GitHub resources, we can safely set `contents: read`. We can do this at the workflow root so it applies to all jobs (`setup`, `build-agent`, `test`, and the summary job), ensuring no job accidentally runs with broader privileges.

The best fix here is to add a top-level `permissions:` section immediately after the `name:` (or before/after `on:`) in `.github/workflows/compatibility-matrix-test.yml`:

- Add:
  ```yaml
  permissions:
    contents: read
  ```
- This restricts the `GITHUB_TOKEN` for all jobs in this workflow to read-only access to repository contents.
- No additional imports, tools, or code changes are necessary because the jobs already operate entirely on checked-out code and local builds/artifacts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
