### PR TITLE
fix(NR-575842): make HttpHeaders thread-safe at the source

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/HttpHeaders.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/HttpHeaders.java
@@ -3,9 +3,9 @@ package com.newrelic.agent.android;
 
 import com.newrelic.agent.android.util.Constants;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class HttpHeaders {
@@ -18,7 +18,9 @@ public class HttpHeaders {
     public static final String OPERATION_ID = "operationId";
 
     private HttpHeaders() {
-        httpHeaders = new HashSet<>();
+        // CopyOnWriteArraySet: lock-free iteration safe under concurrent mutation.
+        // Reads happen on every HTTP request; writes are rare (init / public API).
+        httpHeaders = new CopyOnWriteArraySet<>();
         httpHeaders.add(Constants.ApolloGraphQLHeader.OPERATION_NAME);
         httpHeaders.add(Constants.ApolloGraphQLHeader.OPERATION_ID);
         httpHeaders.add(Constants.ApolloGraphQLHeader.OPERATION_TYPE);

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp2/OkHttp2Instrumentation.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp2/OkHttp2Instrumentation.java
@@ -24,9 +24,7 @@ import com.squareup.okhttp.ResponseBody;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -65,19 +63,13 @@ public class OkHttp2Instrumentation {
      * Adds HTTP headers from the request as custom attributes to the transaction state.
      * Only headers configured via {@link HttpHeaders#addHttpHeaderAsAttribute(String)} are captured.
      *
-     * <p><b>Thread Safety:</b> Creates a defensive copy of the header list to avoid
-     * {@link java.util.ConcurrentModificationException} if headers are modified concurrently.</p>
-     *
      * @param transactionState The transaction state to add attributes to
      * @param request The OkHttp2 request containing headers
      */
     private static void addHeadersAsCustomAttribute(TransactionState transactionState, Request request) {
         Map<String, String> headers = new HashMap<>();
 
-        // Defensive copy to prevent ConcurrentModificationException
-        Set<String> headersCopy = new HashSet<>(HttpHeaders.getInstance().getHttpHeaders());
-
-        for (String headerName : headersCopy) {
+        for (String headerName : HttpHeaders.getInstance().getHttpHeaders()) {
             String headerValue = request.headers().get(headerName);
             if (headerValue != null) {
                 headers.put(HttpHeaders.translateApolloHeader(headerName), headerValue);

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3Instrumentation.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3Instrumentation.java
@@ -21,9 +21,7 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -80,22 +78,13 @@ public class OkHttp3Instrumentation {
      * Adds HTTP headers from the request as custom attributes to the transaction state.
      * Only headers configured via {@link HttpHeaders#addHttpHeaderAsAttribute(String)} are captured.
      *
-     * <h3>Thread Safety:</h3>
-     * Creates a defensive copy of the header list to avoid {@link java.util.ConcurrentModificationException}
-     * if headers are modified concurrently by another thread calling
-     * {@link HttpHeaders#addHttpHeaderAsAttribute(String)} or
-     * {@link HttpHeaders#removeHttpHeaderAsAttribute(String)}.
      * @param transactionState The transaction state to add attributes to
      * @param request The OkHttp request containing headers
      */
     private static void addHeadersAsCustomAttribute(TransactionState transactionState, Request request) {
         Map<String, String> headers = new HashMap<>();
 
-        // Defensive copy to prevent ConcurrentModificationException
-        // If HttpHeaders is modified during iteration, we use the snapshot
-        Set<String> headersCopy = new HashSet<>(HttpHeaders.getInstance().getHttpHeaders());
-
-        for (String headerName : headersCopy) {
+        for (String headerName : HttpHeaders.getInstance().getHttpHeaders()) {
             String headerValue = request.headers().get(headerName);
             if (headerValue != null) {
                 headers.put(HttpHeaders.translateApolloHeader(headerName), headerValue);

--- a/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3TransactionStateUtil.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/instrumentation/okhttp3/OkHttp3TransactionStateUtil.java
@@ -22,9 +22,7 @@ import org.apache.http.HttpStatus;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import okhttp3.Headers;
@@ -263,19 +261,13 @@ public class OkHttp3TransactionStateUtil extends TransactionStateUtil {
      * Adds HTTP headers from the request as custom attributes to the transaction state.
      * Only headers configured via {@link HttpHeaders#addHttpHeaderAsAttribute(String)} are captured.
      *
-     * <p><b>Thread Safety:</b> Creates a defensive copy of the header list to avoid
-     * {@link java.util.ConcurrentModificationException} if headers are modified concurrently.</p>
-     *
      * @param transactionState The transaction state to add attributes to
      * @param request The OkHttp request containing headers
      */
     public static void addHeadersAsCustomAttribute(TransactionState transactionState, Request request) {
         Map<String, String> headers = new HashMap<>();
 
-        // Defensive copy to prevent ConcurrentModificationException
-        Set<String> headersCopy = new HashSet<>(HttpHeaders.getInstance().getHttpHeaders());
-
-        for (String headerName : headersCopy) {
+        for (String headerName : HttpHeaders.getInstance().getHttpHeaders()) {
             String headerValue = request.headers().get(headerName);
             if (headerValue != null) {
                 headers.put(HttpHeaders.translateApolloHeader(headerName), headerValue);

--- a/agent-core/src/test/java/com/newrelic/agent/android/HttpHeadersTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/HttpHeadersTest.java
@@ -14,6 +14,9 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class HttpHeadersTest {
     private HttpHeaders httpHeaders;
@@ -56,6 +59,77 @@ public class HttpHeadersTest {
     public void testRemoveHttpHeaderAsAttribute() {
         httpHeaders.removeHttpHeaderAsAttribute("X-Custom-Header");
         assertFalse(httpHeaders.getHttpHeaders().contains("X-Custom-Header"));
+    }
+
+    @Test
+    public void testConcurrentMutationDoesNotThrow() throws InterruptedException {
+        // Reproduces NR-575842: ConcurrentModificationException when iterating
+        // HttpHeaders while another thread mutates it. The "defensive copy"
+        // pattern new HashSet<>(getHttpHeaders()) does not prevent CME because
+        // HashSet's collection constructor calls iterator() on the source.
+        final String prefix = "TestHeaderConcurrent_";
+        final long deadline = System.currentTimeMillis() + 250;
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final CountDownLatch ready = new CountDownLatch(2);
+        final CountDownLatch start = new CountDownLatch(1);
+
+        Thread iterator = new Thread(() -> {
+            ready.countDown();
+            try {
+                start.await();
+            } catch (InterruptedException ignored) {
+                return;
+            }
+            try {
+                while (System.currentTimeMillis() < deadline) {
+                    Set<String> snapshot = new HashSet<>(httpHeaders.getHttpHeaders());
+                    snapshot.size();
+                }
+            } catch (Throwable t) {
+                error.compareAndSet(null, t);
+            }
+        }, "HttpHeaders-iterator");
+
+        Thread mutator = new Thread(() -> {
+            ready.countDown();
+            try {
+                start.await();
+            } catch (InterruptedException ignored) {
+                return;
+            }
+            try {
+                int i = 0;
+                while (System.currentTimeMillis() < deadline) {
+                    String h = prefix + (i++ & 0x3FF);
+                    httpHeaders.addHttpHeaderAsAttribute(h);
+                    httpHeaders.removeHttpHeaderAsAttribute(h);
+                }
+            } catch (Throwable t) {
+                error.compareAndSet(null, t);
+            }
+        }, "HttpHeaders-mutator");
+
+        try {
+            iterator.start();
+            mutator.start();
+            ready.await();
+            start.countDown();
+            iterator.join();
+            mutator.join();
+
+            if (error.get() != null) {
+                throw new AssertionError(
+                        "Concurrent iteration + mutation must not throw: " + error.get(),
+                        error.get());
+            }
+        } finally {
+            // Restore singleton to pre-test state
+            for (String h : new HashSet<>(httpHeaders.getHttpHeaders())) {
+                if (h != null && h.startsWith(prefix)) {
+                    httpHeaders.removeHttpHeaderAsAttribute(h);
+                }
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-575842](https://newrelic.atlassian.net/browse/NR-575842)
## Associated Jira ticket
[NR-575842 — \[Android\] ConcurrentModificationException in OkHttp3Instrumentation.addHeadersAsCustomAttribute — NR-481812 fix is non-functional](https://new-relic.atlassian.net/browse/NR-575842)

## What & Why

`ConcurrentModificationException` is still thrown from
`OkHttp3Instrumentation.addHeadersAsCustomAttribute` despite the
NR-481812 fix shipped in commit `05644abc`. That fix wrapped iteration
in `new HashSet<>(...)` and labelled it a "defensive copy" — but the
`HashSet(Collection)` constructor calls `addAll`, which calls
`iterator()` on the source set. The unsafe iteration was just moved
into the `HashSet.<init>` stack frame, exactly matching the reported
trace:

```
at java.util.HashMap$HashIterator.nextNode(HashMap.java:1603)
at java.util.AbstractCollection.addAll(AbstractCollection.java:335)
at java.util.HashSet.<init>(HashSet.java:121)
at OkHttp3Instrumentation.addHeadersAsCustomAttribute(...:96)
```

The same broken pattern existed in three call sites, but the **root
cause is in `HttpHeaders`** — it exposed a non-thread-safe `HashSet`
directly. Public API methods (`NewRelic.addHttpHeaderAsAttribute`) and
the OkHttp request path both touched it without synchronization.

This PR fixes it at the source: `HttpHeaders` now uses a
`CopyOnWriteArraySet`. Reads (every HTTP request) are lock-free
snapshot iterators; writes (rare, via the public API) take the
copy-on-write penalty — the right tradeoff for this read-heavy access
pattern.

With the source thread-safe, the bogus `new HashSet<>(...)` copies in
the three OkHttp call sites are no longer needed and have been removed.

## Callouts

- **Behaviour change:** `HttpHeaders.getHttpHeaders()` now returns a
  `CopyOnWriteArraySet`. The public method signature still returns
  `Set<String>`, so callers compile unchanged. Iteration semantics are
  weakly consistent (snapshot view) instead of fail-fast — which is
  exactly what we want here. No public API changes.
- **Affected files:**
  - `HttpHeaders.java` — `HashSet` → `CopyOnWriteArraySet`
  - `OkHttp3Instrumentation.java` — drop bogus defensive copy
  - `OkHttp2Instrumentation.java` — drop bogus defensive copy
  - `OkHttp3TransactionStateUtil.java` — drop bogus defensive copy
- The unsynchronized read at
  `TransactionStateUtil.java:128` (`.contains(field)` on the live set)
  is now safe by construction.

## Test plan

- New unit test `HttpHeadersTest.testConcurrentMutationDoesNotThrow`
  reproduces the original CME by running concurrent iteration (mimicking
  the exact `new HashSet<>(getHttpHeaders())` pattern from the call
  sites) against a mutator thread doing `add` / `remove` in a tight loop
  for 250ms. Self-cleaning so it doesn't perturb the singleton state
  other tests rely on.
- **Verified RED** with the original `HashSet`: test failed with the
  exact `ConcurrentModificationException` from the ticket
  (`HashMap$HashIterator.nextNode` → `AbstractCollection.addAll` →
  `HashSet.<init>`).
- **Verified GREEN** with `CopyOnWriteArraySet`: the new test passes
  and existing `HttpHeadersTest`, `OkHttp2TransactionStateUtilTest`,
  `OkHttp3TransactionStateUtilTest`, `TransactionStateUtilTest`,
  `RetrofitTransactionStateUtilTest` all pass unchanged (52 tests
  total).

```
./gradlew :agent-core:test --tests com.newrelic.agent.android.HttpHeadersTest
```

## Checks

- [x] Backwards compatible with relevant frameworks and APIs (no public
      API changes; `Set<String>` return type unchanged)
- [x] No breaking changes
- [x] No new dependencies (`CopyOnWriteArraySet` is in `java.util.concurrent`)

## Related

- NR-481812 (Closed) — non-functional fix superseded by this PR

[NR-575842]: https://new-relic.atlassian.net/browse/NR-575842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ