### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,6 +14,9 @@ on:
     #    default: ${{ env.GITHUB_REF_NAME }}
     #   type: string
 
+permissions:
+  contents: read
+
 jobs:
   codecov_report:
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility-matrix-test.yml
+++ b/.github/workflows/compatibility-matrix-test.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Read the compatibility matrix and set up the test matrix
   setup:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-android-agent/security/code-scanning/29](https://github.com/newrelic/newrelic-android-agent/security/code-scanning/29)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimal level required. Since the jobs in this file only need to read the repository contents (for checkout) and interact with artifacts and caches (which don’t require repository write permissions), setting `contents: read` at the workflow root is an appropriate baseline. If later a job needs additional permissions (e.g., to comment on PRs), that job can override the root permissions with a more specific `permissions:` block.

The single best fix with no functional change is to add a top-level `permissions:` section right after the `on:` block, applying to all jobs that don’t override it. In `.github/workflows/compatibility-matrix-test.yml`, insert:

```yaml
permissions:
  contents: read
```

at the root level, aligned with `name:` and `on:`. No other code, steps, or jobs need modification for this least-privilege baseline, as none of the shown steps require write access to repository contents or other scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
