### PR TITLE
chore: Removes extra `permissions` key

### DIFF
--- a/.github/workflows/compatibility-matrix-test.yml
+++ b/.github/workflows/compatibility-matrix-test.yml
@@ -21,9 +21,6 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
-
 jobs:
   # Read the compatibility matrix and set up the test matrix
   setup:


### PR DESCRIPTION
I'm not sure when the duplicate key was added back into [compatibility-matrix-test.yml](https://github.com/newrelic/newrelic-android-agent/pull/555/changes#diff-b16ca770315c9e18c5e10ddaf0adc4111884ae41fd2acd1e1bc975a7f89b214c) This PR removes the duplicate again.