### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility-matrix-test.yml
+++ b/.github/workflows/compatibility-matrix-test.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Read the compatibility matrix and set up the test matrix
   setup:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/28](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/28)

To fix the problem, explicitly declare restricted `permissions` for this workflow so that the GITHUB_TOKEN used by its jobs has only the minimal access required. Since the jobs only check out code, run builds/tests, and upload artifacts, they only need read access to repository contents; no write access to `contents` or other scopes is required.

The best fix with minimal functional impact is to add a top‑level `permissions` block right under the `on:` section so that it applies to all jobs (`setup`, `build-agent`, and `test`) without modifying each job individually. Set `contents: read`, which matches the least‑privilege baseline suggested by CodeQL and GitHub. No additional imports, methods, or definitions are needed, as this is a YAML configuration change only. Concretely, in `.github/workflows/compatibility-matrix-test.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (e.g., after line 20), leaving all job logic unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
