### PR TITLE
[NR-563075] refactor(hybrid): update JSError wire keys to camelCase, remove legacy description

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsAttribute.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsAttribute.java
@@ -119,8 +119,8 @@ public class AnalyticsAttribute {
     public static final String JSERROR_ERRORID = "errorId";
     public static final String JSERROR_THREADS = "threads";
     public static final String JSERROR_ISFATAL = "isFatalError";
-    public static final String JSERROR_ERRORTYPE = "errorType";
-    public static final String JSERROR_DESCRIPTION = "description";
+    public static final String JSERROR_ERRORNAME = "errorName";
+    public static final String JSERROR_ERRORMESSAGE = "errorMessage";
     public static final String JSERROR_CAUSE = "cause";
     public static final String JSERROR_TIMESTAMP = "timestamp";
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsAttribute.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsAttribute.java
@@ -123,6 +123,7 @@ public class AnalyticsAttribute {
     public static final String JSERROR_ERRORMESSAGE = "errorMessage";
     public static final String JSERROR_CAUSE = "cause";
     public static final String JSERROR_TIMESTAMP = "timestamp";
+    public static final String APP_VERSION_AT_RECORD_ATTRIBUTE = "appVersionAtRecord";
 
     public static final int ATTRIBUTE_NAME_MAX_LENGTH = 255;
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsValidator.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsValidator.java
@@ -50,6 +50,7 @@ public class AnalyticsValidator {
         add(AnalyticsAttribute.RUNTIME_ATTRIBUTE);
         add(AnalyticsAttribute.ARCHITECTURE_ATTRIBUTE);
         add(AnalyticsAttribute.APP_BUILD_ATTRIBUTE);
+        add(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE);
     }};
 
     protected static Set<String> excludedAttributeNames = new HashSet<String>() {{

--- a/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
@@ -197,7 +197,7 @@ public class Error extends HarvestableObject {
 
         // Always send session events
         JsonArray eventArray = new JsonArray();
-        if (event != null) {
+        if (event != null && !event.isEmpty()) {
             eventArray.add(gson.toJsonTree(event));
         }
         data.add(ANALYTICS_EVENTS_KEY, eventArray);

--- a/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataController.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class JSErrorDataController {
+
+
     private final AgentConfiguration agentConfiguration;
     private final JSErrorStore jsErrorStore;
     private final ReentrantReadWriteLock lock;
@@ -88,9 +90,8 @@ public class JSErrorDataController {
             eventAttributes.put(AnalyticsAttribute.JSERROR_ERRORID, errorId);
             eventAttributes.put(AnalyticsAttribute.JSERROR_THREADS, stackTrace);
             eventAttributes.put(AnalyticsAttribute.JSERROR_ISFATAL, isFatal);
-            eventAttributes.put(AnalyticsAttribute.JSERROR_ERRORTYPE, name);
-            eventAttributes.put(AnalyticsAttribute.JSERROR_DESCRIPTION, message);
-            eventAttributes.put(AnalyticsAttribute.JSERROR_CAUSE, message);
+            eventAttributes.put(AnalyticsAttribute.JSERROR_ERRORNAME, name);
+            eventAttributes.put(AnalyticsAttribute.JSERROR_ERRORMESSAGE, message);
             eventAttributes.put(AnalyticsAttribute.JSERROR_TIMESTAMP, System.currentTimeMillis());
             eventAttributes.put(AnalyticsAttribute.EVENT_TYPE_ATTRIBUTE, AnalyticsEvent.EVENT_TYPE_MOBILE_JSERROR);
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataController.java
@@ -8,21 +8,27 @@ package com.newrelic.agent.android.hybrid;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.analytics.AnalyticsEvent;
+import com.newrelic.agent.android.analytics.AnalyticsValidator;
 import com.newrelic.agent.android.error.Error;
+import com.newrelic.agent.android.harvest.ApplicationInformation;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.payload.PayloadController;
+import com.newrelic.agent.android.util.SafeJsonPrimitive;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -35,6 +41,7 @@ public class JSErrorDataController {
     private final AgentConfiguration agentConfiguration;
     private final JSErrorStore jsErrorStore;
     private final ReentrantReadWriteLock lock;
+    private final AnalyticsValidator validator;
 
     private static final AgentLog log = AgentLogManager.getAgentLog();
     private static final Gson gson = new GsonBuilder().create();
@@ -44,6 +51,7 @@ public class JSErrorDataController {
         this.agentConfiguration = AgentConfiguration.getInstance();
         this.jsErrorStore = agentConfiguration.getJsErrorStore();
         this.lock = new ReentrantReadWriteLock();
+        this.validator = new AnalyticsValidator();
     }
 
     public static JSErrorDataController getInstance() {
@@ -61,6 +69,19 @@ public class JSErrorDataController {
     static void reset() {
         synchronized (JSErrorDataController.class) {
             instance = null;
+        }
+    }
+
+    /**
+     * Returns the current runtime app version, or {@code null} if {@link Agent} or its
+     * {@link ApplicationInformation} are not yet initialized.
+     */
+    private static String currentAppVersion() {
+        try {
+            ApplicationInformation appInfo = Agent.getApplicationInformation();
+            return appInfo == null ? null : appInfo.getAppVersion();
+        } catch (Exception e) {
+            return null;
         }
     }
 
@@ -82,9 +103,18 @@ public class JSErrorDataController {
             }
 
             // additionalAttributes are merged first so that reserved keys below always win.
+            // Reserved attribute names (incl. APP_VERSION_AT_RECORD_ATTRIBUTE, the internal
+            // grouping/header key) are dropped here so caller input cannot misroute
+            // symbolication by overriding the agent's app-version snapshot.
             final HashMap<String, Object> eventAttributes = new HashMap<>();
             if (additionalAttributes != null) {
-                eventAttributes.putAll(additionalAttributes);
+                for (Map.Entry<String, Object> entry : additionalAttributes.entrySet()) {
+                    String key = entry.getKey();
+                    if (key == null || validator.isReservedAttributeName(key)) {
+                        continue;
+                    }
+                    eventAttributes.put(key, entry.getValue());
+                }
             }
             final String errorId = UUID.randomUUID().toString();
             eventAttributes.put(AnalyticsAttribute.JSERROR_ERRORID, errorId);
@@ -98,6 +128,29 @@ public class JSErrorDataController {
             final JsonObject eventObject = new JsonObject();
             for (Map.Entry<String, Object> entry : eventAttributes.entrySet()) {
                 eventObject.add(entry.getKey(), gson.toJsonTree(entry.getValue()));
+            }
+
+            // Snapshot the current app version so the upload header can be set correctly
+            // on flush even if the app has been upgraded since this error was recorded.
+            // The agent owns this internal grouping/header key — the caller-supplied
+            // value (if any) was already filtered out above, so we always write the
+            // agent's snapshot here.
+            final String currentAppVersion = currentAppVersion();
+            if (currentAppVersion != null && !currentAppVersion.isEmpty()) {
+                eventObject.addProperty(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE, currentAppVersion);
+            }
+
+            // Snapshot session attributes synchronously on the calling thread so the event
+            // freezes the session active at recordJavaScriptError time, not whichever session
+            // is active when the cache is later flushed (which may be a different session
+            // entirely after a crash, ANR, or force-stop).
+            AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
+            if (analyticsController != null) {
+                for (AnalyticsAttribute attr : analyticsController.getSessionAttributes()) {
+                    if (!eventObject.has(attr.getName())) {
+                        eventObject.add(attr.getName(), attr.asJsonElement());
+                    }
+                }
             }
 
             PayloadController.submitCallable(new Callable<Boolean>() {
@@ -131,20 +184,29 @@ public class JSErrorDataController {
         }
     }
 
-    String buildErrorEnvelope(List<String> eventJsonList) {
+    String buildErrorEnvelope(List<String> eventJsonList, String appVersionOverride) {
         AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
         if (analyticsController == null) {
             log.error("JSError: AnalyticsController is not initialized");
             return null;
         }
 
-        Error jsError = new Error(analyticsController.getSessionAttributes(), new HashMap<>());
+        Error jsError = new Error(null, new HashMap<>());
         JsonArray eventsArray = new JsonArray();
 
         for (String eventJson : eventJsonList) {
             if (eventJson != null && !eventJson.trim().isEmpty()) {
                 try {
-                    eventsArray.add(JsonParser.parseString(eventJson));
+                    JsonElement parsed = JsonParser.parseString(eventJson);
+                    if (parsed.isJsonObject()) {
+                        // appVersionAtRecord is an internal-only marker used
+                        // by the agent to group cached events and set the
+                        // per-group upload header / appInfo.appVersion. It's
+                        // not a customer-facing attribute and must not ship
+                        // on the wire.
+                        parsed.getAsJsonObject().remove(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE);
+                    }
+                    eventsArray.add(parsed);
                 } catch (Exception e) {
                     log.warn("JSError: Failed to parse stored event JSON: " + e.getMessage());
                 }
@@ -152,69 +214,138 @@ public class JSErrorDataController {
         }
 
         JsonObject rootObject = jsError.asJsonObject();
-        JsonArray existingEvents = rootObject.getAsJsonArray(Error.ANALYTICS_EVENTS_KEY);
+        // Overwrite, don't append: Error.asJsonObject() seeded analyticsEvents
+        // with the constructor's `event` field (designed for the one-event-per-crash
+        // case). Setting the array explicitly here keeps JSError envelopes free
+        // of any leading placeholder regardless of how Error evolves.
+        rootObject.add(Error.ANALYTICS_EVENTS_KEY, eventsArray);
 
-        if (existingEvents != null) {
-            existingEvents.addAll(eventsArray);
-        } else {
-            rootObject.add(Error.ANALYTICS_EVENTS_KEY, eventsArray);
+        // Override appInfo.appVersion to match the per-group recorded version so
+        // the envelope is internally consistent with the X-NewRelic-App-Version
+        // upload header (cached errors recorded under an older build must
+        // self-identify as that older build for backend symbolication). Other
+        // appInfo fields (appName, appBuild, bundleId) are intentionally left
+        // at the current runtime value — snapshotting those is in a deferred
+        // follow-up ticket.
+        if (appVersionOverride != null && !appVersionOverride.isEmpty()) {
+            JsonObject appInfo = rootObject.getAsJsonObject("appInfo");
+            if (appInfo != null) {
+                appInfo.add("appVersion", SafeJsonPrimitive.factory(appVersionOverride));
+            }
         }
 
         return rootObject.toString();
     }
 
     /**
-     * Snapshot of a single harvest batch: the JSON payload to send and the exact
-     * store IDs included in it. Pass {@link #deleteErrors(List)} the
-     * {@code snapshotIds} after a confirmed successful upload so that only the sent
-     * errors are removed — errors that arrived after the snapshot are preserved.
+     * Snapshot of a single harvest batch: the JSON payload to send, the exact
+     * store IDs included in it, and the {@code appVersion} to use for the
+     * {@code X-NewRelic-App-Version} upload header. Pass
+     * {@link #deleteErrors(List)} the {@code snapshotIds} after a confirmed
+     * successful upload so that only the sent errors are removed — errors that
+     * arrived after the snapshot are preserved.
      */
     public static final class HarvestSnapshot {
         public final String payloadJson;
         public final List<String> snapshotIds;
+        public final String appVersion;
 
-        HarvestSnapshot(String payloadJson, List<String> snapshotIds) {
+        HarvestSnapshot(String payloadJson, List<String> snapshotIds, String appVersion) {
             this.payloadJson = payloadJson;
             this.snapshotIds = Collections.unmodifiableList(snapshotIds);
+            this.appVersion = appVersion;
         }
     }
 
     /**
-     * Returns a {@link HarvestSnapshot} of all currently stored errors, or {@code null}
-     * if there are none. Uses a single atomic store read to ensure the payload values
-     * and their IDs are always consistent with each other.
+     * Returns one {@link HarvestSnapshot} per distinct {@code appVersionAtRecord}
+     * value found across stored errors, or an empty list if there are none.
+     * Splitting by version lets each POST set the matching
+     * {@code X-NewRelic-App-Version} header so the backend can pick the right
+     * ProGuard mapping after an app upgrade.
+     *
+     * <p>Uses a single atomic store read so the snapshot IDs and payload values
+     * across all groups are always derived from the same on-disk view.
      */
-    public HarvestSnapshot getStoredJSErrorData() {
+    public List<HarvestSnapshot> getStoredJSErrorData() {
         if (jsErrorStore == null) {
             log.warn("JSErrorStore is not initialized");
-            return null;
+            return Collections.emptyList();
         }
 
-        List<String> values;
-        List<String> snapshotIds;
+        Map<String, String> entries;
         lock.readLock().lock();
         try {
-            Map<String, String> entries = jsErrorStore.fetchAllEntries();
+            entries = jsErrorStore.fetchAllEntries();
             if (entries == null || entries.isEmpty()) {
                 log.debug("No JS errors found in store");
-                return null;
+                return Collections.emptyList();
             }
-
-            values = new ArrayList<>(entries.values());
-            snapshotIds = new ArrayList<>(entries.keySet());
         } catch (Exception e) {
             log.error("Failed to retrieve stored JS error data: " + e.getMessage());
-            return null;
+            return Collections.emptyList();
         } finally {
             lock.readLock().unlock();
         }
 
-        String payloadJson = buildErrorEnvelope(values);
-        if (payloadJson == null) {
-            return null;
+        // Group entries by their recorded app version. Use LinkedHashMap so the
+        // group iteration order is deterministic (oldest-version-seen first).
+        final String fallbackAppVersion = currentAppVersion();
+        final Map<String, List<String>> valuesByVersion = new LinkedHashMap<>();
+        final Map<String, List<String>> idsByVersion = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String id = entry.getKey();
+            String json = entry.getValue();
+            String groupKey = extractAppVersion(json);
+            if (groupKey == null || groupKey.isEmpty()) {
+                groupKey = fallbackAppVersion == null ? "" : fallbackAppVersion;
+            }
+            List<String> groupValues = valuesByVersion.get(groupKey);
+            if (groupValues == null) {
+                groupValues = new ArrayList<>();
+                valuesByVersion.put(groupKey, groupValues);
+                idsByVersion.put(groupKey, new ArrayList<String>());
+            }
+            groupValues.add(json);
+            idsByVersion.get(groupKey).add(id);
         }
 
-        return new HarvestSnapshot(payloadJson, snapshotIds);
+        final List<HarvestSnapshot> snapshots = new ArrayList<>(valuesByVersion.size());
+        for (Map.Entry<String, List<String>> e : valuesByVersion.entrySet()) {
+            String groupVersion = e.getKey();
+            // An empty groupVersion means we have no version at all (no fallback
+            // was available either). Pass null so both the envelope's appInfo
+            // and the sender's header fall back to the current runtime version.
+            String snapshotVersion = groupVersion.isEmpty() ? null : groupVersion;
+            String payloadJson = buildErrorEnvelope(e.getValue(), snapshotVersion);
+            if (payloadJson == null) {
+                continue;
+            }
+            snapshots.add(new HarvestSnapshot(payloadJson, idsByVersion.get(groupVersion), snapshotVersion));
+        }
+
+        return snapshots;
+    }
+
+    /** Returns the {@code appVersionAtRecord} field from a stored event's JSON, or {@code null} if absent or unparseable. */
+    private static String extractAppVersion(String eventJson) {
+        if (eventJson == null || eventJson.isEmpty()) {
+            return null;
+        }
+        try {
+            JsonElement parsed = JsonParser.parseString(eventJson);
+            if (!parsed.isJsonObject()) {
+                return null;
+            }
+            JsonElement v = parsed.getAsJsonObject().get(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE);
+            if (v == null || v.isJsonNull()) {
+                return null;
+            }
+            return v.getAsString();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /**

--- a/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataReporter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.newrelic.agent.android.hybrid.JSErrorDataController.HarvestSnapshot;
@@ -34,6 +35,13 @@ public class JSErrorDataReporter extends PayloadReporter {
     protected final JSErrorStore jsErrorStore;
 
     private final AtomicBoolean startupSendInProgress = new AtomicBoolean(false);
+    /**
+     * Number of in-flight startup-send POSTs from a single fan-out. Used to keep
+     * {@link #startupSendInProgress} {@code true} until every group's response
+     * handler fires. Set on fan-out, decremented in each completion handler;
+     * once it hits zero, {@code startupSendInProgress} is cleared.
+     */
+    private final AtomicInteger inFlightStartupSends = new AtomicInteger(0);
 
     protected final Callable reportCachedJSErrorDataCallable = new Callable() {
         @Override
@@ -84,7 +92,6 @@ public class JSErrorDataReporter extends PayloadReporter {
         if (PayloadController.isInitialized()) {
             if (isEnabled()) {
                 if (isStarted.compareAndSet(false, true)) {
-                    PayloadController.submitCallable(reportCachedJSErrorDataCallable);
                     Harvest.addHarvestListener(this);
                 }
             }
@@ -103,17 +110,27 @@ public class JSErrorDataReporter extends PayloadReporter {
             if (jsErrorStore != null) {
                 startupSendInProgress.set(true);
                 try {
-                    HarvestSnapshot snapshot = JSErrorDataController.getInstance().getStoredJSErrorData();
-                    if (snapshot != null) {
-                        Payload payload = new Payload(snapshot.payloadJson.getBytes(StandardCharsets.UTF_8));
-                        Future future = reportJSErrorData(payload, snapshot.snapshotIds, true);
-                        if (future == null) {
-                            startupSendInProgress.set(false);
-                        }
-                    } else {
+                    List<HarvestSnapshot> snapshots = JSErrorDataController.getInstance().getStoredJSErrorData();
+                    if (snapshots == null || snapshots.isEmpty()) {
                         startupSendInProgress.set(false);
+                        return;
+                    }
+                    // Pre-arm the in-flight counter for the entire fan-out so the
+                    // first group's completion can't prematurely clear the flag.
+                    inFlightStartupSends.set(snapshots.size());
+                    for (HarvestSnapshot snapshot : snapshots) {
+                        Payload payload = new Payload(snapshot.payloadJson.getBytes(StandardCharsets.UTF_8));
+                        Future future = reportJSErrorData(payload, snapshot.snapshotIds, true, snapshot.appVersion);
+                        if (future == null) {
+                            // submit was rejected (e.g. oversized payload) — that group will
+                            // never complete, so decrement here. Clear the flag if we hit zero.
+                            if (inFlightStartupSends.decrementAndGet() == 0) {
+                                startupSendInProgress.set(false);
+                            }
+                        }
                     }
                 } catch (Exception e) {
+                    inFlightStartupSends.set(0);
                     startupSendInProgress.set(false);
                     log.error("JSErrorDataReporter: Failed to report cached JS errors: " + e.getMessage());
                 }
@@ -127,13 +144,20 @@ public class JSErrorDataReporter extends PayloadReporter {
      * @param payload      the payload to send
      * @param sentIds      IDs to delete from the store on HTTP 200/202
      * @param isStartupSend {@code true} only when called from the startup cache-replay path;
-     *                     causes the completion handler to clear {@link #startupSendInProgress}
-     *                     so that {@link #onHarvest} is unblocked once this POST finishes.
-     *                     Must be {@code false} for all harvest-cycle sends to avoid
-     *                     prematurely clearing the flag while a startup send is still in-flight.
+     *                     causes the completion handler to decrement
+     *                     {@link #inFlightStartupSends} and, on the last completion,
+     *                     clear {@link #startupSendInProgress} so that
+     *                     {@link #onHarvest} is unblocked. Must be {@code false} for
+     *                     all harvest-cycle sends to avoid prematurely clearing the
+     *                     flag while a startup send is still in-flight.
+     * @param appVersionOverride Value for the {@code X-NewRelic-App-Version}
+     *                          upload header. Set to the recorded app version
+     *                          when sending cached errors from a previous build;
+     *                          {@code null}/empty to use the current runtime
+     *                          app version.
      */
-    public Future reportJSErrorData(Payload payload, List<String> sentIds, boolean isStartupSend) {
-        PayloadSender payloadSender = new JSErrorDataSender(payload, getAgentConfiguration());
+    public Future reportJSErrorData(Payload payload, List<String> sentIds, boolean isStartupSend, String appVersionOverride) {
+        PayloadSender payloadSender = new JSErrorDataSender(payload, getAgentConfiguration(), appVersionOverride);
 
         if (payload.getBytes().length > Constants.Network.MAX_PAYLOAD_SIZE) {
             DeviceInformation deviceInformation = Agent.getDeviceInformation();
@@ -143,9 +167,8 @@ public class JSErrorDataReporter extends PayloadReporter {
                     .replace(MetricNames.TAG_SUBDESTINATION, "f");
             StatsEngine.notice().inc(name);
             log.error("Unable to upload handled exceptions because payload is larger than 1 MB, handled exceptions are discarded.");
-            if (isStartupSend) {
-                startupSendInProgress.set(false);
-            }
+            // Caller (the fan-out loop) decrements inFlightStartupSends when we
+            // return null, so don't decrement here.
             return null;
         }
 
@@ -153,7 +176,9 @@ public class JSErrorDataReporter extends PayloadReporter {
             @Override
             public void onResponse(PayloadSender payloadSender) {
                 if (isStartupSend) {
-                    startupSendInProgress.set(false);
+                    if (inFlightStartupSends.decrementAndGet() <= 0) {
+                        startupSendInProgress.set(false);
+                    }
                 }
 
                 if (payloadSender.isSuccessfulResponse()) {
@@ -182,7 +207,9 @@ public class JSErrorDataReporter extends PayloadReporter {
             @Override
             public void onException(PayloadSender payloadSender, Exception e) {
                 if (isStartupSend) {
-                    startupSendInProgress.set(false);
+                    if (inFlightStartupSends.decrementAndGet() <= 0) {
+                        startupSendInProgress.set(false);
+                    }
                 }
                 log.error("JSErrorDataReporter.reportJSErrorData(Payload): " + e);
             }
@@ -191,36 +218,12 @@ public class JSErrorDataReporter extends PayloadReporter {
         return future;
     }
 
-    public Future storeAndReportJSErrorData(Payload payload, List<String> sentIds) {
-        return reportJSErrorData(payload, sentIds, false);
+    public Future storeAndReportJSErrorData(Payload payload, List<String> sentIds, String appVersionOverride) {
+        return reportJSErrorData(payload, sentIds, false, appVersionOverride);
     }
 
     @Override
     public void onHarvest() {
-        if (startupSendInProgress.get()) {
-            log.debug("JSErrorDataReporter: Skipping harvest — startup send in progress");
-            super.onHarvest();
-            return;
-        }
-
-        try {
-            HarvestSnapshot snapshot = JSErrorDataController.getInstance().getStoredJSErrorData();
-
-            if (snapshot != null) {
-                try {
-                    Payload payload = new Payload(snapshot.payloadJson.getBytes(StandardCharsets.UTF_8));
-                    storeAndReportJSErrorData(payload, snapshot.snapshotIds);
-                    log.info("JSErrorDataReporter: JS errors added to harvest");
-                } catch (Exception payloadException) {
-                    log.error("JSErrorDataReporter: Failed to create payload - " + payloadException.getMessage());
-                }
-            } else {
-                log.debug("JSErrorDataReporter: No JS errors to harvest");
-            }
-        } catch (Exception e) {
-            log.error("JSErrorDataReporter: Failed to harvest JS errors - " + e.getMessage());
-        }
-
-        super.onHarvest();
+        PayloadController.submitCallable(reportCachedJSErrorDataCallable);
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/hybrid/JSErrorDataSender.java
@@ -26,12 +26,31 @@ import javax.net.ssl.HttpsURLConnection;
 public class JSErrorDataSender extends PayloadSender {
     static final String JSERROR_COLLECTOR_PATH = "/mobile/errors?protocol_version=1&platform=";
 
+    /**
+     * App version override used for the {@code X-NewRelic-App-Version} header.
+     * When non-null and non-empty, takes precedence over the current runtime
+     * {@code Agent.getApplicationInformation().getAppVersion()}. Used to send
+     * cached errors recorded under an older app version with the matching
+     * upload header so the backend picks the right ProGuard mapping.
+     */
+    private final String appVersionOverride;
+
     public JSErrorDataSender(byte[] bytes, AgentConfiguration agentConfiguration) {
+        this(bytes, agentConfiguration, null);
+    }
+
+    public JSErrorDataSender(byte[] bytes, AgentConfiguration agentConfiguration, String appVersionOverride) {
         super(bytes, agentConfiguration);
+        this.appVersionOverride = appVersionOverride;
     }
 
     public JSErrorDataSender(Payload payload, AgentConfiguration agentConfiguration) {
+        this(payload, agentConfiguration, null);
+    }
+
+    public JSErrorDataSender(Payload payload, AgentConfiguration agentConfiguration, String appVersionOverride) {
         super(payload, agentConfiguration);
+        this.appVersionOverride = appVersionOverride;
     }
 
     @Override
@@ -53,7 +72,10 @@ public class JSErrorDataSender extends PayloadSender {
         connection.setRequestProperty(Constants.Network.TRUSTED_ACCOUNT_ID_HEADER, harvestConfiguration.getTrusted_account_key());
         connection.setRequestProperty(Constants.Network.ENTITY_GUID_HEADER, harvestConfiguration.getEntity_guid());
         connection.setRequestProperty(Constants.Network.DEVICE_OS_NAME_HEADER, Agent.getDeviceInformation().getOsName());
-        connection.setRequestProperty(Constants.Network.APP_VERSION_HEADER, Agent.getApplicationInformation().getAppVersion());
+        final String appVersionHeader = (appVersionOverride != null && !appVersionOverride.isEmpty())
+                ? appVersionOverride
+                : Agent.getApplicationInformation().getAppVersion();
+        connection.setRequestProperty(Constants.Network.APP_VERSION_HEADER, appVersionHeader);
 
         // apply the headers passed in harvest configuration (X-NewRelic-Session, X-NewRelic-AgentConfiguration)
         Map<String, String> requestHeaders = Harvest.getHarvestConfiguration().getRequest_headers_map();
@@ -109,6 +131,12 @@ public class JSErrorDataSender extends PayloadSender {
 
     @Override
     protected boolean shouldUploadOpportunistically() {
-        return PayloadController.shouldUploadOpportunistically();
+        // Send JS errors immediately when there's network. Falling back to
+        // PayloadController.shouldUploadOpportunistically() (which checks the
+        // global opportunisticUploads flag, hardcoded to false) would queue the
+        // reaper on payloadReaperQueue and delay the actual POST until the
+        // next harvest tick fires PayloadController.dequeueRunnable. Matches
+        // CrashSender and AEITraceSender semantics.
+        return Agent.hasReachableNetworkConnection(null);
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerAttributesTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerAttributesTest.java
@@ -5,13 +5,19 @@
 
 package com.newrelic.agent.android.hybrid;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.analytics.AnalyticsEvent;
+import com.newrelic.agent.android.harvest.ApplicationInformation;
 import com.newrelic.agent.android.payload.PayloadController;
+import com.newrelic.agent.android.test.stub.StubAgentImpl;
+import com.newrelic.agent.android.test.stub.StubAnalyticsAttributeStore;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -38,13 +44,21 @@ public class JSErrorDataControllerAttributesTest {
 
     private LatchingJSErrorStore store;
 
+    private MutableVersionAgentImpl mutableAgent;
+
     @Before
     public void setUp() {
         FeatureFlag.resetFeatures();
         store = new LatchingJSErrorStore();
         AgentConfiguration config = AgentConfiguration.getInstance();
         config.setJsErrorStore(store);
+        config.setAnalyticsAttributeStore(new StubAnalyticsAttributeStore());
         PayloadController.initialize(config);
+        AnalyticsControllerImpl.initialize(config, new StubAgentImpl());
+        // Install a mutable agent so tests can vary appVersion at runtime to
+        // simulate an upgrade between recordings.
+        mutableAgent = new MutableVersionAgentImpl();
+        Agent.setImpl(mutableAgent);
         JSErrorDataController.reset();
     }
 
@@ -52,8 +66,10 @@ public class JSErrorDataControllerAttributesTest {
     public void tearDown() {
         FeatureFlag.resetFeatures();
         JSErrorDataController.reset();
+        AnalyticsControllerImpl.shutdown();
         PayloadController.shutdown();
         AgentConfiguration.getInstance().setJsErrorStore(null);
+        Agent.setImpl(null);
     }
 
     @Test
@@ -164,6 +180,327 @@ public class JSErrorDataControllerAttributesTest {
         JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
         Assert.assertEquals("",
                 event.get(AnalyticsAttribute.JSERROR_ERRORMESSAGE).getAsString());
+    }
+
+    @Test
+    public void sessionAttributes_areEmbeddedInPersistedEvent() throws Exception {
+        AnalyticsControllerImpl.getInstance().setAttribute("customKey", "customValue", false);
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("user attribute must be embedded as a flat event-level field",
+                "customValue", event.get("customKey").getAsString());
+        Assert.assertTrue("system attribute (osName) from the snapshot must be present",
+                event.has(AnalyticsAttribute.OS_NAME_ATTRIBUTE));
+        Assert.assertTrue("system attribute (sessionId) from the snapshot must be present",
+                event.has(AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+    }
+
+    @Test
+    public void reservedJSErrorKeys_winOverSessionAttributesOnCollision() throws Exception {
+        // 'errorName' is not on the AnalyticsValidator reserved list, so a user
+        // attribute can be set under that name — but the JSError reserved key
+        // must still win when persisted.
+        AnalyticsControllerImpl.getInstance().setAttribute(
+                AnalyticsAttribute.JSERROR_ERRORNAME, "session-bogus", false);
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "RealErrorName", "boom", "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("RealErrorName",
+                event.get(AnalyticsAttribute.JSERROR_ERRORNAME).getAsString());
+    }
+
+    @Test
+    public void additionalAttributes_winOverSessionAttributesOnCollision() throws Exception {
+        AnalyticsControllerImpl.getInstance().setAttribute("conflictKey", "from-session", false);
+
+        Map<String, Object> extras = new HashMap<>();
+        extras.put("conflictKey", "from-additional");
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, extras);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("from-additional", event.get("conflictKey").getAsString());
+    }
+
+    @Test
+    public void snapshot_reflectsRecordTimeNotSendTime() throws Exception {
+        AnalyticsControllerImpl ctrl = AnalyticsControllerImpl.getInstance();
+        ctrl.setAttribute("snapshotKey", "OLD", false);
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject persistedAtRecordTime = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("OLD", persistedAtRecordTime.get("snapshotKey").getAsString());
+
+        // Mutating the controller after recording must not change the persisted bytes.
+        ctrl.setAttribute("snapshotKey", "NEW", false);
+        JsonObject persistedStillFrozen = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("OLD", persistedStillFrozen.get("snapshotKey").getAsString());
+    }
+
+    @Test
+    public void snapshot_includesBothSystemAndUserSessionAttributes() throws Exception {
+        AnalyticsControllerImpl.getInstance().setAttribute("userTag", "user-value", false);
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        // User attribute
+        Assert.assertEquals("user-value", event.get("userTag").getAsString());
+        // System attributes populated from the StubAgentImpl during controller init
+        Assert.assertEquals("Android", event.get(AnalyticsAttribute.OS_NAME_ATTRIBUTE).getAsString());
+        Assert.assertEquals("StubAgent", event.get(AnalyticsAttribute.DEVICE_MODEL_ATTRIBUTE).getAsString());
+        Assert.assertEquals("Fake", event.get(AnalyticsAttribute.DEVICE_MANUFACTURER_ATTRIBUTE).getAsString());
+    }
+
+    @Test
+    public void appVersionAtRecord_isEmbeddedInPersistedEvent() throws Exception {
+        mutableAgent.setAppVersion("1.2.3");
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("recorded app version must be embedded as a flat event-level field",
+                "1.2.3", event.get(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE).getAsString());
+    }
+
+    @Test
+    public void appVersionAtRecord_agentSnapshotAlwaysWinsOverCallerOverride() throws Exception {
+        // appVersionAtRecord is the internal grouping/header key — the agent owns it.
+        // A caller passing it (intentionally or by accident) must NOT be able to
+        // misroute symbolication to the wrong ProGuard mapping. AnalyticsValidator
+        // marks the key as reserved, and sendJSErrorData drops reserved keys from
+        // additionalAttributes before merging, so the agent's snapshot always wins.
+        mutableAgent.setAppVersion("1.2.3");
+
+        Map<String, Object> extras = new HashMap<>();
+        extras.put(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE, "user-override");
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, extras);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("agent snapshot must win — caller cannot override the internal grouping key",
+                "1.2.3", event.get(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE).getAsString());
+    }
+
+    @Test
+    public void additionalAttributes_reservedPrefixedKeysAreDropped() throws Exception {
+        // AnalyticsValidator rejects names beginning with newRelic / nr. / Public_
+        // (in addition to the explicit reserved set). sendJSErrorData must drop
+        // these from additionalAttributes so caller input cannot inject anything
+        // shaped like an agent-internal field.
+        Map<String, Object> extras = new HashMap<>();
+        extras.put("newRelicSomething", "should-drop");
+        extras.put("nr.foo", "should-drop");
+        extras.put("Public_bar", "should-drop");
+        extras.put("safeKey", "should-keep");
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, extras);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertFalse("newRelic-prefixed keys must be dropped",
+                event.has("newRelicSomething"));
+        Assert.assertFalse("nr.-prefixed keys must be dropped", event.has("nr.foo"));
+        Assert.assertFalse("Public_-prefixed keys must be dropped", event.has("Public_bar"));
+        Assert.assertEquals("non-reserved keys must be preserved",
+                "should-keep", event.get("safeKey").getAsString());
+    }
+
+    @Test
+    public void getStoredJSErrorData_singleVersion_returnsOneSnapshot() throws Exception {
+        mutableAgent.setAppVersion("1.0.0");
+
+        recordAndAwait("TypeError", "msg-1");
+        recordAndAwait("TypeError", "msg-2");
+        recordAndAwait("TypeError", "msg-3");
+
+        List<JSErrorDataController.HarvestSnapshot> snapshots =
+                JSErrorDataController.getInstance().getStoredJSErrorData();
+
+        Assert.assertEquals("single-version cache must produce one snapshot",
+                1, snapshots.size());
+        JSErrorDataController.HarvestSnapshot snap = snapshots.get(0);
+        Assert.assertEquals("snapshot.appVersion must match the recorded version",
+                "1.0.0", snap.appVersion);
+        Assert.assertEquals("snapshot must include all three persisted IDs",
+                3, snap.snapshotIds.size());
+    }
+
+    @Test
+    public void getStoredJSErrorData_multiVersion_returnsSnapshotsPerVersion() throws Exception {
+        mutableAgent.setAppVersion("1.0.0");
+        recordAndAwait("TypeError", "v1-msg-1");
+        recordAndAwait("TypeError", "v1-msg-2");
+
+        // Simulate an app upgrade: persisted v1 entries remain in the store, but
+        // subsequent recordings tag themselves with the new version.
+        mutableAgent.setAppVersion("1.1.0");
+        recordAndAwait("TypeError", "v11-msg-1");
+        recordAndAwait("TypeError", "v11-msg-2");
+
+        List<JSErrorDataController.HarvestSnapshot> snapshots =
+                JSErrorDataController.getInstance().getStoredJSErrorData();
+
+        Assert.assertEquals("multi-version cache must produce one snapshot per version",
+                2, snapshots.size());
+
+        // Map snapshots by appVersion for stable assertion regardless of group order
+        Map<String, JSErrorDataController.HarvestSnapshot> byVersion = new HashMap<>();
+        for (JSErrorDataController.HarvestSnapshot s : snapshots) {
+            byVersion.put(s.appVersion, s);
+        }
+        Assert.assertTrue("group for 1.0.0 must exist", byVersion.containsKey("1.0.0"));
+        Assert.assertTrue("group for 1.1.0 must exist", byVersion.containsKey("1.1.0"));
+        Assert.assertEquals("v1.0.0 group must contain its 2 IDs",
+                2, byVersion.get("1.0.0").snapshotIds.size());
+        Assert.assertEquals("v1.1.0 group must contain its 2 IDs",
+                2, byVersion.get("1.1.0").snapshotIds.size());
+
+        // IDs must not bleed between groups
+        for (String id : byVersion.get("1.0.0").snapshotIds) {
+            Assert.assertFalse("v1.0.0 id [" + id + "] must not appear in v1.1.0 group",
+                    byVersion.get("1.1.0").snapshotIds.contains(id));
+        }
+    }
+
+    @Test
+    public void buildErrorEnvelope_doesNotEmitEmptyLeadingEvent() throws Exception {
+        // Regression: Error.asJsonObject() unconditionally seeds analyticsEvents
+        // with the constructor's `event` HashMap (designed for the one-event-per-crash
+        // case). For JSError that map is always empty, so prior behavior was to
+        // append real events after a leading {} placeholder. The envelope must now
+        // contain ONLY the recorded events, with no leading empty entry.
+        recordAndAwait("TypeError", "real-msg-1");
+        recordAndAwait("TypeError", "real-msg-2");
+
+        List<JSErrorDataController.HarvestSnapshot> snapshots =
+                JSErrorDataController.getInstance().getStoredJSErrorData();
+        Assert.assertEquals(1, snapshots.size());
+
+        JsonObject envelope = JsonParser.parseString(snapshots.get(0).payloadJson).getAsJsonObject();
+        JsonArray events = envelope.getAsJsonArray("analyticsEvents");
+
+        Assert.assertEquals("envelope must contain exactly the recorded events, no empty placeholder",
+                2, events.size());
+        for (int i = 0; i < events.size(); i++) {
+            JsonObject e = events.get(i).getAsJsonObject();
+            Assert.assertTrue("event[" + i + "] must contain errorName (rules out empty placeholder)",
+                    e.has(AnalyticsAttribute.JSERROR_ERRORNAME));
+        }
+    }
+
+    @Test
+    public void buildErrorEnvelope_stripsAppVersionAtRecordFromWireEvents() throws Exception {
+        // appVersionAtRecord is an internal-only marker — it stays on disk for
+        // grouping but must not appear as an attribute on the wire event.
+        mutableAgent.setAppVersion("1.0.0");
+        recordAndAwait("TypeError", "msg");
+
+        // Sanity: the persisted on-disk event still carries the marker.
+        JsonObject persisted = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("1.0.0",
+                persisted.get(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE).getAsString());
+
+        // The wire envelope must NOT carry it on any analyticsEvents entry.
+        List<JSErrorDataController.HarvestSnapshot> snapshots =
+                JSErrorDataController.getInstance().getStoredJSErrorData();
+        Assert.assertEquals(1, snapshots.size());
+        JsonObject envelope = JsonParser.parseString(snapshots.get(0).payloadJson).getAsJsonObject();
+        for (com.google.gson.JsonElement event : envelope.getAsJsonArray("analyticsEvents")) {
+            Assert.assertFalse("wire event must not carry the internal appVersionAtRecord field",
+                    event.getAsJsonObject().has(AnalyticsAttribute.APP_VERSION_AT_RECORD_ATTRIBUTE));
+        }
+    }
+
+    @Test
+    public void buildErrorEnvelope_appInfoVersion_matchesRecordedVersion() throws Exception {
+        // Cached errors recorded under an older build must ship with the OLD
+        // appVersion in BOTH the X-NewRelic-App-Version header and the envelope
+        // body's appInfo.appVersion so the backend's symbolication path is
+        // internally consistent.
+        mutableAgent.setAppVersion("1.0.0");
+        recordAndAwait("TypeError", "old-build");
+
+        // Simulate an upgrade BEFORE the cached error gets flushed.
+        mutableAgent.setAppVersion("2.0.0");
+
+        List<JSErrorDataController.HarvestSnapshot> snapshots =
+                JSErrorDataController.getInstance().getStoredJSErrorData();
+        Assert.assertEquals(1, snapshots.size());
+
+        JsonObject envelope = JsonParser.parseString(snapshots.get(0).payloadJson).getAsJsonObject();
+        JsonObject appInfo = envelope.getAsJsonObject("appInfo");
+        Assert.assertNotNull("envelope must contain appInfo", appInfo);
+        Assert.assertEquals("appInfo.appVersion must reflect the recorded build, not the current runtime",
+                "1.0.0", appInfo.get("appVersion").getAsString());
+        Assert.assertEquals("snapshot.appVersion (used for the upload header) must match",
+                "1.0.0", snapshots.get(0).appVersion);
+    }
+
+    @Test
+    public void getStoredJSErrorData_missingVersion_fallsBackToCurrent() throws Exception {
+        mutableAgent.setAppVersion("9.9.9");
+
+        // Inject an entry shaped like a pre-snapshot legacy event (no
+        // appVersionAtRecord field). It must group under the current app
+        // version rather than under null/empty.
+        store.store("legacy-id", "{\"errorName\":\"OldError\",\"errorMessage\":\"legacy\"}");
+
+        List<JSErrorDataController.HarvestSnapshot> snapshots =
+                JSErrorDataController.getInstance().getStoredJSErrorData();
+
+        Assert.assertEquals(1, snapshots.size());
+        Assert.assertEquals("missing version must fall back to current runtime version",
+                "9.9.9", snapshots.get(0).appVersion);
+        Assert.assertEquals(1, snapshots.get(0).snapshotIds.size());
+    }
+
+    private void recordAndAwait(String errorName, String message) throws Exception {
+        final int before = store.count();
+        JSErrorDataController.getInstance().sendJSErrorData(errorName, message, "stack", false, null);
+        long deadline = System.currentTimeMillis() + STORE_WAIT_SECONDS * 1000;
+        while (store.count() <= before && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        Assert.assertTrue("store did not receive new entry within timeout",
+                store.count() > before);
+    }
+
+    /**
+     * Test agent impl whose {@code appVersion} can be mutated mid-test to
+     * simulate an app upgrade between recordings. Other fields are inherited
+     * from {@link StubAgentImpl}.
+     */
+    private static final class MutableVersionAgentImpl extends StubAgentImpl {
+        private volatile String appVersion = "0.0";
+
+        void setAppVersion(String version) {
+            this.appVersion = version;
+        }
+
+        @Override
+        public ApplicationInformation getApplicationInformation() {
+            return new ApplicationInformation("stub", appVersion, "stub", "1");
+        }
     }
 
     private static final class LatchingJSErrorStore implements JSErrorStore {

--- a/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerAttributesTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerAttributesTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.hybrid;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.FeatureFlag;
+import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+import com.newrelic.agent.android.analytics.AnalyticsEvent;
+import com.newrelic.agent.android.payload.PayloadController;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * NR-563075 Phase 1 core-attribute wire keys for MobileJSError events.
+ *
+ * Verifies that {@link JSErrorDataController#sendJSErrorData} emits the
+ * required camelCase wire keys — {@code errorId}, {@code errorName},
+ * {@code errorType}, {@code errorMessage} — and that the legacy
+ * {@code description} key is no longer produced.
+ */
+public class JSErrorDataControllerAttributesTest {
+
+    private static final long STORE_WAIT_SECONDS = 5;
+
+    private LatchingJSErrorStore store;
+
+    @Before
+    public void setUp() {
+        FeatureFlag.resetFeatures();
+        store = new LatchingJSErrorStore();
+        AgentConfiguration config = AgentConfiguration.getInstance();
+        config.setJsErrorStore(store);
+        PayloadController.initialize(config);
+        JSErrorDataController.reset();
+    }
+
+    @After
+    public void tearDown() {
+        FeatureFlag.resetFeatures();
+        JSErrorDataController.reset();
+        PayloadController.shutdown();
+        AgentConfiguration.getInstance().setJsErrorStore(null);
+    }
+
+    @Test
+    public void wireKeys_arePresentAndCamelCase() throws Exception {
+        boolean queued = JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "undefined is not an object", "stack-frames", false, null);
+
+        Assert.assertTrue("sendJSErrorData should queue successfully", queued);
+        Assert.assertTrue("store was not called within timeout",
+                store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+
+        // Phase 1 core attributes — all camelCase per NR-563075
+        Assert.assertEquals("errorId",      "errorId",      AnalyticsAttribute.JSERROR_ERRORID);
+        Assert.assertEquals("errorName",    "errorName",    AnalyticsAttribute.JSERROR_ERRORNAME);
+        Assert.assertEquals("errorMessage", "errorMessage", AnalyticsAttribute.JSERROR_ERRORMESSAGE);
+
+        // Keys present on the wire
+        Assert.assertTrue("errorId must be present",      event.has("errorId"));
+        Assert.assertTrue("errorName must be present",    event.has("errorName"));
+        Assert.assertTrue("errorMessage must be present", event.has("errorMessage"));
+
+        Assert.assertEquals(store.lastId, event.get("errorId").getAsString());
+        Assert.assertFalse("errorId must be non-empty",
+                event.get("errorId").getAsString().isEmpty());
+    }
+
+    @Test
+    public void errorName_reflectsNameArgument() throws Exception {
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "ReferenceError", "x is not defined", "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("ReferenceError",
+                event.get(AnalyticsAttribute.JSERROR_ERRORNAME).getAsString());
+    }
+
+    @Test
+    public void errorMessage_reflectsMessageArgument() throws Exception {
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "SyntaxError", "Unexpected token", "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("Unexpected token",
+                event.get(AnalyticsAttribute.JSERROR_ERRORMESSAGE).getAsString());
+    }
+
+    @Test
+    public void descriptionKey_isNoLongerWritten() throws Exception {
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", true, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertFalse("legacy 'description' wire key must not be written",
+                event.has("description"));
+    }
+
+    @Test
+    public void companionAttributesStillPopulated() throws Exception {
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack-frames", true, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("stack-frames",
+                event.get(AnalyticsAttribute.JSERROR_THREADS).getAsString());
+        Assert.assertTrue(event.get(AnalyticsAttribute.JSERROR_ISFATAL).getAsBoolean());
+        Assert.assertEquals(AnalyticsEvent.EVENT_TYPE_MOBILE_JSERROR,
+                event.get(AnalyticsAttribute.EVENT_TYPE_ATTRIBUTE).getAsString());
+        Assert.assertTrue("timestamp must be present",
+                event.has(AnalyticsAttribute.JSERROR_TIMESTAMP));
+    }
+
+    @Test
+    public void additionalAttributes_doNotOverrideReservedWireKeys() throws Exception {
+        Map<String, Object> extras = new HashMap<>();
+        extras.put(AnalyticsAttribute.JSERROR_ERRORNAME, "HijackedName");
+        extras.put(AnalyticsAttribute.JSERROR_ERRORMESSAGE, "HijackedMessage");
+        extras.put(AnalyticsAttribute.JSERROR_ERRORID, "HijackedId");
+        extras.put("customKey", "customValue");
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "legit message", "stack", false, extras);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("TypeError",
+                event.get(AnalyticsAttribute.JSERROR_ERRORNAME).getAsString());
+
+        Assert.assertEquals("legit message",
+                event.get(AnalyticsAttribute.JSERROR_ERRORMESSAGE).getAsString());
+        Assert.assertNotEquals("HijackedId",
+                event.get(AnalyticsAttribute.JSERROR_ERRORID).getAsString());
+        // Non-reserved additional attributes are preserved
+        Assert.assertEquals("customValue", event.get("customKey").getAsString());
+    }
+
+    @Test
+    public void nullMessage_isNormalizedToEmptyString() throws Exception {
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", null, "stack", false, null);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertEquals("",
+                event.get(AnalyticsAttribute.JSERROR_ERRORMESSAGE).getAsString());
+    }
+
+    private static final class LatchingJSErrorStore implements JSErrorStore {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Map<String, String> data = new HashMap<>();
+        volatile String lastId;
+        volatile String lastValue;
+
+        @Override
+        public boolean store(String id, String value) {
+            this.lastId = id;
+            this.lastValue = value;
+            data.put(id, value);
+            latch.countDown();
+            return true;
+        }
+
+        @Override
+        public List<String> fetchAll() {
+            return new java.util.ArrayList<>(data.values());
+        }
+
+        @Override
+        public Map<String, String> fetchAllEntries() {
+            return new HashMap<>(data);
+        }
+
+        @Override
+        public void delete(String id) {
+            data.remove(id);
+        }
+
+        @Override
+        public int count() {
+            return data.size();
+        }
+
+        @Override
+        public void clear() {
+            data.clear();
+        }
+    }
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataSenderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.hybrid;
+
+import com.newrelic.agent.android.Agent;
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.ConsoleAgentLog;
+import com.newrelic.agent.android.payload.Payload;
+import com.newrelic.agent.android.test.stub.StubAgentImpl;
+import com.newrelic.agent.android.util.Constants;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Verifies that {@link JSErrorDataSender} threads an
+ * {@code appVersionOverride} into the {@code X-NewRelic-App-Version} upload
+ * header so the collector can pick the matching ProGuard mapping when
+ * uploading errors recorded under an older app version.
+ */
+public class JSErrorDataSenderTest {
+
+    private static final byte[] PAYLOAD_BYTES = "{}".getBytes(StandardCharsets.UTF_8);
+
+    @BeforeClass
+    public static void beforeClass() {
+        AgentLogManager.setAgentLog(new ConsoleAgentLog());
+        Agent.setImpl(new StubAgentImpl());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        Agent.setImpl(null);
+    }
+
+    @Before
+    public void setUp() {
+        AgentConfiguration.getInstance().setApplicationToken("DEAD-BEEF_BAAD-F00D");
+    }
+
+    @Test
+    public void getConnection_usesOverride_whenProvided() throws IOException {
+        JSErrorDataSender sender = new JSErrorDataSender(
+                new Payload(PAYLOAD_BYTES), AgentConfiguration.getInstance(), "9.9.9");
+
+        HttpURLConnection conn = sender.getConnection();
+        Map<String, List<String>> headers = conn.getRequestProperties();
+
+        Assert.assertTrue(headers.containsKey(Constants.Network.APP_VERSION_HEADER));
+        Assert.assertEquals(List.of("9.9.9"),
+                headers.get(Constants.Network.APP_VERSION_HEADER));
+    }
+
+    @Test
+    public void getConnection_fallsBackToCurrent_whenOverrideIsNull() throws IOException {
+        JSErrorDataSender sender = new JSErrorDataSender(
+                new Payload(PAYLOAD_BYTES), AgentConfiguration.getInstance(), null);
+
+        HttpURLConnection conn = sender.getConnection();
+        Map<String, List<String>> headers = conn.getRequestProperties();
+
+        Assert.assertEquals(List.of(Agent.getApplicationInformation().getAppVersion()),
+                headers.get(Constants.Network.APP_VERSION_HEADER));
+    }
+
+    @Test
+    public void getConnection_fallsBackToCurrent_whenOverrideIsEmpty() throws IOException {
+        JSErrorDataSender sender = new JSErrorDataSender(
+                new Payload(PAYLOAD_BYTES), AgentConfiguration.getInstance(), "");
+
+        HttpURLConnection conn = sender.getConnection();
+        Map<String, List<String>> headers = conn.getRequestProperties();
+
+        Assert.assertEquals(List.of(Agent.getApplicationInformation().getAppVersion()),
+                headers.get(Constants.Network.APP_VERSION_HEADER));
+    }
+
+    @Test
+    public void getConnection_legacyTwoArgConstructor_fallsBackToCurrent() throws IOException {
+        JSErrorDataSender sender = new JSErrorDataSender(
+                new Payload(PAYLOAD_BYTES), AgentConfiguration.getInstance());
+
+        HttpURLConnection conn = sender.getConnection();
+        Map<String, List<String>> headers = conn.getRequestProperties();
+
+        Assert.assertEquals(List.of(Agent.getApplicationInformation().getAppVersion()),
+                headers.get(Constants.Network.APP_VERSION_HEADER));
+    }
+}

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -1048,13 +1048,17 @@ public final class NewRelic {
             handledExceptionAttributes = new HashMap<>(attributes);
         }
 
-        // Notify SessionReplay about the error for mode switching (if enabled)
-        if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+        boolean accepted = AgentDataController.sendAgentData(throwable, handledExceptionAttributes);
+
+        // Only notify SessionReplay once the exception has been accepted — gating on
+        // sendAgentData() ensures rejected exceptions (HandledExceptions/NativeReporting
+        // disabled, reporter failure) do not switch SR mode or activate logging.
+        if (accepted && agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
             AndroidAgentImpl.activateLoggingForSessionReplay();
             SessionReplay.onError();
         }
 
-        return AgentDataController.sendAgentData(throwable, handledExceptionAttributes);
+        return accepted;
     }
 
     /**
@@ -1134,7 +1138,17 @@ public final class NewRelic {
      * the JSError feature is disabled or the input is invalid.
      */
     public static boolean recordJavaScriptError(String name, String message, String stackTrace, boolean isFatal, Map<String, Object> additionalAttributes) {
-        return JSErrorDataController.getInstance().sendJSErrorData(name, message, stackTrace, isFatal, additionalAttributes);
+        boolean accepted = JSErrorDataController.getInstance().sendJSErrorData(name, message, stackTrace, isFatal, additionalAttributes);
+
+        // Only notify SessionReplay once the JS error has been accepted — gating on
+        // sendJSErrorData() ensures rejected errors (feature disabled, invalid name)
+        // do not switch SR mode or activate logging.
+        if (accepted && agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            AndroidAgentImpl.activateLoggingForSessionReplay();
+            SessionReplay.onError();
+        }
+
+        return accepted;
     }
 
     /**

--- a/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
@@ -991,6 +991,187 @@ public class NewRelicTest {
     }
 
     @Test
+    public void testHandledExceptionTriggersSessionReplayWhenEnabled() {
+        // When SR is enabled and the exception is accepted, the SR error path must
+        // run (samplingOverride flips to true via activateLoggingForSessionReplay()).
+        AgentDataReporterSpy.initialize(agentConfiguration);
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(true);
+
+            Assert.assertTrue("Should queue exception for delivery when SR is enabled",
+                    NewRelic.recordHandledException(new Exception("testException")));
+            Assert.assertTrue("Accepted exception must activate SR error path when SR is enabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testHandledExceptionDoesNotTriggerSessionReplayWhenDisabled() {
+        AgentDataReporterSpy.initialize(agentConfiguration);
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(false);
+
+            Assert.assertTrue("Should queue exception for delivery when SR is disabled",
+                    NewRelic.recordHandledException(new Exception("testException")));
+            Assert.assertFalse("Accepted exception must NOT activate SR error path when SR is disabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testHandledExceptionDoesNotTriggerSessionReplayWhenRejected() {
+        // When both HandledExceptions and NativeReporting are off, sendAgentData()
+        // returns false. The SR error path must NOT run for a rejected exception
+        // even when SR is enabled.
+        AgentDataReporterSpy.initialize(agentConfiguration);
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        boolean originalHandled = FeatureFlag.featureEnabled(FeatureFlag.HandledExceptions);
+        boolean originalNative = FeatureFlag.featureEnabled(FeatureFlag.NativeReporting);
+        try {
+            primeSessionReplayObservability(true);
+            NewRelic.disableFeature(FeatureFlag.HandledExceptions);
+            NewRelic.disableFeature(FeatureFlag.NativeReporting);
+
+            Assert.assertFalse("recordHandledException should be a no-op when HandledExceptions and NativeReporting are both disabled",
+                    NewRelic.recordHandledException(new Exception("testException")));
+            Assert.assertFalse("Rejected exception must NOT activate SR error path",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            if (originalHandled) {
+                NewRelic.enableFeature(FeatureFlag.HandledExceptions);
+            }
+            if (originalNative) {
+                NewRelic.enableFeature(FeatureFlag.NativeReporting);
+            }
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testRecordJavaScriptError() {
+        Assert.assertTrue("JSError feature should be enabled by default",
+                FeatureFlag.featureEnabled(FeatureFlag.JSError));
+
+        Assert.assertTrue("Should queue JS error for delivery",
+                NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorWithAttributes() {
+        HashMap<String, Object> attributes = new HashMap<>();
+        attributes.put("module", "junit");
+        attributes.put("fakedError", true);
+
+        Assert.assertTrue("Should queue JS error with attributes for delivery",
+                NewRelic.recordJavaScriptError("TypeError", "boom", "stack", true, attributes));
+
+        // verify null attribute set also
+        Assert.assertTrue("Should queue JS error with null attributes for delivery",
+                NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorFeatureDisabled() {
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(true);
+            NewRelic.disableFeature(FeatureFlag.JSError);
+
+            Assert.assertFalse("recordJavaScriptError should be a no-op when JSError feature is disabled",
+                    NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+            Assert.assertFalse("Rejected JS error must NOT activate SR error path when feature is disabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            NewRelic.enableFeature(FeatureFlag.JSError);
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorRejectsInvalidName() {
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(true);
+
+            Assert.assertFalse("Null error name must be rejected",
+                    NewRelic.recordJavaScriptError(null, "boom", "stack", false, null));
+            Assert.assertFalse("Rejected null-name JS error must NOT activate SR error path",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+
+            Assert.assertFalse("Empty error name must be rejected",
+                    NewRelic.recordJavaScriptError("", "boom", "stack", false, null));
+            Assert.assertFalse("Rejected empty-name JS error must NOT activate SR error path",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorTriggersSessionReplayWhenEnabled() {
+        // Mirrors the recordHandledException SessionReplay trigger pattern (NR-547254):
+        // when SR is enabled, a JS error must invoke the SR error path so error-mode
+        // sessions flush their buffer and sampled-start sessions evaluate the error
+        // sampling rate. The SR path must be safe to invoke even when SR runtime
+        // components are not initialized in this unit-test environment.
+        // We observe the SR-trigger side effect via LogReportingConfiguration's
+        // samplingOverride flag, which AndroidAgentImpl.activateLoggingForSessionReplay()
+        // flips to true on the SR error path.
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(true);
+
+            Assert.assertTrue("Should queue JS error for delivery when SR is enabled",
+                    NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+            Assert.assertTrue("Accepted JS error must activate SR error path when SR is enabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorDoesNotTriggerSessionReplayWhenDisabled() {
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(false);
+
+            Assert.assertTrue("Should queue JS error for delivery when SR is disabled",
+                    NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+            Assert.assertFalse("Accepted JS error must NOT activate SR error path when SR is disabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    /**
+     * Prepare LogReporting + SessionReplay state so the SR error path is observable
+     * via {@link com.newrelic.agent.android.logging.LogReportingConfiguration#isSamplingOverridden()}.
+     * AndroidAgentImpl.activateLoggingForSessionReplay() only flips samplingOverride
+     * when LogReporting is enabled and the level is not NONE.
+     */
+    private void primeSessionReplayObservability(boolean srEnabled) {
+        agentConfiguration.getSessionReplayConfiguration().setEnabled(srEnabled);
+        agentConfiguration.getLogReportingConfiguration().setLoggingEnabled(true);
+        agentConfiguration.getLogReportingConfiguration().setLogLevel(LogLevel.DEBUG);
+        agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+    }
+
+    @Test
     public void testRecordBreadCrumb() {
         Assert.assertTrue("MobileBreadcrumb event should be recorded", NewRelic.recordBreadcrumb("Name.foo"));
     }
@@ -1546,6 +1727,11 @@ public class NewRelicTest {
 
         @Override
         public void delete(AnalyticsAttribute attribute) {
+        }
+
+        @Override
+        public String getRootPath() {
+            return "";
         }
     }
 

--- a/agent/src/test/java/com/newrelic/agent/android/stores/TestEventStore.java
+++ b/agent/src/test/java/com/newrelic/agent/android/stores/TestEventStore.java
@@ -45,5 +45,10 @@ class TestEventStore implements AnalyticsEventStore {
     public void delete(AnalyticsEvent event) {
         events.remove(event);
     }
+
+    @Override
+    public String getRootPath() {
+        return "";
+    }
 }
 

--- a/agent/src/test/java/com/newrelic/agent/android/test/stub/StubAnalyticsAttributeStore.java
+++ b/agent/src/test/java/com/newrelic/agent/android/test/stub/StubAnalyticsAttributeStore.java
@@ -35,5 +35,10 @@ public class StubAnalyticsAttributeStore implements AnalyticsAttributeStore {
     @Override
     public void delete(AnalyticsAttribute attribute) {
     }
+
+    @Override
+    public String getRootPath() {
+        return "";
+    }
 }
 


### PR DESCRIPTION
## Jira
- [NR-563075](https://issues.newrelic.com/browse/NR-563075)

## What & Why
Updates `MobileJSError` event attributes to use standard camelCase wire keys. Replaces the legacy `description` and `cause` keys with `errorName` and `errorMessage` for consistency with cross-platform reporting.

## Callouts
Wire-format change — verify backend ingestion and any downstream consumers expecting the old keys.

## Stack
Part **8 of 12** — split out from umbrella PR #483 to make review easier. Each PR builds on the previous one; merging in order is intended (GitHub will auto-retarget the next PR to `develop` as each one lands).

- **Previous:** #535
- **Next:** #537

## Test plan
- See umbrella PR #483 for the original end-to-end manual + automated coverage.
- Per-PR manual verification: TODO (author to fill in)

[NR-563075]: https://new-relic.atlassian.net/browse/NR-563075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ