### PR TITLE
fix(NR-577053): relocate bundled commons-io in gradle plugin shadowJar

### DIFF
--- a/plugins/gradle/build.gradle
+++ b/plugins/gradle/build.gradle
@@ -182,6 +182,13 @@ tasks.named('check') {
 
 shadowJar {
     archiveClassifier = null
+
+    // Relocate bundled commons-io so the plugin jar does not pollute the root
+    // buildscript classpath with an unrelocated copy. Without this, the pinned
+    // commons-io version collides with newer commons-io required by other
+    // applied plugins (e.g. Guardsquare/DexGuard), causing NoSuchMethodError
+    // on the shared buildscript classloader. See NR-577053 / issue #560.
+    relocate 'org.apache.commons.io', 'com.newrelic.org.apache.commons.io'
 }
 
 artifacts {


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-577053](https://newrelic.atlassian.net/browse/NR-577053)
## What & Why

Relocates the bundled `commons-io` inside the gradle plugin's shadowJar so the plugin jar does not pollute the root buildscript classpath with an unrelocated copy.

Without this relocation, the pinned `commons-io` version collides with the newer `commons-io` required by other applied plugins (e.g. Guardsquare/DexGuard) on the shared buildscript classloader, causing a `NoSuchMethodError`. See NR-577053 / #560.

This restores the relocation fix from `8fb9e8bf`, which was previously committed directly to `develop` and then reverted in #563 (because `develop` is protected and the commit needed to land via a reviewed PR instead). This branch reintroduces it through the proper PR flow.

## Callouts

- `plugins/gradle/build.gradle` — adds `relocate 'org.apache.commons.io', 'com.newrelic.org.apache.commons.io'` to the `shadowJar` block.

## Test plan

- Review the diff.
- Build the gradle plugin shadowJar and confirm `commons-io` classes are relocated under `com.newrelic.org.apache.commons.io`.
- Apply the plugin alongside DexGuard and confirm the `NoSuchMethodError` from the commons-io collision no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[NR-577053]: https://new-relic.atlassian.net/browse/NR-577053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ