### PR TITLE
revert: NR-577053 relocate bundled commons-io in gradle plugin shadowJar

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.debug.obsoleteApi=true
 android.useAndroidX=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.7.8-SNAPSHOT
+newrelic.agent.version = 7.7.6
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 

--- a/plugins/gradle/build.gradle
+++ b/plugins/gradle/build.gradle
@@ -182,13 +182,6 @@ tasks.named('check') {
 
 shadowJar {
     archiveClassifier = null
-
-    // Relocate bundled commons-io so the plugin jar does not pollute the root
-    // buildscript classpath with an unrelocated copy. Without this, the pinned
-    // commons-io version collides with newer commons-io required by other
-    // applied plugins (e.g. Guardsquare/DexGuard), causing NoSuchMethodError
-    // on the shared buildscript classloader. See NR-577053 / issue #560.
-    relocate 'org.apache.commons.io', 'com.newrelic.org.apache.commons.io'
 }
 
 artifacts {


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-577053](https://newrelic.atlassian.net/browse/NR-577053)
## What & Why

Reverts commit 8fb9e8bf ("fix(NR-577053): relocate bundled commons-io in gradle plugin shadowJar").

`develop` is a protected branch and cannot be force-pushed, so this commit is removed via a standard revert + PR rather than a history rewrite.

## Callouts

- Reverts changes to `gradle.properties` and `plugins/gradle/build.gradle` (the commons-io relocation in the gradle plugin shadowJar).

## Test plan

- Review the reverted diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NR-577053]: https://new-relic.atlassian.net/browse/NR-577053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ