### PR TITLE
chore(NR-572283): Automate including jira link in PR body

### DIFF
--- a/.github/workflows/jira-link.yml
+++ b/.github/workflows/jira-link.yml
@@ -1,0 +1,21 @@
+name: Add JIRA Links
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  add-jira-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codenamegrant/jira-pr-link-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          jira-base-url: 'https://newrelic.atlassian.net'
+          jira-link-mode: 'body-start'
+          issue-pattern: '(NR-\d+)'


### PR DESCRIPTION
Include a new github action to include a link to the jira ticket IF the title includes the ticket number

Pattern: `NR-###`


_Example of result from running the new jira-link action. Note the action has to be merged into the main branch before use._
<img width="914" height="286" alt="Screenshot 2026-06-03 at 4 39 54 PM" src="https://github.com/user-attachments/assets/52beb23b-14f2-48dd-8d43-df8f6e6e1258" />
