### PR TITLE
[NR-547254] feat(js-error): integrate JS error reporting with Session Replay

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -1048,13 +1048,17 @@ public final class NewRelic {
             handledExceptionAttributes = new HashMap<>(attributes);
         }
 
-        // Notify SessionReplay about the error for mode switching (if enabled)
-        if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+        boolean accepted = AgentDataController.sendAgentData(throwable, handledExceptionAttributes);
+
+        // Only notify SessionReplay once the exception has been accepted — gating on
+        // sendAgentData() ensures rejected exceptions (HandledExceptions/NativeReporting
+        // disabled, reporter failure) do not switch SR mode or activate logging.
+        if (accepted && agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
             AndroidAgentImpl.activateLoggingForSessionReplay();
             SessionReplay.onError();
         }
 
-        return AgentDataController.sendAgentData(throwable, handledExceptionAttributes);
+        return accepted;
     }
 
     /**
@@ -1134,13 +1138,17 @@ public final class NewRelic {
      * the JSError feature is disabled or the input is invalid.
      */
     public static boolean recordJavaScriptError(String name, String message, String stackTrace, boolean isFatal, Map<String, Object> additionalAttributes) {
-        // Notify SessionReplay about the JS error for mode switching (if enabled)
-        if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+        boolean accepted = JSErrorDataController.getInstance().sendJSErrorData(name, message, stackTrace, isFatal, additionalAttributes);
+
+        // Only notify SessionReplay once the JS error has been accepted — gating on
+        // sendJSErrorData() ensures rejected errors (feature disabled, invalid name)
+        // do not switch SR mode or activate logging.
+        if (accepted && agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
             AndroidAgentImpl.activateLoggingForSessionReplay();
             SessionReplay.onError();
         }
 
-        return JSErrorDataController.getInstance().sendJSErrorData(name, message, stackTrace, isFatal, additionalAttributes);
+        return accepted;
     }
 
     /**

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -1134,6 +1134,12 @@ public final class NewRelic {
      * the JSError feature is disabled or the input is invalid.
      */
     public static boolean recordJavaScriptError(String name, String message, String stackTrace, boolean isFatal, Map<String, Object> additionalAttributes) {
+        // Notify SessionReplay about the JS error for mode switching (if enabled)
+        if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            AndroidAgentImpl.activateLoggingForSessionReplay();
+            SessionReplay.onError();
+        }
+
         return JSErrorDataController.getInstance().sendJSErrorData(name, message, stackTrace, isFatal, additionalAttributes);
     }
 

--- a/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
@@ -991,6 +991,66 @@ public class NewRelicTest {
     }
 
     @Test
+    public void testRecordJavaScriptError() {
+        Assert.assertTrue("JSError feature should be enabled by default",
+                FeatureFlag.featureEnabled(FeatureFlag.JSError));
+
+        Assert.assertTrue("Should queue JS error for delivery",
+                NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorWithAttributes() {
+        HashMap<String, Object> attributes = new HashMap<>();
+        attributes.put("module", "junit");
+        attributes.put("fakedError", true);
+
+        Assert.assertTrue("Should queue JS error with attributes for delivery",
+                NewRelic.recordJavaScriptError("TypeError", "boom", "stack", true, attributes));
+
+        // verify null attribute set also
+        Assert.assertTrue("Should queue JS error with null attributes for delivery",
+                NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorFeatureDisabled() {
+        try {
+            NewRelic.disableFeature(FeatureFlag.JSError);
+            Assert.assertFalse("recordJavaScriptError should be a no-op when JSError feature is disabled",
+                    NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+        } finally {
+            NewRelic.enableFeature(FeatureFlag.JSError);
+        }
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorRejectsInvalidName() {
+        Assert.assertFalse("Null error name must be rejected",
+                NewRelic.recordJavaScriptError(null, "boom", "stack", false, null));
+        Assert.assertFalse("Empty error name must be rejected",
+                NewRelic.recordJavaScriptError("", "boom", "stack", false, null));
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorTriggersSessionReplayWhenEnabled() {
+        // Mirrors the recordHandledException SessionReplay trigger pattern (NR-547254):
+        // when SR is enabled, a JS error must invoke the SR error path so error-mode
+        // sessions flush their buffer and sampled-start sessions evaluate the error
+        // sampling rate. The SR path must be safe to invoke even when SR runtime
+        // components are not initialized in this unit-test environment.
+        boolean originalEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(true);
+
+            Assert.assertTrue("Should queue JS error for delivery when SR is enabled",
+                    NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalEnabled);
+        }
+    }
+
+    @Test
     public void testRecordBreadCrumb() {
         Assert.assertTrue("MobileBreadcrumb event should be recorded", NewRelic.recordBreadcrumb("Name.foo"));
     }
@@ -1546,6 +1606,11 @@ public class NewRelicTest {
 
         @Override
         public void delete(AnalyticsAttribute attribute) {
+        }
+
+        @Override
+        public String getRootPath() {
+            return "";
         }
     }
 

--- a/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/NewRelicTest.java
@@ -991,6 +991,72 @@ public class NewRelicTest {
     }
 
     @Test
+    public void testHandledExceptionTriggersSessionReplayWhenEnabled() {
+        // When SR is enabled and the exception is accepted, the SR error path must
+        // run (samplingOverride flips to true via activateLoggingForSessionReplay()).
+        AgentDataReporterSpy.initialize(agentConfiguration);
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(true);
+
+            Assert.assertTrue("Should queue exception for delivery when SR is enabled",
+                    NewRelic.recordHandledException(new Exception("testException")));
+            Assert.assertTrue("Accepted exception must activate SR error path when SR is enabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testHandledExceptionDoesNotTriggerSessionReplayWhenDisabled() {
+        AgentDataReporterSpy.initialize(agentConfiguration);
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(false);
+
+            Assert.assertTrue("Should queue exception for delivery when SR is disabled",
+                    NewRelic.recordHandledException(new Exception("testException")));
+            Assert.assertFalse("Accepted exception must NOT activate SR error path when SR is disabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
+    public void testHandledExceptionDoesNotTriggerSessionReplayWhenRejected() {
+        // When both HandledExceptions and NativeReporting are off, sendAgentData()
+        // returns false. The SR error path must NOT run for a rejected exception
+        // even when SR is enabled.
+        AgentDataReporterSpy.initialize(agentConfiguration);
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        boolean originalHandled = FeatureFlag.featureEnabled(FeatureFlag.HandledExceptions);
+        boolean originalNative = FeatureFlag.featureEnabled(FeatureFlag.NativeReporting);
+        try {
+            primeSessionReplayObservability(true);
+            NewRelic.disableFeature(FeatureFlag.HandledExceptions);
+            NewRelic.disableFeature(FeatureFlag.NativeReporting);
+
+            Assert.assertFalse("recordHandledException should be a no-op when HandledExceptions and NativeReporting are both disabled",
+                    NewRelic.recordHandledException(new Exception("testException")));
+            Assert.assertFalse("Rejected exception must NOT activate SR error path",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            if (originalHandled) {
+                NewRelic.enableFeature(FeatureFlag.HandledExceptions);
+            }
+            if (originalNative) {
+                NewRelic.enableFeature(FeatureFlag.NativeReporting);
+            }
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    @Test
     public void testRecordJavaScriptError() {
         Assert.assertTrue("JSError feature should be enabled by default",
                 FeatureFlag.featureEnabled(FeatureFlag.JSError));
@@ -1015,21 +1081,41 @@ public class NewRelicTest {
 
     @Test
     public void testRecordJavaScriptErrorFeatureDisabled() {
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
         try {
+            primeSessionReplayObservability(true);
             NewRelic.disableFeature(FeatureFlag.JSError);
+
             Assert.assertFalse("recordJavaScriptError should be a no-op when JSError feature is disabled",
                     NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+            Assert.assertFalse("Rejected JS error must NOT activate SR error path when feature is disabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
         } finally {
             NewRelic.enableFeature(FeatureFlag.JSError);
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
         }
     }
 
     @Test
     public void testRecordJavaScriptErrorRejectsInvalidName() {
-        Assert.assertFalse("Null error name must be rejected",
-                NewRelic.recordJavaScriptError(null, "boom", "stack", false, null));
-        Assert.assertFalse("Empty error name must be rejected",
-                NewRelic.recordJavaScriptError("", "boom", "stack", false, null));
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(true);
+
+            Assert.assertFalse("Null error name must be rejected",
+                    NewRelic.recordJavaScriptError(null, "boom", "stack", false, null));
+            Assert.assertFalse("Rejected null-name JS error must NOT activate SR error path",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+
+            Assert.assertFalse("Empty error name must be rejected",
+                    NewRelic.recordJavaScriptError("", "boom", "stack", false, null));
+            Assert.assertFalse("Rejected empty-name JS error must NOT activate SR error path",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
     }
 
     @Test
@@ -1039,15 +1125,50 @@ public class NewRelicTest {
         // sessions flush their buffer and sampled-start sessions evaluate the error
         // sampling rate. The SR path must be safe to invoke even when SR runtime
         // components are not initialized in this unit-test environment.
-        boolean originalEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        // We observe the SR-trigger side effect via LogReportingConfiguration's
+        // samplingOverride flag, which AndroidAgentImpl.activateLoggingForSessionReplay()
+        // flips to true on the SR error path.
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
         try {
-            agentConfiguration.getSessionReplayConfiguration().setEnabled(true);
+            primeSessionReplayObservability(true);
 
             Assert.assertTrue("Should queue JS error for delivery when SR is enabled",
                     NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+            Assert.assertTrue("Accepted JS error must activate SR error path when SR is enabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
         } finally {
-            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalEnabled);
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
         }
+    }
+
+    @Test
+    public void testRecordJavaScriptErrorDoesNotTriggerSessionReplayWhenDisabled() {
+        boolean originalSrEnabled = agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled();
+        try {
+            primeSessionReplayObservability(false);
+
+            Assert.assertTrue("Should queue JS error for delivery when SR is disabled",
+                    NewRelic.recordJavaScriptError("TypeError", "boom", "stack", false, null));
+            Assert.assertFalse("Accepted JS error must NOT activate SR error path when SR is disabled",
+                    agentConfiguration.getLogReportingConfiguration().isSamplingOverridden());
+        } finally {
+            agentConfiguration.getSessionReplayConfiguration().setEnabled(originalSrEnabled);
+            agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
+        }
+    }
+
+    /**
+     * Prepare LogReporting + SessionReplay state so the SR error path is observable
+     * via {@link com.newrelic.agent.android.logging.LogReportingConfiguration#isSamplingOverridden()}.
+     * AndroidAgentImpl.activateLoggingForSessionReplay() only flips samplingOverride
+     * when LogReporting is enabled and the level is not NONE.
+     */
+    private void primeSessionReplayObservability(boolean srEnabled) {
+        agentConfiguration.getSessionReplayConfiguration().setEnabled(srEnabled);
+        agentConfiguration.getLogReportingConfiguration().setLoggingEnabled(true);
+        agentConfiguration.getLogReportingConfiguration().setLogLevel(LogLevel.DEBUG);
+        agentConfiguration.getLogReportingConfiguration().setSamplingOverride(false);
     }
 
     @Test

--- a/agent/src/test/java/com/newrelic/agent/android/stores/TestEventStore.java
+++ b/agent/src/test/java/com/newrelic/agent/android/stores/TestEventStore.java
@@ -45,5 +45,10 @@ class TestEventStore implements AnalyticsEventStore {
     public void delete(AnalyticsEvent event) {
         events.remove(event);
     }
+
+    @Override
+    public String getRootPath() {
+        return "";
+    }
 }
 

--- a/agent/src/test/java/com/newrelic/agent/android/test/stub/StubAnalyticsAttributeStore.java
+++ b/agent/src/test/java/com/newrelic/agent/android/test/stub/StubAnalyticsAttributeStore.java
@@ -35,5 +35,10 @@ public class StubAnalyticsAttributeStore implements AnalyticsAttributeStore {
     @Override
     public void delete(AnalyticsAttribute attribute) {
     }
+
+    @Override
+    public String getRootPath() {
+        return "";
+    }
 }
 


### PR DESCRIPTION
## Jira
- [NR-547254](https://issues.newrelic.com/browse/NR-547254)

## What & Why
Updates the `recordJavaScriptError` API to notify the Session Replay system when a JavaScript error occurs. Session replays correctly transition to error mode (flushing buffers) or evaluate sampling rates when a JS error is detected, mirroring the behavior of handled exceptions.


## Stack
Part **12 of 12** — split out from umbrella PR #483 to make review easier. Each PR builds on the previous one; merging in order is intended (GitHub will auto-retarget the next PR to `develop` as each one lands).

- **Previous:** #539
- **Next:** _(end of stack)_

## Test plan
- See umbrella PR #483 for the original end-to-end manual + automated coverage.
- Per-PR manual verification: TODO (author to fill in)

[NR-547254]: https://new-relic.atlassian.net/browse/NR-547254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ