### PR TITLE
fix(NR-564673): Conditionally call incrementUploadCount 

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashSender.java
@@ -50,12 +50,14 @@ public class CrashSender extends PayloadSender {
     public PayloadSender call() {
         setPayload(crash.toJsonString().getBytes());
 
-        // Increment the upload counter
-        crash.incrementUploadCount();
-        agentConfiguration.getCrashStore().store(crash);
-
         try {
-            return super.call();
+            PayloadSender result = super.call();
+
+            if(responseCode > 0) { // `responseCode` is part of the PayloadSender interface
+                crash.incrementUploadCount();
+                agentConfiguration.getCrashStore().store(crash);
+            }
+            return result;
 
         } catch (Exception e) {
             onFailedUpload("Unable to report crash to New Relic, will try again later. " + e);

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
@@ -67,10 +67,12 @@ public class CrashSenderTest {
 
     @Test
     public void call() throws Exception {
-        crash.incrementUploadCount();
         int preUploadCount = crash.getUploadCount();
+
         crashSender.call();
         Assert.assertTrue("Should increment upload count", preUploadCount < crash.getUploadCount());
+
+
     }
 
     @Test
@@ -117,6 +119,19 @@ public class CrashSenderTest {
         Mockito.doReturn(null).when(crashSender).getConnection();
         crashSender.call();
         verify(crashSender, atLeastOnce()).onFailedUpload(any(String.class));
+    }
+
+    @Test
+    public void testCallWhenOfflineDoesNotIncrementUploadCount() throws Exception {
+        int preUploadCount = crash.getUploadCount();
+
+        HttpURLConnection connection = Mockito.mock(HttpURLConnection.class);
+        Mockito.doThrow(new IOException("Network unreachable")).when(connection).connect();
+        Mockito.doReturn(connection).when(crashSender).getConnection();
+
+        crashSender.call();
+
+        Assert.assertEquals("Should not increment upload count when device is offline", preUploadCount, crash.getUploadCount());
     }
 
     private HttpURLConnection getMockedConnection(CrashSender crashSender) throws IOException {

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
@@ -77,7 +77,7 @@ public class CrashSenderTest {
 
     @Test
     public void testRequestResponse() throws Exception {
-        HttpURLConnection connection = getMockedConnection(crashSender);
+        HttpURLConnection connection = getMockedConnection();
 
         Mockito.doReturn(HttpsURLConnection.HTTP_OK).when(connection).getResponseCode();
         crashSender.onRequestResponse(connection);
@@ -125,7 +125,8 @@ public class CrashSenderTest {
     public void testCallWhenOfflineDoesNotIncrementUploadCount() throws Exception {
         int preUploadCount = crash.getUploadCount();
 
-        HttpURLConnection connection = Mockito.mock(HttpURLConnection.class);
+        HttpURLConnection connection = getMockedConnection();
+
         Mockito.doThrow(new IOException("Network unreachable")).when(connection).connect();
         Mockito.doReturn(connection).when(crashSender).getConnection();
 
@@ -134,7 +135,7 @@ public class CrashSenderTest {
         Assert.assertEquals("Should not increment upload count when device is offline", preUploadCount, crash.getUploadCount());
     }
 
-    private HttpURLConnection getMockedConnection(CrashSender crashSender) throws IOException {
+    private HttpURLConnection getMockedConnection() throws IOException {
         HttpURLConnection connection = Mockito.mock(HttpURLConnection.class);
 
         Mockito.doReturn(false).when(connection).getDoOutput();


### PR DESCRIPTION
[NR-564673](https://new-relic.atlassian.net/browse/NR-564673)

## Summary

Fixes a bug where `CrashSender` would increment the upload count and persist the crash to the store **before** attempting the network request — causing the upload counter to advance even when the device was offline or the request failed with no response.

## Problem

The original code called `crash.incrementUploadCount()` and `agentConfiguration.getCrashStore().store(crash)` unconditionally before `super.call()`. If the network request failed (e.g., device offline, `IOException` thrown), the upload count was already incremented, potentially causing crashes to be dropped before they were successfully delivered.

## Solution

Move `incrementUploadCount()` and the store update to execute only after a successful network attempt, guarded by a check that `responseCode > 0`. A `responseCode` of 0 indicates the request never reached the server (e.g., no network connectivity).

## Changes

- `CrashSender.java`: Deferred `incrementUploadCount()` and `crashStore.store()` to only execute when `responseCode > 0` after `super.call()` returns.
- `CrashSenderTest.java`: 
  - Updated `call()` test to remove the pre-test manual `incrementUploadCount()` call that masked the bug.
  - Added `testCallWhenOfflineDoesNotIncrementUploadCount()` to assert the upload count is unchanged when an `IOException` prevents the request from completing.
  - Refactored `getMockedConnection()` helper to remove the unused `CrashSender` parameter.

## Testing

- Existing `call()` test confirms upload count increments on a successful send.
- New `testCallWhenOfflineDoesNotIncrementUploadCount()` test covers the offline/failure scenario.

[NR-564673]: https://new-relic.atlassian.net/browse/NR-564673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ