### PR TITLE
feat(NR-578863): add supportability metric for unknown harvest data responses

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
@@ -240,6 +240,10 @@ public class Harvester implements HarvestConfigurable {
         // Network level error, or something else really bad. Don't clear the harvest data, we'll attempt again
         if (response == null || response.isUnknown()) {
             log.debug("Harvest data response: " + response.getResponseCode());
+            // The data POST body was sent but no response could be read (e.g. read timeout). The
+            // collector may already have ingested the payload, yet the retained buffer is resent
+            // next cycle, risking duplicate events. Track frequency to correlate with collector latency.
+            StatsEngine.notice().inc(MetricNames.SUPPORTABILITY_COLLECTOR + "Harvest/Error/UNKNOWN");
             checkOfflineAndPersist();
             fireOnHarvestSendFailed();
             return;


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-578863](https://newrelic.atlassian.net/browse/NR-578863)
## Jira
- [NR-578863](https://new-relic.atlassian.net/browse/NR-578863) — Android agent uploads duplicate events when `/data` receives an UNKNOWN harvest response
- Originating GTSE: [NR-578363](https://new-relic.atlassian.net/browse/NR-578363) (DirecTV, account 1499449)

## What & Why
When a harvest data POST is fully sent but the agent can't read a response (e.g. the 4s read timeout trips on a slow collector), `Harvester.connected()` classifies the result as `UNKNOWN`, retains the buffer, and resends it next cycle. The collector has very likely already ingested the payload, so the retransmit produces **duplicate events with identical timestamps**. This is at-least-once delivery with no idempotency — the agent cannot distinguish "ingested but response lost" from "never ingested."

Today the `UNKNOWN`/null branch (`Harvester.java:241`) returns early and emits **no supportability metric**, so we have no way to quantify how often this happens in the field. The `Harvest/Error/<code>` metric family never reaches the `UNKNOWN` case because that branch short-circuits before the error block.

This PR adds the missing counter:

```
Supportability/AgentHealth/Collector/Harvest/Error/UNKNOWN
```

emitted via `StatsEngine.notice()`, matching the existing `Harvest/Error/*` shape so it slots into dashboards already faceting on that family.

## Callouts
- **Observability only** — this does **not** change the duplicate behavior. The real fix requires collector-side idempotency/dedup, which DEM platform is investigating (why `/mobile/v3/data` is slow/not responding within the 4s read window for this account).
- Uses the literal `"UNKNOWN"` rather than `response.getResponseCode()` because the branch is entered when `response == null || response.isUnknown()`, so the value is definitionally UNKNOWN and the literal avoids any null dependence.
- A pre-existing latent NPE on the preceding `log.debug` line (dereferences `response` when it can be null) was left untouched as out of scope.

## Test plan
- Metric appears once per UNKNOWN data-harvest response; verify in NRDB after a build ships:
  ```sql
  SELECT count(*) FROM Metric
  WHERE metricName = 'Supportability/AgentHealth/Collector/Harvest/Error/UNKNOWN'
  FACET appName SINCE 1 day ago
  ```
- Repro (from NR-578863): record events, drop inbound 443, wait N harvest cycles — counter increments once per cycle while the response is unreadable.


[NR-578863]: https://new-relic.atlassian.net/browse/NR-578863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-578363]: https://new-relic.atlassian.net/browse/NR-578363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ