### PR TITLE
[NR-538838] NewRelicMapUploadTask fix, backward compatible

### DIFF
--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
@@ -114,12 +114,17 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
         filteredOutput.contains("Maps will be tagged and uploaded for variants [")
         mapUploadVariants.each { var ->
             buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
-            with(new File(buildDir, "outputs/dexguard/mapping/${var}/${var}-mapping.txt")) {
+            // Check the tagged output file instead of original mapping file
+            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
+            }
+            // Check that original mapping file detection still works
+            with(new File(buildDir, "outputs/dexguard/mapping/${var}/${var}-mapping.txt")) {
+                exists()
                 filteredOutput.contains("Map file for variant [${var}] detected: [${getCanonicalPath()}]")
-                filteredOutput.contains("Tagging map [${getCanonicalPath()}] with buildID [") ||
-                        filteredOutput.contains("Map [${getCanonicalPath()}] has already been tagged")
+                filteredOutput.contains("Tagging map [") && filteredOutput.contains("] with buildID [") ||
+                        filteredOutput.contains("Map already tagged, skipping duplicate tag for [")
             }
         }
     }
@@ -194,11 +199,13 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
         }
         mapUploadVariants.each { var ->
             buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
+            // Bundle mapping should not be tagged (only APK mapping is tagged)
             with(new File(buildDir, "outputs/dexguard/mapping/bundle/release/mapping.txt")) {
                 exists()
                 !text.contains(Proguard.NR_MAP_PREFIX)
             }
-            with(new File(buildDir, "outputs/dexguard/mapping/${var}/${var}-mapping.txt")) {
+            // Check tagged output file for APK variant
+            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
             }

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
@@ -85,12 +85,17 @@ class PluginDexGuardRegressionSpec extends PluginSpec {
         mapUploadVariants.each { var ->
             buildResult.task(":newrelicMapUpload${var.capitalize()}")?.outcome == SUCCESS ||
                     buildResult.task(":newrelicMapUploadDexguard${var.capitalize()}")?.outcome == SUCCESS
-            with(new File(buildDir, "outputs/dexguard/mapping/${var}/${var}-mapping.txt")) {
+            // Check the tagged output file instead of original mapping file
+            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
+            }
+            // Check that original mapping file detection still works
+            with(new File(buildDir, "outputs/dexguard/mapping/${var}/${var}-mapping.txt")) {
+                exists()
                 filteredOutput.contains("Map file for variant [${var}] detected: [${getCanonicalPath()}]")
-                filteredOutput.contains("Tagging map [${getCanonicalPath()}] with buildID [") ||
-                        filteredOutput.contains("Map [${getCanonicalPath()}] has already been tagged")
+                filteredOutput.contains("Tagging map [") && filteredOutput.contains("] with buildID [") ||
+                        filteredOutput.contains("Map already tagged, skipping duplicate tag for [")
             }
         }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
@@ -98,12 +98,16 @@ class PluginJDK11SmokeSpec extends PluginSpec {
         testVariants.each { var ->
             buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
 
-            with(new File(buildDir, "outputs/mapping/${var}/mapping.txt")) {
+            // Check the tagged output file instead of original mapping file
+            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
+            }
+            // Check that original mapping file detection still works
+            with(new File(buildDir, "outputs/mapping/${var}/mapping.txt")) {
                 filteredOutput.contains("Map file for variant [${var}] detected: [${getCanonicalPath()}]")
-                (filteredOutput.contains("Tagging map [${getCanonicalPath()}] with buildID [") &&
-                        filteredOutput.contains("Map [${getCanonicalPath()}] has already been tagged"))
+                (filteredOutput.contains("Tagging map [") && filteredOutput.contains("] with buildID [")) ||
+                        filteredOutput.contains("Map already tagged, skipping duplicate tag for [")
             }
         }
     }

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
@@ -96,12 +96,16 @@ class PluginJDK17SmokeSpec extends PluginSpec {
 
         mapUploadVariants.each { var ->
             buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
-            with(new File(buildDir, "outputs/mapping/${var}/mapping.txt")) {
+            // Check the tagged output file instead of original mapping file
+            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
+            }
+            // Check that original mapping file detection still works
+            with(new File(buildDir, "outputs/mapping/${var}/mapping.txt")) {
                 filteredOutput.contains("Map file for variant [${var}] detected: [${getCanonicalPath()}]")
-                (filteredOutput.contains("Tagging map [${getCanonicalPath()}] with buildID [") &&
-                        filteredOutput.contains("Map [${getCanonicalPath()}] has already been tagged"))
+                (filteredOutput.contains("Tagging map [") && filteredOutput.contains("] with buildID [")) ||
+                        filteredOutput.contains("Map already tagged, skipping duplicate tag for [")
             }
         }
     }

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginRegressionSpec.groovy
@@ -72,7 +72,8 @@ class PluginRegressionSpec extends PluginSpec {
                 (task(":${NewRelicMapUploadTask.NAME}${var.capitalize()}")?.outcome == SUCCESS ||
                         task("newrelicMapUploadMinify${var.capitalize()}WithR8")?.outcome == SUCCESS)
 
-                with(new File(buildDir, "outputs/mapping/${var}/mapping.txt")) {
+                // Check the tagged output file instead of original mapping file
+                with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                     exists()
                     text.contains(Proguard.NR_MAP_PREFIX)
                 }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicMapUploadTaskTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicMapUploadTaskTest.groovy
@@ -55,4 +55,38 @@ class NewRelicMapUploadTaskTest extends PluginTest {
     void getLogger() {
         Assert.assertEquals(provider.getLogger(), NewRelicGradlePlugin.LOGGER)
     }
+
+    @Test
+    void getTaggedMappingFile() {
+        def taggedFile = provider.getTaggedMappingFile()
+        def expectedPath = project.layout.buildDirectory.file("outputs/newrelic/release/mapping.txt").get().asFile
+
+        Assert.assertEquals(expectedPath.absolutePath, taggedFile.absolutePath)
+        Assert.assertTrue("Tagged file path should contain variant name",
+                          taggedFile.absolutePath.contains("release"))
+        Assert.assertTrue("Tagged file should be separate from input",
+                          taggedFile != provider.getMappingFile().asFile.get())
+    }
+
+    @Test
+    void getTaggedMappingFileWithCompoundVariantName() {
+        // Test compound variant names (flavor + build type) like "googleQa", "amazonRelease", etc.
+        def compoundProvider = plugin.buildHelper.variantAdapter.registerOrNamed(
+                "testMapUploadGoogleQa", NewRelicMapUploadTask) { task ->
+            task.variantName.set("googleQa")
+            task.buildId.set("test-build-id")
+            task.mapProvider.set("r8")
+            task.projectRoot.set(project.layout.projectDirectory)
+        }.get()
+
+        def taggedFile = compoundProvider.getTaggedMappingFile()
+        def expectedPath = project.layout.buildDirectory.file("outputs/newrelic/googleQa/mapping.txt").get().asFile
+
+        Assert.assertEquals("Compound variant names should work correctly",
+                          expectedPath.absolutePath, taggedFile.absolutePath)
+        Assert.assertTrue("Tagged file path should contain compound variant name",
+                          taggedFile.absolutePath.contains("googleQa"))
+        Assert.assertTrue("Output path should be isolated per variant",
+                          !taggedFile.absolutePath.contains("release"))
+    }
 }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicMapUploadTaskTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicMapUploadTaskTest.groovy
@@ -89,4 +89,79 @@ class NewRelicMapUploadTaskTest extends PluginTest {
         Assert.assertTrue("Output path should be isolated per variant",
                           !taggedFile.absolutePath.contains("release"))
     }
+
+    @Test
+    void taskExecutionConditionsWithRegeneratedInput() {
+        // Test the critical scenario: existing tagged output + regenerated input should trigger execution
+        def testProvider = plugin.buildHelper.variantAdapter.registerOrNamed(
+                "testMapUploadFreshness", NewRelicMapUploadTask) { task ->
+            task.variantName.set("testVariant")
+            task.buildId.set("test-build-id-123")
+            task.mapProvider.set("r8")
+            task.projectRoot.set(project.layout.projectDirectory)
+        }.get()
+
+        // Create mock input mapping file
+        def mockInputFile = new File(project.buildDir, "outputs/mapping/testVariant/mapping.txt")
+        mockInputFile.parentFile.mkdirs()
+        mockInputFile.text = """
+# Original mapping content
+com.example.Test -> a:
+    void method() -> a
+"""
+
+        // Create mock tagged output with correct tag (simulates previous run)
+        def taggedFile = testProvider.getTaggedMappingFile()
+        taggedFile.parentFile.mkdirs()
+        taggedFile.text = """
+# Original mapping content
+com.example.Test -> a:
+    void method() -> a
+
+# NR_MAP_PREFIX=test-build-id-123
+"""
+
+        // Initially, tagged output is newer (task should be up-to-date)
+        Thread.sleep(100) // Ensure time difference
+        def initialInputTime = mockInputFile.lastModified()
+        def initialTaggedTime = taggedFile.lastModified()
+
+        Assert.assertTrue("Initially tagged file should be newer",
+                         initialTaggedTime >= initialInputTime)
+
+        // Now simulate input regeneration (R8/ProGuard runs again)
+        Thread.sleep(100) // Ensure time difference
+        mockInputFile.text = """
+# Regenerated mapping content (different obfuscation)
+com.example.Test -> b:
+    void method() -> b
+"""
+
+        def regeneratedInputTime = mockInputFile.lastModified()
+        Assert.assertTrue("Input should now be newer after regeneration",
+                         regeneratedInputTime > initialTaggedTime)
+
+        // Test onlyIf condition - should return true because input is newer
+        testProvider.configure { task ->
+            task.mappingFile.set(mockInputFile)
+        }
+
+        // Simulate the onlyIf logic
+        def tag = "# NR_MAP_PREFIX=test-build-id-123"
+        def inputExists = mockInputFile.exists()
+        def taggedExists = taggedFile.exists()
+        def taggedContainsTag = taggedExists && taggedFile.text.contains(tag)
+        def inputNewer = inputExists && taggedExists && (mockInputFile.lastModified() > taggedFile.lastModified())
+        def shouldExecute = inputExists && (!taggedContainsTag || inputNewer)
+
+        Assert.assertTrue("Input file should exist", inputExists)
+        Assert.assertTrue("Tagged file should exist", taggedExists)
+        Assert.assertTrue("Tagged file should contain tag", taggedContainsTag)
+        Assert.assertTrue("Input should be newer than tagged output", inputNewer)
+        Assert.assertTrue("Task should execute because input is newer", shouldExecute)
+
+        // Test upToDateWhen condition - should return false because input is newer
+        def isUpToDate = inputExists && taggedExists && taggedContainsTag && !inputNewer
+        Assert.assertFalse("Task should NOT be up-to-date when input is newer", isUpToDate)
+    }
 }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 abstract class NewRelicMapUploadTask extends DefaultTask {
@@ -37,6 +38,15 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
 
     @Internal
     abstract DirectoryProperty getProjectRoot()
+
+    /**
+     * FIX: Use an @OutputFile to prevent mutating the @InputFile.
+     * This ensures BundleTool can read the original mapping file without ZipExceptions.
+     */
+    @OutputFile
+    File getTaggedMappingFile() {
+        return project.layout.buildDirectory.file("outputs/newrelic/" + variantName.get() + "/mapping.txt").get().asFile
+    }
 
     @Internal
     abstract Property<ConfigurableFileCollection> getTaggedMappingFiles()
@@ -63,39 +73,46 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
             }
 
             if (mappingFile.isPresent()) {
-                // we know where map should be (Gradle tells us)
-                def mapFilePath = mappingFile.asFile.get()
+                def infile = mappingFile.asFile.get()
+                def taggedFile = getTaggedMappingFile()
 
-                if (taggedMappingFiles.isPresent() && !taggedMappingFiles.get().empty) {
-                    def infile = mappingFile.asFile.get()
-                    taggedMappingFiles.get().files.add(project.file(mappingFile))
-                    mapFilePath = taggedMappingFiles.get().files.first().asFile
-                }
+                if (infile.exists()) {
+                    logger.debug("Map file for variant [${variantName.get()}] detected: [${infile.absolutePath}]")
 
-                if (mapFilePath?.exists()) {
-                    logger.debug("Map file for variant [${variantName.get()}] detected: [${mapFilePath.absolutePath}]")
+                    taggedFile.parentFile.mkdirs()
 
-                    agentOptions.put(Proguard.MAPPING_FILE_KEY, mapFilePath.absolutePath)
+                    /**
+                     * ROOT CAUSE FIX:
+                     * Instead of infile.text = ..., we stream to taggedFile.
+                     * This keeps infile read-only for concurrent BundleTool tasks.
+                     * Includes duplicate tag prevention for backwards compatibility.
+                     */
+                    taggedFile.withOutputStream { os ->
+                        def originalContent = infile.text
+                        os.write(originalContent.getBytes("UTF-8"))
+
+                        // Restore duplicate prevention logic for backwards compatibility
+                        if (!originalContent.contains(Proguard.NR_MAP_PREFIX)) {
+                            String tag = BuildHelper.NEWLN + Proguard.NR_MAP_PREFIX + buildId.get() + BuildHelper.NEWLN
+                            os.write(tag.getBytes("UTF-8"))
+                            logger.info("Tagging map [${taggedFile.getAbsolutePath()}] with buildID [${buildId.get()}]")
+                        } else {
+                            logger.debug("Map already tagged, skipping duplicate tag for [${taggedFile.getAbsolutePath()}]")
+                        }
+                    }
+
+                    agentOptions.put(Proguard.MAPPING_FILE_KEY, taggedFile.absolutePath)
                     agentOptions.put(Proguard.MAPPING_PROVIDER_KEY, mapProvider.get())
                     agentOptions.put(Proguard.VARIANT_KEY, variantName.get())
                     agentOptions.put(BuildId.BUILD_ID_KEY, buildId.get())
 
-                    // tag the map now to avoid Gradle race conditions
-                    mapFilePath.with {
-                        if (!text.contains(Proguard.NR_MAP_PREFIX)) {
-                            text = text + BuildHelper.NEWLN +
-                                    Proguard.NR_MAP_PREFIX + buildId.get() + BuildHelper.NEWLN
-                            logger.info("Tagging map [" + it.getAbsolutePath() + "] with buildID [" + buildId.get() + "]");
-                        }
-                    }
-
                     new Proguard(NewRelicGradlePlugin.LOGGER, agentOptions).findAndSendMapFile()
                 } else {
-                    logger.debug("No map file for variant [${variantName.get()}] detected: [${mapFilePath.absolutePath}]")
+                    logger.debug("No map file for variant [${variantName.get()}] detected at [${infile.absolutePath}]")
                 }
 
             } else {
-                logger.warn("variant[${variantName.get()}] taggedMappingFile is null")
+                logger.warn("variant[${variantName.get()}] mappingFile is not present")
             }
 
         } catch (Exception e) {

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
@@ -41,7 +41,6 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
 
     /**
      * FIX: Use an @OutputFile to prevent mutating the @InputFile.
-     * This ensures BundleTool can read the original mapping file without ZipExceptions.
      */
     @OutputFile
     File getTaggedMappingFile() {
@@ -81,12 +80,6 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
 
                     taggedFile.parentFile.mkdirs()
 
-                    /**
-                     * ROOT CAUSE FIX:
-                     * Instead of infile.text = ..., we stream to taggedFile.
-                     * This keeps infile read-only for concurrent BundleTool tasks.
-                     * Includes duplicate tag prevention for backwards compatibility.
-                     */
                     taggedFile.withOutputStream { os ->
                         def originalContent = infile.text
                         os.write(originalContent.getBytes("UTF-8"))

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -211,32 +211,40 @@ abstract class VariantAdapter {
                 // Execute the task only if the given spec is satisfied. The spec will
                 // be evaluated at task execution time, not during configuration.
                 def tag = "${Proguard.NR_MAP_PREFIX}${mapUploadTask.buildId.get()}"
-                def mf = it.mappingFile.asFile.get()
-                def exists = mf.exists()
-                def containsTag = exists && mf.text.contains(tag)
-                def shouldExecute = exists && !containsTag
+                def inputFile = it.mappingFile.asFile.get()
+                def taggedFile = it.getTaggedMappingFile()
+                def inputExists = inputFile.exists()
+                def taggedExists = taggedFile.exists()
+                def taggedContainsTag = taggedExists && taggedFile.text.contains(tag)
+                def shouldExecute = inputExists && !taggedContainsTag
 
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Checking execution conditions for variant [${variantName}]")
-                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Mapping file path: ${mf.absolutePath}")
-                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Mapping file exists: ${exists}")
+                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Input mapping file path: ${inputFile.absolutePath}")
+                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Tagged output file path: ${taggedFile.absolutePath}")
+                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Input file exists: ${inputExists}")
+                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Tagged file exists: ${taggedExists}")
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Build ID tag: ${tag}")
-                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Mapping file contains tag: ${containsTag}")
+                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Tagged file contains tag: ${taggedContainsTag}")
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Should execute: ${shouldExecute}")
 
                 return shouldExecute
             }
 
             mapUploadTask.outputs.upToDateWhen {
-                def mf = it.mappingFile.asFile.get()
+                def inputFile = it.mappingFile.asFile.get()
+                def taggedFile = it.getTaggedMappingFile()
                 def tag = "${Proguard.NR_MAP_PREFIX}${mapUploadTask.buildId.get()}"
-                def exists = mf.exists()
-                def containsTag = exists && mf.text.contains(tag)
-                def isUpToDate = exists && containsTag
+                def inputExists = inputFile.exists()
+                def taggedExists = taggedFile.exists()
+                def taggedContainsTag = taggedExists && taggedFile.text.contains(tag)
+                def isUpToDate = inputExists && taggedExists && taggedContainsTag
 
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Checking up-to-date status for variant [${variantName}]")
-                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Mapping file path: ${mf.absolutePath}")
-                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Mapping file exists: ${exists}")
-                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Contains tag: ${containsTag}")
+                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Input mapping file path: ${inputFile.absolutePath}")
+                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Tagged output file path: ${taggedFile.absolutePath}")
+                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Input file exists: ${inputExists}")
+                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Tagged file exists: ${taggedExists}")
+                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Tagged file contains tag: ${taggedContainsTag}")
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Is up-to-date: ${isUpToDate}")
 
                 return isUpToDate

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -216,7 +216,9 @@ abstract class VariantAdapter {
                 def inputExists = inputFile.exists()
                 def taggedExists = taggedFile.exists()
                 def taggedContainsTag = taggedExists && taggedFile.text.contains(tag)
-                def shouldExecute = inputExists && !taggedContainsTag
+
+                def inputNewer = inputExists && taggedExists && (inputFile.lastModified() > taggedFile.lastModified())
+                def shouldExecute = inputExists && (!taggedContainsTag || inputNewer)
 
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Checking execution conditions for variant [${variantName}]")
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Input mapping file path: ${inputFile.absolutePath}")
@@ -225,6 +227,7 @@ abstract class VariantAdapter {
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Tagged file exists: ${taggedExists}")
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Build ID tag: ${tag}")
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Tagged file contains tag: ${taggedContainsTag}")
+                it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Input newer than output: ${inputNewer}")
                 it.logger.lifecycle("NewRelicMapUploadTask.onlyIf: Should execute: ${shouldExecute}")
 
                 return shouldExecute
@@ -237,7 +240,9 @@ abstract class VariantAdapter {
                 def inputExists = inputFile.exists()
                 def taggedExists = taggedFile.exists()
                 def taggedContainsTag = taggedExists && taggedFile.text.contains(tag)
-                def isUpToDate = inputExists && taggedExists && taggedContainsTag
+
+                def inputNewer = inputExists && taggedExists && (inputFile.lastModified() > taggedFile.lastModified())
+                def isUpToDate = inputExists && taggedExists && taggedContainsTag && !inputNewer
 
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Checking up-to-date status for variant [${variantName}]")
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Input mapping file path: ${inputFile.absolutePath}")
@@ -245,6 +250,7 @@ abstract class VariantAdapter {
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Input file exists: ${inputExists}")
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Tagged file exists: ${taggedExists}")
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Tagged file contains tag: ${taggedContainsTag}")
+                it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Input newer than output: ${inputNewer}")
                 it.logger.lifecycle("NewRelicMapUploadTask.upToDateWhen: Is up-to-date: ${isUpToDate}")
 
                 return isUpToDate


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-538838](https://newrelic.atlassian.net/browse/NR-538838)
Ticket: https://new-relic.atlassian.net/browse/NR-538838

What's changed:
1. Fix for NewRelicMapUploadTask writes to @InputFile mapping file, causing concurrent ZipExceptions in BundleTool
2. Backward compatible
3. Add unit tests

[NR-538838]: https://new-relic.atlassian.net/browse/NR-538838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ