### PR TITLE
fix(NR-577769): avoid Task.project access in newrelicMapUpload for configuration cache

### DIFF
--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
@@ -39,12 +39,19 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
     @Internal
     abstract DirectoryProperty getProjectRoot()
 
+    @Internal
+    abstract DirectoryProperty getBuildDirectory()
+
     /**
      * FIX: Use an @OutputFile to prevent mutating the @InputFile.
+     *
+     * Resolved from the wired-in buildDirectory property rather than
+     * Task.project, so the task stays configuration-cache compatible
+     * (Task.project access is forbidden at execution time).
      */
     @OutputFile
     File getTaggedMappingFile() {
-        return project.layout.buildDirectory.file("outputs/newrelic/" + variantName.get() + "/mapping.txt").get().asFile
+        return buildDirectory.file("outputs/newrelic/" + variantName.get() + "/mapping.txt").get().asFile
     }
 
     @Internal

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -203,6 +203,7 @@ abstract class VariantAdapter {
             mapUploadTask.mappingFile.set(variantMap)
             mapUploadTask.taggedMappingFiles.set(buildHelper.project.files())
             mapUploadTask.projectRoot.set(buildHelper.project.layout.projectDirectory)
+            mapUploadTask.buildDirectory.set(buildHelper.project.layout.buildDirectory)
             mapUploadTask.buildId.convention(uuid)
             mapUploadTask.variantName.set(objectFactory.property(String).value(variantName))
             mapUploadTask.mapProvider.set(objectFactory.property(String).value(buildHelper.getMapCompilerName()))


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-577769](https://newrelic.atlassian.net/browse/NR-577769)
## Jira
[NR-577769](https://new-relic.atlassian.net/browse/NR-577769)

## What & Why
The New Relic Android Gradle plugin fails when Gradle's **configuration cache** is enabled. The `newrelicMapUpload<Variant>` task accessed `Task.project` at execution time, which the configuration cache forbids:

```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':app:newrelicMapUploadRelease'.
> Invocation of 'Task.project' by task ':app:newrelicMapUploadRelease' at execution time is unsupported with the configuration cache.
```

### Root cause
In `NewRelicMapUploadTask.groovy`, the `@OutputFile` getter resolved its path through `project`:

```groovy
@OutputFile
File getTaggedMappingFile() {
    return project.layout.buildDirectory.file("outputs/newrelic/" + variantName.get() + "/mapping.txt").get().asFile
}
```

`project` resolves to `Task.getProject()`. This getter is evaluated as the task's output provider, in the `onlyIf` / `upToDateWhen` specs, and inside `@TaskAction` — all at execution time. Accessing `Task.project` during execution is unsupported with the configuration cache, so the build fails.

### Fix
Capture the build directory at **configuration time** into a wired-in `DirectoryProperty` (mirroring the existing `projectRoot` wiring) and resolve the tagged mapping file from it. `project.layout.buildDirectory` is itself a `DirectoryProperty`, so this is type-identical to the previous code but removes the `Task.project` reference from execution time.

## Callouts
- Follows the established property-wiring pattern already used for `projectRoot` in `VariantAdapter.wiredWithMapUploadProvider`.
- The wiring runs on the same lifecycle path that already set `projectRoot`, so the new property is populated for every variant whose task executes.

## Test plan
- [ ] Apply the plugin to an app module with R8/ProGuard minification enabled.
- [ ] Enable the configuration cache (`org.gradle.configuration-cache=true`).
- [ ] Run `:app:assembleRelease` (triggers `:app:newrelicMapUploadRelease`); build succeeds and reuses the configuration cache on a second run with no `Task.project` error.
- [ ] Confirm the tagged mapping file is still written to `build/outputs/newrelic/<variant>/mapping.txt` and uploaded as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[NR-577769]: https://new-relic.atlassian.net/browse/NR-577769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ