### PR TITLE
[NR-575774]Handle unset start-up timestamps in AppStartUpMetrics

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
+++ b/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
@@ -9,6 +9,8 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 
 import com.newrelic.agent.android.AgentConfiguration;
@@ -59,6 +61,12 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
         AppTracer.getInstance().setAppOnCreateTime(SystemClock.uptimeMillis());
         if (this.context instanceof Application) {
             ((Application) this.context).registerActivityLifecycleCallbacks(this);
+            // Captures end of Application.onCreate(): ContentProvider.onCreate runs inside
+            // ActivityThread.handleBindApplication, which also runs Application.onCreate before
+            // returning. A Runnable posted here cannot execute until handleBindApplication
+            // returns, so it lands right after Application.onCreate completes.
+            new Handler(Looper.getMainLooper()).post(() ->
+                    AppTracer.getInstance().setAppOnCreateEndTime(SystemClock.uptimeMillis()));
         } else {
             log.error("Unable to register activity lifecycle callbacks: ApplicationContext is not an Application instance. " +
                     "Context type: " + (this.context != null ? this.context.getClass().getName() : "null"));
@@ -98,6 +106,12 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
     public void onActivityStarted(Activity activity) {
         log.debug("App launch time onActivityStarted " + new Date().getTime());
         AppTracer tracer = AppTracer.getInstance();
+        if (tracer.getFirstActivityStartTime() == 0L) {
+            // Cold-start fallback: the branch below only fires on background→foreground
+            // transitions, so without this firstActivityStartTime stays 0 on cold start
+            // and hotStartTime ends up ≈ uptime.
+            tracer.setFirstActivityStartTime(SystemClock.uptimeMillis());
+        }
         if (++activityReferences == 1 && !isActivityChangingConfig && isBackgrounded) {
             isForegrounded = true;
             isBackgrounded = false;

--- a/agent/src/main/java/com/newrelic/agent/android/rum/AppStartUpMetrics.java
+++ b/agent/src/main/java/com/newrelic/agent/android/rum/AppStartUpMetrics.java
@@ -6,44 +6,44 @@
 package com.newrelic.agent.android.rum;
 
 public class AppStartUpMetrics {
-    private Long contentProviderToAppStart = 0L;
     private Long applicationOnCreateTime = 0L;
     private Long appOnCreateEndToFirstActivityCreate = 0L;
     private Long firstActivityCreateToResume = 0L;
     private Long coldStartTime = 0L;
     private Long hotStartTime = 0L;
-    private Long warmStartTime = 0L;
 
     public AppStartUpMetrics() {
         AppTracer tracer = AppTracer.getInstance();
-        this.contentProviderToAppStart = tracer.getAppOnCreateTime() - tracer.getContentProviderStartedTime();
-        this.applicationOnCreateTime = tracer.getAppOnCreateEndTime() - tracer.getAppOnCreateTime();
-        this.appOnCreateEndToFirstActivityCreate = tracer.getFirstActivityCreatedTime() - tracer.getAppOnCreateEndTime();
-        this.firstActivityCreateToResume = tracer.getFirstActivityResumeTime() - tracer.getFirstActivityCreatedTime();
-        this.coldStartTime = tracer.getFirstActivityResumeTime() - tracer.getContentProviderStartedTime();
-        this.hotStartTime = tracer.getFirstActivityResumeTime() - tracer.getFirstActivityStartTime();
-        this.warmStartTime = tracer.getFirstActivityResumeTime() - tracer.getContentProviderStartedTime();
+        long appOnCreateEnd = tracer.getAppOnCreateEndTime();
+        long firstActivityStart = tracer.getFirstActivityStartTime();
+
+        // Guard against appOnCreateEndTime never being set (Handler.post Runnable
+        // didn't run before AppStartUpMetrics was constructed). Without the guard,
+        // these would be -uptime / +uptime instead of zero.
+        this.applicationOnCreateTime = appOnCreateEnd > 0
+                ? appOnCreateEnd - tracer.getAppOnCreateTime()
+                : 0L;
+        this.appOnCreateEndToFirstActivityCreate = appOnCreateEnd > 0
+                ? tracer.getFirstActivityCreatedTime() - appOnCreateEnd
+                : 0L;
+        this.firstActivityCreateToResume =
+                tracer.getFirstActivityResumeTime() - tracer.getFirstActivityCreatedTime();
+        this.coldStartTime =
+                tracer.getFirstActivityResumeTime() - tracer.getContentProviderStartedTime();
+        this.hotStartTime = firstActivityStart > 0
+                ? tracer.getFirstActivityResumeTime() - firstActivityStart
+                : 0L;
     }
 
     @Override
     public String toString() {
         return "NewRelicAppStartUpMetrics{" +
-                "contentProviderToAppStart=" + contentProviderToAppStart / 1000.0 +
-                ", applicationOnCreateTime=" + applicationOnCreateTime / 1000.0 +
+                "applicationOnCreateTime=" + applicationOnCreateTime / 1000.0 +
                 ", appOnCreateEndToFirstActivityCreate=" + appOnCreateEndToFirstActivityCreate / 1000.0 +
                 ", firstActivityCreateToResume=" + firstActivityCreateToResume / 1000.0 +
                 ", coldStartTime=" + coldStartTime / 1000.0 +
                 ", hotStartTime=" + hotStartTime / 1000.0 +
-                ", warmStartTime=" + warmStartTime / 1000.0 +
                 '}';
-    }
-
-    public Long getContentProviderToAppStart() {
-        return contentProviderToAppStart;
-    }
-
-    public void setContentProviderToAppStart(Long contentProviderToAppStart) {
-        this.contentProviderToAppStart = contentProviderToAppStart;
     }
 
     public Long getApplicationOnCreateTime() {
@@ -84,13 +84,5 @@ public class AppStartUpMetrics {
 
     public void setHotStartTime(Long hotStartTime) {
         this.hotStartTime = hotStartTime;
-    }
-
-    public Long getWarmStartTime() {
-        return warmStartTime;
-    }
-
-    public void setWarmStartTime(Long warmStartTime) {
-        this.warmStartTime = warmStartTime;
     }
 }

--- a/agent/src/test/java/com/newrelic/agent/android/rum/AppStartUpMetricsTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/rum/AppStartUpMetricsTest.java
@@ -15,7 +15,6 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class AppStartUpMetricsTest {
     private AppTracer tracerInstance;
-    private AppStartUpMetrics metrics;
 
     @Before
     public void setUp() {
@@ -30,18 +29,40 @@ public class AppStartUpMetricsTest {
         tracerInstance.setFirstActivityStartTime(600L);
         tracerInstance.setFirstActivityResumeTime(700L);
         tracerInstance.setLastAppPauseTime(800L);
-
-        metrics = new AppStartUpMetrics();
     }
 
     @Test
     public void validateMetrics() {
-        Assert.assertEquals((long) metrics.getContentProviderToAppStart(), 100L);
-        Assert.assertEquals((long) metrics.getApplicationOnCreateTime(), 100L);
-        Assert.assertEquals((long) metrics.getAppOnCreateEndToFirstActivityCreate(), 200L);
-        Assert.assertEquals((long) metrics.getFirstActivityCreateToResume(), 200L);
-        Assert.assertEquals((long) metrics.getColdStartTime(), 600L);
-        Assert.assertEquals((long) metrics.getHotStartTime(), 100L);
-        Assert.assertEquals((long) metrics.getWarmStartTime(), 600L);
+        AppStartUpMetrics metrics = new AppStartUpMetrics();
+
+        Assert.assertEquals(100L, (long) metrics.getApplicationOnCreateTime());
+        Assert.assertEquals(200L, (long) metrics.getAppOnCreateEndToFirstActivityCreate());
+        Assert.assertEquals(200L, (long) metrics.getFirstActivityCreateToResume());
+        Assert.assertEquals(600L, (long) metrics.getColdStartTime());
+        Assert.assertEquals(100L, (long) metrics.getHotStartTime());
+    }
+
+    @Test
+    public void appOnCreateEndTimeUnset_returnsZeroForDependentMetrics() {
+        // Simulates the Handler.post Runnable not having drained yet:
+        // appOnCreateEndTime stays at its default 0L. The constructor must NOT
+        // emit a negative value for applicationOnCreateTime — that's #559.
+        tracerInstance.setAppOnCreateEndTime(0L);
+
+        AppStartUpMetrics metrics = new AppStartUpMetrics();
+
+        Assert.assertEquals(0L, (long) metrics.getApplicationOnCreateTime());
+        Assert.assertEquals(0L, (long) metrics.getAppOnCreateEndToFirstActivityCreate());
+    }
+
+    @Test
+    public void firstActivityStartTimeUnset_returnsZeroForHotStart() {
+        // Defensive: if firstActivityStartTime never got set, hotStartTime would
+        // otherwise resolve to ≈ uptime.
+        tracerInstance.setFirstActivityStartTime(0L);
+
+        AppStartUpMetrics metrics = new AppStartUpMetrics();
+
+        Assert.assertEquals(0L, (long) metrics.getHotStartTime());
     }
 }


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-575774](https://newrelic.atlassian.net/browse/NR-575774)
Prevents negative or inflated start-up metrics by adding guards against unset (zero) timestamps for `appOnCreateEndTime` and `firstActivityStartTime`.

#559

[NR-575774]: https://new-relic.atlassian.net/browse/NR-575774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ