### PR TITLE
fix(NR-373723): prevent NDK stop() ABI mismatch from crashing app

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
@@ -108,7 +108,14 @@ public class NativeReporting extends HarvestAdapter {
         if (NativeReporting.isInitialized()) {
             try {
                 agentNdk.get().stop();
-            } catch (Exception e) {
+            } catch (Exception | LinkageError e) {
+                // AgentNDK.stop()/nativeStop() have changed return type across agent-ndk
+                // releases (void <-> boolean). agent-ndk is a compileOnly dependency whose
+                // version the host app resolves independently (often via a dynamic "1.+"
+                // range), so the method descriptor this agent was compiled against can differ
+                // from the AgentNDK class loaded at runtime. That surfaces here as a
+                // NoSuchMethodError (a LinkageError, not an Exception). The return value is
+                // unused, so degrade gracefully on shutdown instead of crashing the app.
                 log.error(e.toString());
             }
             StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_NDK_STOP);

--- a/agent/src/test/java/com/newrelic/agent/android/ndk/NativeReportingTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/ndk/NativeReportingTest.java
@@ -184,6 +184,24 @@ public class NativeReportingTest {
     }
 
     @Test
+    public void stopSurvivesNdkAbiMismatch() {
+        // Reproduces the runtime crash where the agent was compiled against an
+        // AgentNDK.stop() with a different return-type descriptor than the agent-ndk
+        // class loaded at runtime (void <-> boolean across releases). The JVM raises a
+        // NoSuchMethodError (a LinkageError) at the call site. stop() must not propagate
+        // it, otherwise backgrounding the app crashes the process.
+        AgentNDK mismatched = Mockito.mock(AgentNDK.class);
+        Mockito.doThrow(new NoSuchMethodError("No virtual method stop()V in class AgentNDK"))
+                .when(mismatched).stop();
+        NativeReporting.agentNdk.set(mismatched);
+
+        nativeReporter.stop();
+
+        Assert.assertTrue(statsEngineContains(MetricNames.SUPPORTABILITY_NDK_STOP));
+        Assert.assertNull(NativeReporting.agentNdk.get());
+    }
+
+    @Test
     public void onNativeCrash() {
         agentNDK.flushPendingReports();
         Assert.assertTrue(statsEngineContains(MetricNames.SUPPORTABILITY_NDK_REPORTS_CRASH));


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-373723](https://newrelic.atlassian.net/browse/NR-373723)
## Jira
NR-373723

## What & Why
Apps using the agent crash on backgrounding with:

```
FATAL EXCEPTION: NR_AppStateMon-1
java.lang.NoSuchMethodError: No virtual method stop()V in class
  Lcom/newrelic/agent/android/ndk/AgentNDK;
    at com.newrelic.agent.android.ndk.NativeReporting.stop(NativeReporting.java:110)
    at com.newrelic.agent.android.ndk.NativeReporting.shutdown(NativeReporting.java:53)
    at com.newrelic.agent.android.AndroidAgentImpl.stop(AndroidAgentImpl.java:659)
    at com.newrelic.agent.android.AndroidAgentImpl.applicationBackgrounded(AndroidAgentImpl.java:945)
```

**Root cause:** `AgentNDK.stop()`/`nativeStop()` changed return type across `agent-ndk` releases:

| agent-ndk | `stop()` | JVM descriptor |
|---|---|---|
| 1.1.3 | `void`    | `stop()V` |
| 1.1.4 | `boolean` | `stop()Z` |

The JVM resolves a virtual method by name **and full descriptor including return type**, so `stop()V` and `stop()Z` are distinct methods. `agent-ndk` is a `compileOnly` dependency whose version the host app resolves independently — typically via a dynamic `1.+` range. So the agent built against 1.1.3 emits `INVOKEVIRTUAL stop()V`, but the app resolves 1.1.4 at runtime, which only has `stop()Z` → `NoSuchMethodError`.

The call in `NativeReporting.stop()` was already wrapped in a best-effort `try/catch`, but it only caught `Exception`. `NoSuchMethodError extends IncompatibleClassChangeError → LinkageError → Error`, so it slipped past the catch and crashed the process.

## The fix
Widen the catch to `catch (Exception | LinkageError e)`. This makes the agent resilient to the return-type drift in **either** direction without reflection (rejected: `agent-ndk` ships no consumer ProGuard keep rules, so a string-based `getMethod("stop")` could be broken by R8 in obfuscated apps). The `stop()` return value is unused, so no behavior is lost. In the normal aligned case (this agent + matching agent-ndk) native stop runs fully and the catch never fires.

## Callouts
- **Forward fix.** This protects apps rebuilt with this agent version. Already-shipped agents (compiled to `stop()V`) keep crashing against agent-ndk 1.1.4 until an ndk-side release > 1.1.4 restores a `void` `stop()`. The two fixes are complementary.
- In a true mismatch, native stop is now skipped (caught + logged) rather than executed — acceptable on a shutdown/cleanup path.
- Consider a follow-up to pin `newrelic.ndk` off the floating `1.+` to an exact tested version so the compiled descriptor and resolved runtime class can't diverge.

## Test plan
- New `NativeReportingTest.stopSurvivesNdkAbiMismatch()` stubs the internal `AgentNDK` to throw `NoSuchMethodError` from `stop()` and asserts `NativeReporting.stop()` does not propagate it (and still records the stat + clears the ref). Fails on the prior `catch (Exception)`, passes with the fix.
- File changed in context: `agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NR-373723]: https://new-relic.atlassian.net/browse/NR-373723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ