### PR TITLE
NR-572735 added a way to detect KMP and add a supportability metric for it

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -68,6 +68,7 @@ public class MetricNames {
 
     public static final String SUPPORTABILITY_MOBILE_ANDROID = "Supportability/Mobile/Android/";
     public static final String SUPPORTABILITY_MOBILE_ANDROID_JETPACK_COMPOSE = SUPPORTABILITY_MOBILE_ANDROID + "JetPackCompose";
+    public static final String SUPPORTABILITY_MOBILE_ANDROID_HYBRID_PLATFORM_KMP = SUPPORTABILITY_MOBILE_ANDROID + "HybridPlatform/KMP";
     public static final String SUPPORTABILITY_NDK = SUPPORTABILITY_MOBILE_ANDROID + "NDK/";
     public static final String SUPPORTABILITY_NDK_INIT = SUPPORTABILITY_NDK + "Init";
     public static final String SUPPORTABILITY_NDK_START = SUPPORTABILITY_NDK + "Start";

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -259,6 +259,7 @@ public class AndroidAgentImpl implements
 
         //check if KMP is used for app
         if(KmpChecker.isKmpUsed()) {
+            log.debug("KMP detected.");
             StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_MOBILE_ANDROID_HYBRID_PLATFORM_KMP);
         }
 

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -77,6 +77,7 @@ import com.newrelic.agent.android.tracing.TraceMachine;
 import com.newrelic.agent.android.util.ActivityLifecycleBackgroundListener;
 import com.newrelic.agent.android.util.AndroidEncoder;
 import com.newrelic.agent.android.util.ComposeChecker;
+import com.newrelic.agent.android.util.KmpChecker;
 import com.newrelic.agent.android.util.Connectivity;
 import com.newrelic.agent.android.util.Encoder;
 import com.newrelic.agent.android.util.OfflineStorage;
@@ -254,6 +255,11 @@ public class AndroidAgentImpl implements
                 log.error("NativeReporting feature is enabled, but agent-ndk was not found (probably missing as a dependency).");
                 log.error("Native reporting will not be enabled");
             }
+        }
+
+        //check if KMP is used for app
+        if(KmpChecker.isKmpUsed()) {
+            StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_MOBILE_ANDROID_HYBRID_PLATFORM_KMP);
         }
 
     }

--- a/agent/src/main/java/com/newrelic/agent/android/util/KmpChecker.java
+++ b/agent/src/main/java/com/newrelic/agent/android/util/KmpChecker.java
@@ -1,0 +1,49 @@
+package com.newrelic.agent.android.util;
+
+public class KmpChecker {
+
+    public static boolean isKmpUsed() {
+        // Check for Kotlin runtime
+        if (!isKotlinPresent()) {
+            return false;
+        }
+
+        // Check for common KMP libraries
+        return hasKmpLibraries();
+    }
+
+    private static boolean isKotlinPresent() {
+        try {
+            Class.forName("kotlin.Unit");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+
+    private static boolean hasKmpLibraries() {
+        // Check for coroutines (most KMP apps use this for async operations)
+        boolean hasCoroutines = checkForClass("kotlinx.coroutines.Job");
+
+        // Check for serialization (many KMP apps use this for JSON parsing)
+        boolean hasSerialization = checkForClass("kotlinx.serialization.KSerializer");
+
+        // Check for Ktor client (popular KMP networking library)
+        boolean hasKtor = checkForClass("io.ktor.client.HttpClient");
+
+        return hasCoroutines || hasSerialization || hasKtor;
+    }
+
+    private static boolean checkForClass(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        } catch (Throwable e) {
+            return false;
+        }
+    }
+}

--- a/agent/src/main/java/com/newrelic/agent/android/util/KmpChecker.java
+++ b/agent/src/main/java/com/newrelic/agent/android/util/KmpChecker.java
@@ -24,16 +24,23 @@ public class KmpChecker {
     }
 
     private static boolean hasKmpLibraries() {
-        // Check for coroutines (most KMP apps use this for async operations)
-        boolean hasCoroutines = checkForClass("kotlinx.coroutines.Job");
+        // Check for Kotlin/Native concurrent primitives (only present in KMP projects with iOS/Native targets)
+        boolean hasNativeConcurrent = checkForClass("kotlin.native.concurrent.SharedImmutable") ||
+                                      checkForClass("kotlin.native.concurrent.FreezingException") ||
+                                      checkForClass("kotlin.native.concurrent.AtomicReference");
 
-        // Check for serialization (many KMP apps use this for JSON parsing)
-        boolean hasSerialization = checkForClass("kotlinx.serialization.KSerializer");
+        // Check for atomicfu (heavily used in KMP for shared state across platforms)
+        boolean hasAtomicFu = checkForClass("kotlinx.atomicfu.AtomicInt") ||
+                              checkForClass("kotlinx.atomicfu.AtomicRef");
 
-        // Check for Ktor client (popular KMP networking library)
-        boolean hasKtor = checkForClass("io.ktor.client.HttpClient");
+        // Check for Kotlin/JS indicators (present in KMP projects targeting JS)
+        boolean hasKotlinJs = checkForClass("kotlin.js.JsName") ||
+                              checkForClass("kotlin.js.JsExport");
 
-        return hasCoroutines || hasSerialization || hasKtor;
+        // Check for common.stdlib markers (multiplatform standard library)
+        boolean hasCommonStdlib = checkForClass("kotlin.native.concurrent.Worker");
+
+        return hasNativeConcurrent || hasAtomicFu || hasKotlinJs || hasCommonStdlib;
     }
 
     private static boolean checkForClass(String className) {


### PR DESCRIPTION
## Summary
  Adds automatic detection of Kotlin Multiplatform (KMP) usage in Android applications and reports a supportability metric when detected. This enables New Relic to track KMP adoption and provide better support for multiplatform applications https://new-relic.atlassian.net/browse/NR-572735

### Detection Strategy
  The `KmpChecker` uses runtime class detection to identify KMP projects by checking for platform-specific classes:

  - **Kotlin/Native classes** (`kotlin.native.concurrent.*`) - Present when iOS/Native targets are enabled
  - **AtomicFU classes** (`kotlinx.atomicfu.*`) - Used for shared mutable state across platforms
  - **Kotlin/JS classes** (`kotlin.js.*`) - Present when JavaScript/WASM targets are enabled

  ### Key Features
   **No false positives** - Only detects actual KMP projects, not regular Kotlin Android apps
   **Automatic** - Runs during agent initialization
   **Lightweight** - Simple class existence checks with no performance impact

  ### Limitations
  - **False negatives possible**: May not detect Android-only KMP builds (iOS targets disabled)
  - **Most production apps detected**: Real-world KMP apps typically ship with iOS targets enabled

  ## Metric Reported
  When KMP is detected, the agent increments:
  Supportability/Mobile/Android/HybridPlatform/KMP