### PR TITLE
fix(NR-562135): Keep session attributes intact during shutdown harvest

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -1062,10 +1062,10 @@ public class AndroidAgentImpl implements
             //clear activity traces
             TraceMachine.clearActivityHistory();
 
-            //clear analytics
+            //clear pending events only; session attributes must survive for the final shutdown harvest
             AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
             if (analyticsController != null) {
-                analyticsController.clear();
+                analyticsController.getEventManager().empty();
             }
 
             //clear measurementEngine

--- a/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
@@ -453,6 +453,31 @@ public class AndroidAgentImplTest {
     }
 
 
+    @Test
+    public void testShutdownHarvestIncludesFullSessionAttributes() throws Exception {
+        agentStart();
+
+        final AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
+        final int systemAttrCountBeforeShutdown = analyticsController.getSystemAttributes().size();
+        Assert.assertTrue("Agent should have system attributes after start", systemAttrCountBeforeShutdown > 1);
+
+        final int[] systemAttrCountDuringHarvest = {-1};
+        Harvest.addHarvestListener(new HarvestAdapter() {
+            @Override
+            public void onHarvestBefore() {
+                systemAttrCountDuringHarvest[0] = analyticsController.getSystemAttributes().size();
+            }
+        });
+
+        NewRelic.isShutdown = true;
+        agentImpl.stop(true);
+        NewRelic.isShutdown = false;
+
+        Assert.assertTrue(
+                "Shutdown harvest must include full session attributes, not just sessionDuration. Got: " + systemAttrCountDuringHarvest[0],
+                systemAttrCountDuringHarvest[0] > 1);
+    }
+
     private void agentStart() throws InterruptedException {
         Agent.start();
         Thread.sleep(1 * 500);


### PR DESCRIPTION
jira ticket: NR-562135

## Summary

Fixes a bug where session attributes (e.g. `sessionDuration`, `appBuild`, `osName`, etc.) were missing from the final harvest payload sent on agent shutdown.

## Root Cause

During shutdown, `AndroidAgentImpl.stop()` called `analyticsController.clear()` to flush state before the final harvest. The problem is that `AnalyticsControllerImpl.clear()` wipes **both** the event queue **and** all session attributes (`systemAttributes` and `userAttributes`):

```java
// AnalyticsControllerImpl.clear()
systemAttributes.clear();   // <-- nukes all session attributes
userAttributes.clear();     // <-- nukes all session attributes
eventManager.empty();       // clears queued events
```

Because `stop()` triggers a harvest immediately after this call, the harvest payload was built with an empty attribute set — resulting in events that carried no session context at all.

## Fix

Replace `analyticsController.clear()` with `analyticsController.getEventManager().empty()`, which only drains the pending event queue without touching session attributes:

```java
// Before (incorrect — wipes session attributes before harvest)
analyticsController.clear();

// After (correct — only empties queued events; attributes survive for the shutdown harvest)
analyticsController.getEventManager().empty();
```

This ensures that when the shutdown harvest fires, all session attributes are still present and will be attached to the outgoing payload.


## Checklist

- [x] Bug reproduced and root cause identified
- [x] Fix is surgical — only the shutdown code path is affected
- [x] Unit test added to prevent regression