### PR TITLE
feat(NR-575950): recover prior-session attributes for AEI via a shared SessionContextStore

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -60,7 +60,7 @@ public class AgentConfiguration implements HarvestConfigurable {
     public static final int DEFAULT_MAX_CACHED_PAYLOAD_COUNT = Integer.MAX_VALUE;
 
     public static final int DEFAULT_MAX_CACHED_JS_ERROR_COUNT = Integer.MAX_VALUE;
-    public static final int DEFAULT_MAX_CACHED_SESSION_CONTEXT_COUNT = Integer.MAX_VALUE;
+    public static final int DEFAULT_MAX_CACHED_SESSION_CONTEXT_COUNT = 32;
 
     public static final int DEFAULT_MAX_CACHED_CRASH_COUNT = Integer.MAX_VALUE;
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/AgentConfiguration.java
@@ -12,6 +12,7 @@ import com.newrelic.agent.android.crash.CrashStore;
 import com.newrelic.agent.android.harvest.HarvestConfigurable;
 import com.newrelic.agent.android.harvest.HarvestConfiguration;
 import com.newrelic.agent.android.hybrid.JSErrorStore;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.logging.LogLevel;
@@ -59,6 +60,7 @@ public class AgentConfiguration implements HarvestConfigurable {
     public static final int DEFAULT_MAX_CACHED_PAYLOAD_COUNT = Integer.MAX_VALUE;
 
     public static final int DEFAULT_MAX_CACHED_JS_ERROR_COUNT = Integer.MAX_VALUE;
+    public static final int DEFAULT_MAX_CACHED_SESSION_CONTEXT_COUNT = Integer.MAX_VALUE;
 
     public static final int DEFAULT_MAX_CACHED_CRASH_COUNT = Integer.MAX_VALUE;
 
@@ -86,12 +88,14 @@ public class AgentConfiguration implements HarvestConfigurable {
     private PayloadStore<Payload> payloadStore = new NullPayloadStore<Payload>();
     private int maxCachedPayloadCount = DEFAULT_MAX_CACHED_PAYLOAD_COUNT;
     private int maxCachedJsErrorCount = DEFAULT_MAX_CACHED_JS_ERROR_COUNT;
+    private int maxCachedSessionContextCount = DEFAULT_MAX_CACHED_SESSION_CONTEXT_COUNT;
     private int maxCachedCrashCount = DEFAULT_MAX_CACHED_CRASH_COUNT;
     private int maxCachedEventCount = DEFAULT_MAX_CACHED_EVENT_COUNT;
     private AnalyticsEventStore eventStore;
     private SessionReplayStore sessionReplayStore;
     private OfflineSessionReplayStore offlineSessionReplayStore;
     private JSErrorStore jsErrorStore;
+    private SessionContextStore sessionContextStore;
     private ApplicationFramework applicationFramework = ApplicationFramework.Native;
     private String applicationFrameworkVersion = Agent.getVersion();
     private String deviceID;
@@ -197,6 +201,14 @@ public class AgentConfiguration implements HarvestConfigurable {
 
     public void setJsErrorStore(JSErrorStore jsErrorStore) {
         this.jsErrorStore = jsErrorStore;
+    }
+
+    public SessionContextStore getSessionContextStore() {
+        return sessionContextStore;
+    }
+
+    public void setSessionContextStore(SessionContextStore sessionContextStore) {
+        this.sessionContextStore = sessionContextStore;
     }
 
     public boolean getReportHandledExceptions() {
@@ -337,6 +349,14 @@ public class AgentConfiguration implements HarvestConfigurable {
 
     public void setMaxCachedJsErrorCount(int n) {
         this.maxCachedJsErrorCount = n > 0 ? n : DEFAULT_MAX_CACHED_JS_ERROR_COUNT;
+    }
+
+    public int getMaxCachedSessionContextCount() {
+        return maxCachedSessionContextCount;
+    }
+
+    public void setMaxCachedSessionContextCount(int n) {
+        this.maxCachedSessionContextCount = n > 0 ? n : DEFAULT_MAX_CACHED_SESSION_CONTEXT_COUNT;
     }
 
     public int getMaxCachedCrashCount() {

--- a/agent-core/src/main/java/com/newrelic/agent/android/FeatureFlag.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/FeatureFlag.java
@@ -64,5 +64,6 @@ public enum FeatureFlag {
         enableFeature(AppStartMetrics);
         enableFeature(ApplicationExitReporting);
         enableFeature(LogReporting);
+        enableFeature(EventPersistence);
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsControllerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsControllerImpl.java
@@ -10,6 +10,10 @@ import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.AgentImpl;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.api.v1.Defaults;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
+import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.harvest.EnvironmentInformation;
 import com.newrelic.agent.android.harvest.Harvest;
@@ -1029,6 +1033,7 @@ public class AnalyticsControllerImpl extends HarvestAdapter implements Analytics
                     // hand-off current event set atomically
                     Collection<AnalyticsEvent> pendingEvents = eventManager.getQueuedEventsSnapshot();
                     if (pendingEvents.size() > 0) {
+                        reattributeRecoveredEvents(pendingEvents);
                         harvestData.getAnalyticsEvents().addAll(pendingEvents);
                         log.debug("EventManager: [" + pendingEvents.size() + "] events moved from buffer to HarvestData");
 
@@ -1048,5 +1053,43 @@ public class AnalyticsControllerImpl extends HarvestAdapter implements Analytics
                 }
             }
         }
+    }
+
+    /**
+     * Re-attribute persisted events that were recorded in a prior (now-ended) session and
+     * reloaded on this launch. Each persisted event carries its originating {@code sessionId}
+     * (stamped in {@link EventManagerImpl#addEvent}); for any whose origin differs from the
+     * current session, overlay that session's attribute set from the {@link SessionContextStore}
+     * so the event is emitted under the session that actually produced it rather than the current
+     * one. Live (current-session) events are left untouched and use the harvest attribute block.
+     */
+    void reattributeRecoveredEvents(Collection<AnalyticsEvent> events) {
+        final String currentSessionId = AgentConfiguration.getInstance().getSessionID();
+        final SessionContextStore ctxStore = AgentConfiguration.getInstance().getSessionContextStore();
+        for (AnalyticsEvent event : events) {
+            final String origin = sessionIdOf(event);
+            if (origin == null || origin.equals(currentSessionId)) {
+                continue; // live event — the current-session harvest block is correct
+            }
+            final SessionManifest manifest = (ctxStore != null) ? ctxStore.get(origin) : null;
+            if (manifest != null) {
+                event.putAttributesUnchecked(manifest.getAttributes());
+                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_EVENT_PERSISTENCE_REATTRIBUTED);
+            } else {
+                // No manifest (e.g. the session died before its first harvest). Keep the origin
+                // sessionId so correlation is at least right; other attrs fall to the current block.
+                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_EVENT_PERSISTENCE_MANIFEST_MISSING);
+            }
+        }
+    }
+
+    /** @return the value of the event's {@code sessionId} attribute, or {@code null} if absent. */
+    private static String sessionIdOf(AnalyticsEvent event) {
+        for (AnalyticsAttribute attribute : event.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(attribute.getName())) {
+                return attribute.getStringValue();
+            }
+        }
+        return null;
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
@@ -147,17 +147,6 @@ public class AnalyticsEvent extends HarvestableObject {
         }
     }
 
-    /**
-     * Removes a previously-added attribute (equality is by name). Trusted internal use, e.g. to
-     * strip a transient persistence stamp from the in-memory event after it has been serialized to
-     * the store, so the live harvest is unaffected.
-     */
-    void removeAttributeUnchecked(AnalyticsAttribute attribute) {
-        if (attribute != null) {
-            attributeSet.remove(attribute);
-        }
-    }
-
     public String getName() {
         return name;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
@@ -132,6 +132,32 @@ public class AnalyticsEvent extends HarvestableObject {
         }
     }
 
+    /**
+     * Trusted internal merge used by the event-persistence session-attribution path. Bypasses
+     * {@link AnalyticsValidator} (so reserved names such as {@code sessionId} are allowed) and
+     * replaces any same-named attribute already present ({@link AnalyticsAttribute} equality is by
+     * name), so the supplied (origin-session) attributes win. Not for public/event-author use.
+     */
+    void putAttributesUnchecked(Set<AnalyticsAttribute> attrs) {
+        if (attrs != null) {
+            for (AnalyticsAttribute attribute : attrs) {
+                attributeSet.remove(attribute); // drop any same-named attr first
+                attributeSet.add(attribute);
+            }
+        }
+    }
+
+    /**
+     * Removes a previously-added attribute (equality is by name). Trusted internal use, e.g. to
+     * strip a transient persistence stamp from the in-memory event after it has been serialized to
+     * the store, so the live harvest is unaffected.
+     */
+    void removeAttributeUnchecked(AnalyticsAttribute attribute) {
+        if (attribute != null) {
+            attributeSet.remove(attribute);
+        }
+    }
+
     public String getName() {
         return name;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
@@ -204,8 +204,23 @@ public class EventManagerImpl implements EventManager, EventListener {
 
             if (events.get().add(event)) {
                 // log.audit("Event added: [" + event.asJson() + "]");
-                if (FeatureFlag.featureEnabled(FeatureFlag.EventPersistence) && eventStore != null) {
+                // Persist only freshly-recorded events. A reloaded event from a prior session
+                // already carries its origin sessionId and is already on disk (it came from
+                // eventStore.fetchAll() at init), so re-storing it would be a redundant write of an
+                // event we just read. Skip it; it stays queued with its origin sessionId so the
+                // next harvest can re-attribute it (see AnalyticsControllerImpl.onHarvest).
+                if (FeatureFlag.featureEnabled(FeatureFlag.EventPersistence) && eventStore != null
+                        && !hasSessionId(event)) {
+                    // Stamp the current sessionId so a replay on the next launch can be
+                    // re-attributed, then strip it from the in-memory event (store() already
+                    // serialized the stamped copy to disk, and the live harvest carries sessionId
+                    // in its own session-attributes block).
+                    AnalyticsAttribute sessionIdAttr = new AnalyticsAttribute(
+                            AnalyticsAttribute.SESSION_ID_ATTRIBUTE,
+                            AgentConfiguration.getInstance().getSessionID(), false);
+                    event.putAttributesUnchecked(Collections.singleton(sessionIdAttr));
                     eventStore.store(event);
+                    event.removeAttributeUnchecked(sessionIdAttr);
                 }
                 eventsRecorded.incrementAndGet();
                 return true;
@@ -213,6 +228,16 @@ public class EventManagerImpl implements EventManager, EventListener {
 
             return false;
         }
+    }
+
+    /** @return true if the event already carries an origin sessionId (i.e. a reloaded persisted event). */
+    private static boolean hasSessionId(AnalyticsEvent event) {
+        for (AnalyticsAttribute attribute : event.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(attribute.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
@@ -211,16 +211,17 @@ public class EventManagerImpl implements EventManager, EventListener {
                 // next harvest can re-attribute it (see AnalyticsControllerImpl.onHarvest).
                 if (FeatureFlag.featureEnabled(FeatureFlag.EventPersistence) && eventStore != null
                         && !hasSessionId(event)) {
-                    // Stamp the current sessionId so a replay on the next launch can be
-                    // re-attributed, then strip it from the in-memory event (store() already
-                    // serialized the stamped copy to disk, and the live harvest carries sessionId
-                    // in its own session-attributes block).
-                    AnalyticsAttribute sessionIdAttr = new AnalyticsAttribute(
+                    // Persist a clone stamped with the origin sessionId (for next-launch
+                    // re-attribution), leaving the in-memory event clean so the live harvest is
+                    // unaffected. The clone keeps the same UUID so the harvest-time delete-by-UUID
+                    // still removes it. The store serializes and writes the clone off the calling
+                    // (often main) thread, so this hot path never blocks on disk I/O.
+                    AnalyticsEvent persisted = new AnalyticsEvent(event);
+                    persisted.setEventUUID(event.getEventUUID());
+                    persisted.putAttributesUnchecked(Collections.singleton(new AnalyticsAttribute(
                             AnalyticsAttribute.SESSION_ID_ATTRIBUTE,
-                            AgentConfiguration.getInstance().getSessionID(), false);
-                    event.putAttributesUnchecked(Collections.singleton(sessionIdAttr));
-                    eventStore.store(event);
-                    event.removeAttributeUnchecked(sessionIdAttr);
+                            AgentConfiguration.getInstance().getSessionID(), false)));
+                    eventStore.store(persisted);
                 }
                 eventsRecorded.incrementAndGet();
                 return true;

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -47,6 +47,9 @@ public class MetricNames {
     public static final String SUPPORTABILITY_PAYLOAD_CORRUPTED = SUPPORTABILITY_AGENT + "Payload/Corrupted";
     public static final String SUPPORTABILITY_JS_ERROR_EVICTED = SUPPORTABILITY_AGENT + "JSError/Removed/Evicted";
     public static final String SUPPORTABILITY_JS_ERROR_CORRUPTED = SUPPORTABILITY_AGENT + "JSError/Corrupted";
+    public static final String SUPPORTABILITY_SESSION_CONTEXT_EVICTED = SUPPORTABILITY_AGENT + "SessionContext/Removed/Evicted";
+    public static final String SUPPORTABILITY_SESSION_CONTEXT_CORRUPTED = SUPPORTABILITY_AGENT + "SessionContext/Corrupted";
+    public static final String SUPPORTABILITY_SESSION_CONTEXT_MISSING = SUPPORTABILITY_AGENT + "SessionContext/Missing";
     public static final String SUPPORTABILITY_SESSION_INVALID_DURATION = SUPPORTABILITY_AGENT + "Session/InvalidDuration";
     public static final String SUPPORTABILITY_RESPONSE_TIME_INVALID_DURATION = SUPPORTABILITY_AGENT + "Network/Request/ResponseTime/InvalidDuration";
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -54,6 +54,8 @@ public class MetricNames {
     public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_SKIPPED = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Skipped";
     public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_STALE = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Stale";
     public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_CORRUPT = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Corrupt";
+    public static final String SUPPORTABILITY_EVENT_PERSISTENCE_REATTRIBUTED = SUPPORTABILITY_AGENT + "EventPersistence/Reattributed";
+    public static final String SUPPORTABILITY_EVENT_PERSISTENCE_MANIFEST_MISSING = SUPPORTABILITY_AGENT + "EventPersistence/ManifestMissing";
     public static final String SUPPORTABILITY_SESSION_INVALID_DURATION = SUPPORTABILITY_AGENT + "Session/InvalidDuration";
     public static final String SUPPORTABILITY_RESPONSE_TIME_INVALID_DURATION = SUPPORTABILITY_AGENT + "Network/Request/ResponseTime/InvalidDuration";
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -50,6 +50,10 @@ public class MetricNames {
     public static final String SUPPORTABILITY_SESSION_CONTEXT_EVICTED = SUPPORTABILITY_AGENT + "SessionContext/Removed/Evicted";
     public static final String SUPPORTABILITY_SESSION_CONTEXT_CORRUPTED = SUPPORTABILITY_AGENT + "SessionContext/Corrupted";
     public static final String SUPPORTABILITY_SESSION_CONTEXT_MISSING = SUPPORTABILITY_AGENT + "SessionContext/Missing";
+    public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVERED = SUPPORTABILITY_AGENT + "SessionReplay/Recovered";
+    public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_SKIPPED = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Skipped";
+    public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_STALE = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Stale";
+    public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_CORRUPT = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Corrupt";
     public static final String SUPPORTABILITY_SESSION_INVALID_DURATION = SUPPORTABILITY_AGENT + "Session/InvalidDuration";
     public static final String SUPPORTABILITY_RESPONSE_TIME_INVALID_DURATION = SUPPORTABILITY_AGENT + "Network/Request/ResponseTime/InvalidDuration";
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessioncontext;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
+import com.newrelic.agent.android.harvest.Harvest;
+import com.newrelic.agent.android.harvest.HarvestLifecycleAware;
+import com.newrelic.agent.android.logging.AgentLog;
+import com.newrelic.agent.android.logging.AgentLogManager;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Writes a {@link SessionManifest} snapshot of the current session's context to the
+ * configured {@link SessionContextStore} once per harvest cycle.
+ *
+ * <p>This is an <b>always-on</b> harvest listener — it is intentionally NOT tied to the
+ * AEI code path, which only runs on API 30+ and behind {@code FeatureFlag.ApplicationExitReporting}
+ * + remote config. {@link #onHarvest()} fires every ~60s cycle in the CONNECTED state, so
+ * the data token's agent id is always valid when the snapshot is taken.
+ */
+public class SessionContextManager implements HarvestLifecycleAware {
+
+    private static final AgentLog log = AgentLogManager.getAgentLog();
+
+    private static SessionContextManager instance;
+
+    /** Create (once) and register as a harvest listener. Idempotent. */
+    public static synchronized SessionContextManager initialize() {
+        if (instance == null) {
+            instance = new SessionContextManager();
+            Harvest.addHarvestListener(instance);
+        }
+        return instance;
+    }
+
+    public static synchronized void shutdown() {
+        if (instance != null) {
+            Harvest.removeHarvestListener(instance);
+            instance = null;
+        }
+    }
+
+    @Override
+    public void onHarvest() {
+        snapshotCurrentSessionContext();
+    }
+
+    void snapshotCurrentSessionContext() {
+        SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+        if (store == null) {
+            return;
+        }
+        try {
+            AnalyticsControllerImpl controller = AnalyticsControllerImpl.getInstance();
+            Set<AnalyticsAttribute> sessionAttributes = (controller == null)
+                    ? Collections.emptySet() : controller.getSessionAttributes();
+
+            long sessionStartMs = 0L;
+            Harvest harvest = Harvest.getInstance();
+            if (harvest != null && harvest.getHarvestTimer() != null) {
+                sessionStartMs = harvest.getHarvestTimer().getSessionStartTimeMs();
+            }
+
+            SessionManifest manifest = new SessionManifest(
+                    AgentConfiguration.getInstance().getSessionID(),
+                    Harvest.getHarvestConfiguration().getDataToken().getAgentId(),
+                    sessionStartMs,
+                    System.currentTimeMillis(),
+                    sessionAttributes);
+            store.upsert(manifest);
+        } catch (Exception e) {
+            log.error("SessionContextManager: failed to snapshot session context: " + e);
+        }
+    }
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
@@ -30,12 +30,16 @@ public class SessionContextManager implements HarvestLifecycleAware {
 
     private static SessionContextManager instance;
 
-    /** Create (once) and register as a harvest listener. Idempotent. */
+    /** Create (once) and ensure registration as a harvest listener. Idempotent. */
     public static synchronized SessionContextManager initialize() {
         if (instance == null) {
             instance = new SessionContextManager();
-            Harvest.addHarvestListener(instance);
         }
+        // Always (re-)register. A stop/start cycle in the same process builds a new Harvester,
+        // so registering only on first creation would leave the manager detached after restart
+        // and silently stop writing snapshots. Harvester.addHarvestListener de-dups, so calling
+        // this when already registered (same Harvester reused) is a harmless no-op.
+        Harvest.addHarvestListener(instance);
         return instance;
     }
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
@@ -7,9 +7,6 @@ package com.newrelic.agent.android.sessioncontext;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
-import com.newrelic.agent.android.background.ApplicationStateEvent;
-import com.newrelic.agent.android.background.ApplicationStateListener;
-import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.harvest.HarvestLifecycleAware;
 import com.newrelic.agent.android.logging.AgentLog;
@@ -20,42 +17,24 @@ import java.util.Set;
 
 /**
  * Writes a {@link SessionManifest} snapshot of the current session's context to the
- * configured {@link SessionContextStore} once per harvest cycle, and removes it once the
- * session's data has been safely harvested at background time.
+ * configured {@link SessionContextStore} once per harvest cycle.
  *
  * <p>This is an <b>always-on</b> harvest listener — it is intentionally NOT tied to the
  * AEI code path, which only runs on API 30+ and behind {@code FeatureFlag.ApplicationExitReporting}
  * + remote config. {@link #onHarvest()} fires every ~60s cycle in the CONNECTED state, so
  * the data token's agent id is always valid when the snapshot is taken.
- *
- * <p><b>Cleanup.</b> The manifest is only needed to attribute an abnormal-termination event
- * (crash / ANR / process-exit / force-close) to the session that was alive when it happened.
- * When the app backgrounds, the agent forces a final harvest; once that harvest has either
- * been delivered online or persisted offline, the current session's manifest is deleted.
- * (A subsequent OS kill of the backgrounded process therefore recovers with no session
- * attributes plus a {@code SessionContext/Missing} supportability metric — an accepted
- * trade-off.) The store's bounded entry count is the backstop for anything not cleaned here.
  */
-public class SessionContextManager implements HarvestLifecycleAware, ApplicationStateListener {
+public class SessionContextManager implements HarvestLifecycleAware {
 
     private static final AgentLog log = AgentLogManager.getAgentLog();
 
     private static SessionContextManager instance;
 
-    /**
-     * Whether the most recent harvest was delivered online (2xx) or persisted offline.
-     * A server rejection (4xx/5xx) clears it. Read on background to decide whether the
-     * session's data is safe enough to drop its manifest. Written on the harvest thread,
-     * read on the app-state thread after the forced background harvest has completed.
-     */
-    private volatile boolean lastHarvestHandled = false;
-
-    /** Create (once) and register as harvest + application-state listener. Idempotent. */
+    /** Create (once) and register as a harvest listener. Idempotent. */
     public static synchronized SessionContextManager initialize() {
         if (instance == null) {
             instance = new SessionContextManager();
             Harvest.addHarvestListener(instance);
-            ApplicationStateMonitor.getInstance().addApplicationStateListener(instance);
         }
         return instance;
     }
@@ -63,7 +42,6 @@ public class SessionContextManager implements HarvestLifecycleAware, Application
     public static synchronized void shutdown() {
         if (instance != null) {
             Harvest.removeHarvestListener(instance);
-            ApplicationStateMonitor.getInstance().removeApplicationStateListener(instance);
             instance = null;
         }
     }
@@ -71,44 +49,6 @@ public class SessionContextManager implements HarvestLifecycleAware, Application
     @Override
     public void onHarvest() {
         snapshotCurrentSessionContext();
-    }
-
-    @Override
-    public void onHarvestComplete() {
-        // Harvest POST accepted (2xx).
-        lastHarvestHandled = true;
-    }
-
-    @Override
-    public void onHarvestSendFailed() {
-        // No connectivity — the harvest data was persisted offline for later upload.
-        // Treated as "handled" so background cleanup runs whether online or offline.
-        lastHarvestHandled = true;
-    }
-
-    @Override
-    public void onHarvestError() {
-        // Server rejected the data (4xx/5xx); it was not accepted. Keep the manifest.
-        lastHarvestHandled = false;
-    }
-
-    @Override
-    public void applicationForegrounded(ApplicationStateEvent e) {
-        // No-op: the next onHarvest() re-snapshots the (continuing or new) session.
-    }
-
-    /**
-     * The app has gone to the background. The agent forces a final harvest before this
-     * callback runs (it is registered ahead of us and blocks until the tick finishes), so
-     * {@link #lastHarvestHandled} reflects that harvest's outcome. If the data was delivered
-     * or persisted, drop the current session's manifest — it is no longer needed for a clean
-     * shutdown, and the bounded store handles anything left behind.
-     */
-    @Override
-    public void applicationBackgrounded(ApplicationStateEvent e) {
-        if (lastHarvestHandled) {
-            deleteCurrentSessionContext();
-        }
     }
 
     void snapshotCurrentSessionContext() {
@@ -136,17 +76,6 @@ public class SessionContextManager implements HarvestLifecycleAware, Application
             store.upsert(manifest);
         } catch (Exception e) {
             log.error("SessionContextManager: failed to snapshot session context: " + e);
-        }
-    }
-
-    void deleteCurrentSessionContext() {
-        SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
-        if (store == null) {
-            return;
-        }
-        String sessionId = AgentConfiguration.getInstance().getSessionID();
-        if (sessionId != null && !sessionId.isEmpty()) {
-            store.delete(sessionId);
         }
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextManager.java
@@ -7,6 +7,9 @@ package com.newrelic.agent.android.sessioncontext;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
+import com.newrelic.agent.android.background.ApplicationStateEvent;
+import com.newrelic.agent.android.background.ApplicationStateListener;
+import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.harvest.HarvestLifecycleAware;
 import com.newrelic.agent.android.logging.AgentLog;
@@ -17,24 +20,42 @@ import java.util.Set;
 
 /**
  * Writes a {@link SessionManifest} snapshot of the current session's context to the
- * configured {@link SessionContextStore} once per harvest cycle.
+ * configured {@link SessionContextStore} once per harvest cycle, and removes it once the
+ * session's data has been safely harvested at background time.
  *
  * <p>This is an <b>always-on</b> harvest listener — it is intentionally NOT tied to the
  * AEI code path, which only runs on API 30+ and behind {@code FeatureFlag.ApplicationExitReporting}
  * + remote config. {@link #onHarvest()} fires every ~60s cycle in the CONNECTED state, so
  * the data token's agent id is always valid when the snapshot is taken.
+ *
+ * <p><b>Cleanup.</b> The manifest is only needed to attribute an abnormal-termination event
+ * (crash / ANR / process-exit / force-close) to the session that was alive when it happened.
+ * When the app backgrounds, the agent forces a final harvest; once that harvest has either
+ * been delivered online or persisted offline, the current session's manifest is deleted.
+ * (A subsequent OS kill of the backgrounded process therefore recovers with no session
+ * attributes plus a {@code SessionContext/Missing} supportability metric — an accepted
+ * trade-off.) The store's bounded entry count is the backstop for anything not cleaned here.
  */
-public class SessionContextManager implements HarvestLifecycleAware {
+public class SessionContextManager implements HarvestLifecycleAware, ApplicationStateListener {
 
     private static final AgentLog log = AgentLogManager.getAgentLog();
 
     private static SessionContextManager instance;
 
-    /** Create (once) and register as a harvest listener. Idempotent. */
+    /**
+     * Whether the most recent harvest was delivered online (2xx) or persisted offline.
+     * A server rejection (4xx/5xx) clears it. Read on background to decide whether the
+     * session's data is safe enough to drop its manifest. Written on the harvest thread,
+     * read on the app-state thread after the forced background harvest has completed.
+     */
+    private volatile boolean lastHarvestHandled = false;
+
+    /** Create (once) and register as harvest + application-state listener. Idempotent. */
     public static synchronized SessionContextManager initialize() {
         if (instance == null) {
             instance = new SessionContextManager();
             Harvest.addHarvestListener(instance);
+            ApplicationStateMonitor.getInstance().addApplicationStateListener(instance);
         }
         return instance;
     }
@@ -42,6 +63,7 @@ public class SessionContextManager implements HarvestLifecycleAware {
     public static synchronized void shutdown() {
         if (instance != null) {
             Harvest.removeHarvestListener(instance);
+            ApplicationStateMonitor.getInstance().removeApplicationStateListener(instance);
             instance = null;
         }
     }
@@ -49,6 +71,44 @@ public class SessionContextManager implements HarvestLifecycleAware {
     @Override
     public void onHarvest() {
         snapshotCurrentSessionContext();
+    }
+
+    @Override
+    public void onHarvestComplete() {
+        // Harvest POST accepted (2xx).
+        lastHarvestHandled = true;
+    }
+
+    @Override
+    public void onHarvestSendFailed() {
+        // No connectivity — the harvest data was persisted offline for later upload.
+        // Treated as "handled" so background cleanup runs whether online or offline.
+        lastHarvestHandled = true;
+    }
+
+    @Override
+    public void onHarvestError() {
+        // Server rejected the data (4xx/5xx); it was not accepted. Keep the manifest.
+        lastHarvestHandled = false;
+    }
+
+    @Override
+    public void applicationForegrounded(ApplicationStateEvent e) {
+        // No-op: the next onHarvest() re-snapshots the (continuing or new) session.
+    }
+
+    /**
+     * The app has gone to the background. The agent forces a final harvest before this
+     * callback runs (it is registered ahead of us and blocks until the tick finishes), so
+     * {@link #lastHarvestHandled} reflects that harvest's outcome. If the data was delivered
+     * or persisted, drop the current session's manifest — it is no longer needed for a clean
+     * shutdown, and the bounded store handles anything left behind.
+     */
+    @Override
+    public void applicationBackgrounded(ApplicationStateEvent e) {
+        if (lastHarvestHandled) {
+            deleteCurrentSessionContext();
+        }
     }
 
     void snapshotCurrentSessionContext() {
@@ -76,6 +136,17 @@ public class SessionContextManager implements HarvestLifecycleAware {
             store.upsert(manifest);
         } catch (Exception e) {
             log.error("SessionContextManager: failed to snapshot session context: " + e);
+        }
+    }
+
+    void deleteCurrentSessionContext() {
+        SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+        if (store == null) {
+            return;
+        }
+        String sessionId = AgentConfiguration.getInstance().getSessionID();
+        if (sessionId != null && !sessionId.isEmpty()) {
+            store.delete(sessionId);
         }
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextStore.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextStore.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessioncontext;
+
+import java.util.List;
+
+/**
+ * Persistent, {@code sessionId}-keyed store of {@link SessionManifest} snapshots. One
+ * manifest per session; {@link #upsert(SessionManifest)} replaces an existing entry for
+ * the same {@code sessionId}.
+ */
+public interface SessionContextStore {
+
+    /** Store or replace the manifest for its {@code sessionId}. Returns false on IO failure. */
+    boolean upsert(SessionManifest manifest);
+
+    /** Returns the manifest for {@code sessionId}, or {@code null} if absent/unreadable. */
+    SessionManifest get(String sessionId);
+
+    /** Returns all stored manifests (order unspecified). */
+    List<SessionManifest> fetchAll();
+
+    /** Removes the manifest for {@code sessionId} if present. */
+    void delete(String sessionId);
+
+    /** Number of stored manifests. */
+    int count();
+
+    /** Removes all stored manifests. */
+    void clear();
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextStore.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionContextStore.java
@@ -16,6 +16,12 @@ public interface SessionContextStore {
     /** Store or replace the manifest for its {@code sessionId}. Returns false on IO failure. */
     boolean upsert(SessionManifest manifest);
 
+    /** Set the Session Replay state for a session, preserving its context fields. Creates a minimal record if absent. */
+    void updateSessionReplayState(String sessionId, boolean reachedFullMode, boolean isFirstChunk);
+
+    /** Set the OS exit reason for a session, preserving all other fields. No-op if the session has no record. */
+    void updateExitReason(String sessionId, int exitReason);
+
     /** Returns the manifest for {@code sessionId}, or {@code null} if absent/unreadable. */
     SessionManifest get(String sessionId);
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionManifest.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionManifest.java
@@ -35,6 +35,9 @@ public class SessionManifest {
     static final String KEY_SESSION_START_MS = "sessionStartMs";
     static final String KEY_LAST_UPDATE_MS = "lastUpdateMs";
     static final String KEY_ATTRIBUTES = "attributes";
+    static final String KEY_REACHED_FULL_MODE = "reachedFullMode";
+    static final String KEY_IS_FIRST_CHUNK = "isFirstChunk";
+    static final String KEY_EXIT_REASON = "exitReason";
 
     private final int schemaVersion;
     private final String sessionId;
@@ -42,20 +45,35 @@ public class SessionManifest {
     private final long sessionStartMs;
     private final long lastUpdateMs;
     private final Set<AnalyticsAttribute> attributes;
+    // Internal, never-sent fields. null = "unknown / not set by any writer".
+    private final Boolean reachedFullMode;
+    private final Boolean isFirstChunk;
+    private final Integer exitReason;
 
     public SessionManifest(String sessionId, int realAgentId, long sessionStartMs,
                            long lastUpdateMs, Set<AnalyticsAttribute> attributes) {
-        this(CURRENT_SCHEMA_VERSION, sessionId, realAgentId, sessionStartMs, lastUpdateMs, attributes);
+        this(CURRENT_SCHEMA_VERSION, sessionId, realAgentId, sessionStartMs, lastUpdateMs,
+                attributes, null, null, null);
     }
 
     SessionManifest(int schemaVersion, String sessionId, int realAgentId, long sessionStartMs,
                     long lastUpdateMs, Set<AnalyticsAttribute> attributes) {
+        this(schemaVersion, sessionId, realAgentId, sessionStartMs, lastUpdateMs,
+                attributes, null, null, null);
+    }
+
+    public SessionManifest(int schemaVersion, String sessionId, int realAgentId, long sessionStartMs,
+                           long lastUpdateMs, Set<AnalyticsAttribute> attributes,
+                           Boolean reachedFullMode, Boolean isFirstChunk, Integer exitReason) {
         this.schemaVersion = schemaVersion;
         this.sessionId = sessionId == null ? "" : sessionId;
         this.realAgentId = realAgentId;
         this.sessionStartMs = sessionStartMs;
         this.lastUpdateMs = lastUpdateMs;
         this.attributes = attributes == null ? new HashSet<>() : new HashSet<>(attributes);
+        this.reachedFullMode = reachedFullMode;
+        this.isFirstChunk = isFirstChunk;
+        this.exitReason = exitReason;
     }
 
     public int getSchemaVersion() {
@@ -82,6 +100,18 @@ public class SessionManifest {
         return Collections.unmodifiableSet(attributes);
     }
 
+    public Boolean getReachedFullMode() {
+        return reachedFullMode;
+    }
+
+    public Boolean getIsFirstChunk() {
+        return isFirstChunk;
+    }
+
+    public Integer getExitReason() {
+        return exitReason;
+    }
+
     public boolean isValid() {
         return sessionId != null && !sessionId.isEmpty();
     }
@@ -102,6 +132,17 @@ public class SessionManifest {
             }
         }
         root.add(KEY_ATTRIBUTES, attrs);
+
+        // Internal, never-sent fields live at the manifest top level, never inside attributes.
+        if (reachedFullMode != null) {
+            root.addProperty(KEY_REACHED_FULL_MODE, reachedFullMode);
+        }
+        if (isFirstChunk != null) {
+            root.addProperty(KEY_IS_FIRST_CHUNK, isFirstChunk);
+        }
+        if (exitReason != null) {
+            root.addProperty(KEY_EXIT_REASON, exitReason);
+        }
         return root;
     }
 
@@ -121,6 +162,11 @@ public class SessionManifest {
         } else {
             attributes = new HashSet<>();
         }
-        return new SessionManifest(schemaVersion, sessionId, realAgentId, sessionStartMs, lastUpdateMs, attributes);
+
+        Boolean reachedFullMode = root.has(KEY_REACHED_FULL_MODE) ? root.get(KEY_REACHED_FULL_MODE).getAsBoolean() : null;
+        Boolean isFirstChunk = root.has(KEY_IS_FIRST_CHUNK) ? root.get(KEY_IS_FIRST_CHUNK).getAsBoolean() : null;
+        Integer exitReason = root.has(KEY_EXIT_REASON) ? root.get(KEY_EXIT_REASON).getAsInt() : null;
+        return new SessionManifest(schemaVersion, sessionId, realAgentId, sessionStartMs, lastUpdateMs,
+                attributes, reachedFullMode, isFirstChunk, exitReason);
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionManifest.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/SessionManifest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessioncontext;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A frozen snapshot of one session's context — its id, agent id, start time, and the
+ * session attributes that were live at snapshot time. Persisted (one file per session,
+ * keyed by {@link #getSessionId()}) so a cross-process consumer (e.g. an AEI emitted on
+ * the next launch) can attach the attributes that were active when the session was alive
+ * rather than the post-restart session's attributes.
+ *
+ * <p>Attributes are serialized as a JSON object of {@code name -> primitive} using
+ * {@link AnalyticsAttribute#asJsonElement()} and reconstructed with
+ * {@link AnalyticsAttribute#newFromJson(JsonObject)}. This round-trip is faithful because
+ * {@code AnalyticsAttribute} has only STRING/DOUBLE/BOOLEAN types (no int — all numerics
+ * are stored as double), so no custom typed record is needed.
+ */
+public class SessionManifest {
+
+    public static final int CURRENT_SCHEMA_VERSION = 1;
+
+    static final String KEY_SCHEMA_VERSION = "schemaVersion";
+    static final String KEY_SESSION_ID = "sessionId";
+    static final String KEY_REAL_AGENT_ID = "realAgentId";
+    static final String KEY_SESSION_START_MS = "sessionStartMs";
+    static final String KEY_LAST_UPDATE_MS = "lastUpdateMs";
+    static final String KEY_ATTRIBUTES = "attributes";
+
+    private final int schemaVersion;
+    private final String sessionId;
+    private final int realAgentId;
+    private final long sessionStartMs;
+    private final long lastUpdateMs;
+    private final Set<AnalyticsAttribute> attributes;
+
+    public SessionManifest(String sessionId, int realAgentId, long sessionStartMs,
+                           long lastUpdateMs, Set<AnalyticsAttribute> attributes) {
+        this(CURRENT_SCHEMA_VERSION, sessionId, realAgentId, sessionStartMs, lastUpdateMs, attributes);
+    }
+
+    SessionManifest(int schemaVersion, String sessionId, int realAgentId, long sessionStartMs,
+                    long lastUpdateMs, Set<AnalyticsAttribute> attributes) {
+        this.schemaVersion = schemaVersion;
+        this.sessionId = sessionId == null ? "" : sessionId;
+        this.realAgentId = realAgentId;
+        this.sessionStartMs = sessionStartMs;
+        this.lastUpdateMs = lastUpdateMs;
+        this.attributes = attributes == null ? new HashSet<>() : new HashSet<>(attributes);
+    }
+
+    public int getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public int getRealAgentId() {
+        return realAgentId;
+    }
+
+    public long getSessionStartMs() {
+        return sessionStartMs;
+    }
+
+    public long getLastUpdateMs() {
+        return lastUpdateMs;
+    }
+
+    public Set<AnalyticsAttribute> getAttributes() {
+        return Collections.unmodifiableSet(attributes);
+    }
+
+    public boolean isValid() {
+        return sessionId != null && !sessionId.isEmpty();
+    }
+
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+        root.addProperty(KEY_SCHEMA_VERSION, schemaVersion);
+        root.addProperty(KEY_SESSION_ID, sessionId);
+        root.addProperty(KEY_REAL_AGENT_ID, realAgentId);
+        root.addProperty(KEY_SESSION_START_MS, sessionStartMs);
+        root.addProperty(KEY_LAST_UPDATE_MS, lastUpdateMs);
+
+        JsonObject attrs = new JsonObject();
+        for (AnalyticsAttribute attribute : attributes) {
+            JsonElement element = attribute.asJsonElement();
+            if (element != null) {
+                attrs.add(attribute.getName(), element);
+            }
+        }
+        root.add(KEY_ATTRIBUTES, attrs);
+        return root;
+    }
+
+    public static SessionManifest fromJson(JsonObject root) {
+        if (root == null) {
+            return new SessionManifest(CURRENT_SCHEMA_VERSION, "", 0, 0L, 0L, new HashSet<>());
+        }
+        int schemaVersion = root.has(KEY_SCHEMA_VERSION) ? root.get(KEY_SCHEMA_VERSION).getAsInt() : CURRENT_SCHEMA_VERSION;
+        String sessionId = root.has(KEY_SESSION_ID) ? root.get(KEY_SESSION_ID).getAsString() : "";
+        int realAgentId = root.has(KEY_REAL_AGENT_ID) ? root.get(KEY_REAL_AGENT_ID).getAsInt() : 0;
+        long sessionStartMs = root.has(KEY_SESSION_START_MS) ? root.get(KEY_SESSION_START_MS).getAsLong() : 0L;
+        long lastUpdateMs = root.has(KEY_LAST_UPDATE_MS) ? root.get(KEY_LAST_UPDATE_MS).getAsLong() : 0L;
+
+        Set<AnalyticsAttribute> attributes;
+        if (root.has(KEY_ATTRIBUTES) && root.get(KEY_ATTRIBUTES).isJsonObject()) {
+            attributes = AnalyticsAttribute.newFromJson(root.getAsJsonObject(KEY_ATTRIBUTES));
+        } else {
+            attributes = new HashSet<>();
+        }
+        return new SessionManifest(schemaVersion, sessionId, realAgentId, sessionStartMs, lastUpdateMs, attributes);
+    }
+}

--- a/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/util/Constants.java
@@ -41,6 +41,7 @@ public final class Constants {
         public static final String CONTENT_ENCODING = "content_encoding";
         public static final String APP_VERSION = "appVersion";
         public static final String SESSION_ID = "sessionId";
+        public static final String RECOVERED = "recovered";
         public static final String FIRST_TIMESTAMP = "firstTimestamp";
         public static final String LAST_TIMESTAMP = "lastTimestamp";
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/FeatureFlagTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/FeatureFlagTest.java
@@ -69,6 +69,7 @@ public class FeatureFlagTest {
         Assert.assertTrue("AppStartMetrics is enabled by default", FeatureFlag.featureEnabled(AppStartMetrics));
         Assert.assertTrue("ApplicationExitReporting is enabled by default", FeatureFlag.featureEnabled(ApplicationExitReporting));
         Assert.assertTrue("LogReporting is enabled by default", FeatureFlag.featureEnabled(LogReporting));
+        Assert.assertTrue("EventPersistence is enabled by default", FeatureFlag.featureEnabled(EventPersistence));
     }
 
     @Test
@@ -76,7 +77,6 @@ public class FeatureFlagTest {
         Assert.assertFalse("FedRamp is disabled by default", FeatureFlag.featureEnabled(FedRampEnabled));
         Assert.assertFalse("OfflineStorage is disabled by default", FeatureFlag.featureEnabled(OfflineStorage));
         Assert.assertFalse("BackgroundReporting is disabled by default", FeatureFlag.featureEnabled(BackgroundReporting));
-        Assert.assertFalse("EventPersistence is disabled by default", FeatureFlag.featureEnabled(EventPersistence));
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsControllerImplTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsControllerImplTests.java
@@ -7,6 +7,8 @@ package com.newrelic.agent.android.analytics;
 
 import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.harvest.Harvest;
@@ -95,6 +97,55 @@ public class AnalyticsControllerImplTests {
     @After
     public void tearDown() throws Exception {
 
+    }
+
+    @Test
+    public void reattributesRecoveredEventToOriginSession() {
+        InMemorySessionContextStore store = new InMemorySessionContextStore();
+        AgentConfiguration.getInstance().setSessionContextStore(store);
+        String current = AgentConfiguration.getInstance().getSessionID();
+
+        Set<AnalyticsAttribute> originAttrs = new HashSet<AnalyticsAttribute>();
+        originAttrs.add(new AnalyticsAttribute("userId", "u1"));
+        store.upsert(new SessionManifest("S_OLD", 7, 0L, 0L, originAttrs));
+
+        AnalyticsEvent recovered = stampedEvent("recovered", "S_OLD");
+        AnalyticsEvent live = stampedEvent("live", current);
+
+        controller.reattributeRecoveredEvents(Arrays.asList(recovered, live));
+
+        // Recovered event picks up its origin session's attributes, keyed to the dead session.
+        Assert.assertEquals("u1", attrValue(recovered, "userId"));
+        Assert.assertEquals("S_OLD", attrValue(recovered, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        // Live (current-session) event is left for the harvest's current-session block.
+        Assert.assertNull(attrValue(live, "userId"));
+    }
+
+    @Test
+    public void manifestMissingKeepsOriginSessionId() {
+        AgentConfiguration.getInstance().setSessionContextStore(new InMemorySessionContextStore());
+        AnalyticsEvent recovered = stampedEvent("recovered", "S_GONE");
+
+        controller.reattributeRecoveredEvents(Arrays.asList(recovered));
+
+        Assert.assertEquals("S_GONE", attrValue(recovered, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+    }
+
+    private static AnalyticsEvent stampedEvent(String name, String sessionId) {
+        AnalyticsEvent event = new AnalyticsEvent(name);
+        Set<AnalyticsAttribute> attrs = new HashSet<AnalyticsAttribute>();
+        attrs.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, sessionId, false));
+        event.putAttributesUnchecked(attrs);
+        return event;
+    }
+
+    private static String attrValue(AnalyticsEvent event, String name) {
+        for (AnalyticsAttribute a : event.getAttributeSet()) {
+            if (name.equals(a.getName())) {
+                return a.getStringValue();
+            }
+        }
+        return null;
     }
 
     @Test
@@ -1206,5 +1257,18 @@ public class AnalyticsControllerImplTests {
         protected Harvester getHarvester() {
             return new HarvesterStub();
         }
+    }
+
+    private static class InMemorySessionContextStore implements SessionContextStore {
+        final Map<String, SessionManifest> map = new HashMap<String, SessionManifest>();
+
+        @Override public boolean upsert(SessionManifest m) { map.put(m.getSessionId(), m); return true; }
+        @Override public SessionManifest get(String id) { return map.get(id); }
+        @Override public List<SessionManifest> fetchAll() { return new ArrayList<SessionManifest>(map.values()); }
+        @Override public void delete(String id) { map.remove(id); }
+        @Override public int count() { return map.size(); }
+        @Override public void clear() { map.clear(); }
+        @Override public void updateSessionReplayState(String id, boolean reachedFullMode, boolean isFirstChunk) { }
+        @Override public void updateExitReason(String id, int exitReason) { }
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsEventTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsEventTests.java
@@ -176,4 +176,33 @@ public class AnalyticsEventTests {
         AnalyticsEvent newEvent = AnalyticsEvent.eventFromJsonString(origUUID, origEvent.toJsonString());
         Assert.assertEquals("UUID should stay the same", origUUID, newEvent.getEventUUID());
     }
+
+    @Test
+    public void putAttributesUncheckedReplacesByNameAndAllowsReserved() {
+        AnalyticsEvent event = new AnalyticsEvent("e");
+
+        // Reserved name (sessionId) is accepted here — the public addAttributes() would reject it.
+        Set<AnalyticsAttribute> first = new HashSet<AnalyticsAttribute>();
+        first.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, "S_OLD", false));
+        first.add(new AnalyticsAttribute("userId", "u1"));
+        event.putAttributesUnchecked(first);
+        Assert.assertEquals("S_OLD", attrValue(event, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        Assert.assertEquals("u1", attrValue(event, "userId"));
+
+        // A same-named attribute is replaced (supplied value wins); others are preserved.
+        Set<AnalyticsAttribute> second = new HashSet<AnalyticsAttribute>();
+        second.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, "S_NEW", false));
+        event.putAttributesUnchecked(second);
+        Assert.assertEquals("S_NEW", attrValue(event, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        Assert.assertEquals("u1", attrValue(event, "userId"));
+    }
+
+    private static String attrValue(AnalyticsEvent event, String name) {
+        for (AnalyticsAttribute a : event.getAttributeSet()) {
+            if (name.equals(a.getName())) {
+                return a.getStringValue();
+            }
+        }
+        return null;
+    }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/EventManagerTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/EventManagerTests.java
@@ -23,7 +23,10 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +67,94 @@ public class EventManagerTests implements EventListener {
     public void tearDown() throws Exception {
         eventStore.clear();
         manager.shutdown();
+    }
+
+    @Test
+    public void persistedEventIsStampedButLiveEventIsNot() {
+        // Capturing store records the serialized form at store() time (like FileEventStore on disk),
+        // so we can assert the persisted snapshot independently of later in-memory mutations.
+        final List<String> capturedJson = new ArrayList<String>();
+        AnalyticsEventStore capturingStore = new AnalyticsEventStore() {
+            @Override public boolean store(AnalyticsEvent e) { capturedJson.add(e.asJsonObject().toString()); return true; }
+            @Override public List<AnalyticsEvent> fetchAll() { return new ArrayList<AnalyticsEvent>(); }
+            @Override public int count() { return capturedJson.size(); }
+            @Override public void clear() { capturedJson.clear(); }
+            @Override public void delete(AnalyticsEvent e) { }
+            @Override public String getRootPath() { return ""; }
+        };
+
+        AgentConfiguration cfg = new AgentConfiguration();
+        cfg.setEnableAnalyticsEvents(true);
+        cfg.setEventStore(capturingStore);
+        cfg.setAnalyticsAttributeStore(new StubAnalyticsAttributeStore());
+
+        EventManagerImpl localManager = new EventManagerImpl();
+        localManager.initialize(cfg);
+
+        FeatureFlag.enableFeature(FeatureFlag.EventPersistence);
+        AnalyticsEvent event = new CustomEvent("persisted", null);
+        localManager.addEvent(event);
+
+        // The persisted (serialized) form carries the origin sessionId...
+        Assert.assertEquals(1, capturedJson.size());
+        Assert.assertTrue("persisted JSON must carry sessionId",
+                capturedJson.get(0).contains(AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        // ...but the live in-memory event does not — the stamp is stripped after store().
+        boolean liveHasSessionId = false;
+        for (AnalyticsAttribute a : event.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(a.getName())) {
+                liveHasSessionId = true;
+                break;
+            }
+        }
+        Assert.assertFalse("live event must not keep the inline sessionId", liveHasSessionId);
+
+        localManager.shutdown();
+    }
+
+    @Test
+    public void reloadedEventIsNotRepersistedAndKeepsOriginSessionId() {
+        // A persisted event reloaded on the next launch already carries its origin sessionId and is
+        // already on disk: it must NOT be re-stored (no duplicate write), and it must keep its
+        // origin sessionId on the in-memory event so the next harvest can re-attribute it.
+        final List<String> capturedJson = new ArrayList<String>();
+        AnalyticsEventStore capturingStore = new AnalyticsEventStore() {
+            @Override public boolean store(AnalyticsEvent e) { capturedJson.add(e.asJsonObject().toString()); return true; }
+            @Override public List<AnalyticsEvent> fetchAll() { return new ArrayList<AnalyticsEvent>(); }
+            @Override public int count() { return capturedJson.size(); }
+            @Override public void clear() { capturedJson.clear(); }
+            @Override public void delete(AnalyticsEvent e) { }
+            @Override public String getRootPath() { return ""; }
+        };
+
+        AgentConfiguration cfg = new AgentConfiguration();
+        cfg.setEnableAnalyticsEvents(true);
+        cfg.setEventStore(capturingStore);
+        cfg.setAnalyticsAttributeStore(new StubAnalyticsAttributeStore());
+
+        EventManagerImpl localManager = new EventManagerImpl();
+        localManager.initialize(cfg);
+
+        FeatureFlag.enableFeature(FeatureFlag.EventPersistence);
+        AnalyticsEvent reloaded = new CustomEvent("reloaded", null);
+        Set<AnalyticsAttribute> origin = new HashSet<AnalyticsAttribute>();
+        origin.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, "S_OLD", false));
+        reloaded.putAttributesUnchecked(origin);
+
+        localManager.addEvent(reloaded);
+
+        // Already on disk → must NOT be re-stored.
+        Assert.assertEquals("reloaded event must not be re-persisted", 0, capturedJson.size());
+        // Live event keeps its origin sessionId so the next harvest can re-attribute it.
+        String liveSessionId = null;
+        for (AnalyticsAttribute a : reloaded.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(a.getName())) {
+                liveSessionId = a.getStringValue();
+            }
+        }
+        Assert.assertEquals("S_OLD", liveSessionId);
+
+        localManager.shutdown();
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/TestEventStore.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/TestEventStore.java
@@ -6,26 +6,25 @@
 package com.newrelic.agent.android.analytics;
 
 
-import org.junit.Assert;
-
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 public class TestEventStore implements AnalyticsEventStore {
-    Set<AnalyticsEvent> events = new HashSet<>();
+    // Keyed by event UUID to mirror FileEventStore (which stores one file per UUID and
+    // deletes by UUID), so a persisted clone is correctly de-duped and deletable.
+    Map<String, AnalyticsEvent> events = new LinkedHashMap<>();
 
     @Override
     public boolean store(AnalyticsEvent event) {
-        events.add(event);
-        Assert.assertTrue(events.contains(event));
-        return events.contains(event);
+        events.put(event.getEventUUID(), event);
+        return true;
     }
 
     @Override
     public List<AnalyticsEvent> fetchAll() {
-        return new ArrayList<>(events);
+        return new ArrayList<>(events.values());
     }
 
     @Override
@@ -40,7 +39,7 @@ public class TestEventStore implements AnalyticsEventStore {
 
     @Override
     public void delete(AnalyticsEvent event) {
-        events.remove(event);
+        events.remove(event.getEventUUID());
     }
 
     @Override

--- a/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerFeatureFlagTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerFeatureFlagTest.java
@@ -101,9 +101,6 @@ public class JSErrorDataControllerFeatureFlagTest {
         final Map<String, String> data = new HashMap<>();
         /** Released after the first {@link #store} call so tests can join the worker thread. */
         final CountDownLatch stored = new CountDownLatch(1);
-    private static final class CountingJSErrorStore implements JSErrorStore {
-        final AtomicInteger storeCalls = new AtomicInteger(0);
-        final Map<String, String> data = new HashMap<>();
 
         @Override
         public boolean store(String id, String value) {

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessioncontext;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.harvest.DataToken;
+import com.newrelic.agent.android.harvest.Harvest;
+import com.newrelic.agent.android.harvest.HarvestConfiguration;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.ConsoleAgentLog;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SessionContextManagerTest {
+
+    static class InMemorySessionContextStore implements SessionContextStore {
+        final Map<String, SessionManifest> map = new HashMap<>();
+
+        @Override public boolean upsert(SessionManifest m) { map.put(m.getSessionId(), m); return true; }
+        @Override public SessionManifest get(String id) { return map.get(id); }
+        @Override public List<SessionManifest> fetchAll() { return new ArrayList<>(map.values()); }
+        @Override public void delete(String id) { map.remove(id); }
+        @Override public int count() { return map.size(); }
+        @Override public void clear() { map.clear(); }
+    }
+
+    private InMemorySessionContextStore store;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AgentLogManager.setAgentLog(new ConsoleAgentLog());
+        HarvestConfiguration harvestConfig = Harvest.getHarvestConfiguration();
+        harvestConfig.setData_token(new DataToken(1, 2).asIntArray());
+    }
+
+    @Before
+    public void setUp() {
+        store = new InMemorySessionContextStore();
+        AgentConfiguration.getInstance().setSessionContextStore(store);
+    }
+
+    @After
+    public void tearDown() {
+        AgentConfiguration.getInstance().setSessionContextStore(null);
+    }
+
+    @Test
+    public void snapshotWritesManifestForCurrentSession() {
+        new SessionContextManager().snapshotCurrentSessionContext();
+
+        String sessionId = AgentConfiguration.getInstance().getSessionID();
+        SessionManifest manifest = store.get(sessionId);
+        Assert.assertNotNull(manifest);
+        Assert.assertEquals(sessionId, manifest.getSessionId());
+    }
+
+    @Test
+    public void onHarvestDelegatesToSnapshot() {
+        new SessionContextManager().onHarvest();
+
+        Assert.assertEquals(1, store.count());
+    }
+
+    @Test
+    public void noStoreConfiguredIsNoOp() {
+        AgentConfiguration.getInstance().setSessionContextStore(null);
+        // Must not throw.
+        new SessionContextManager().snapshotCurrentSessionContext();
+    }
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
@@ -33,6 +33,22 @@ public class SessionContextManagerTest {
         @Override public void delete(String id) { map.remove(id); }
         @Override public int count() { return map.size(); }
         @Override public void clear() { map.clear(); }
+        @Override public void updateSessionReplayState(String id, boolean reachedFullMode, boolean isFirstChunk) {
+            SessionManifest e = map.get(id);
+            map.put(id, new SessionManifest(SessionManifest.CURRENT_SCHEMA_VERSION, id,
+                    e != null ? e.getRealAgentId() : 0,
+                    e != null ? e.getSessionStartMs() : 0L,
+                    e != null ? e.getLastUpdateMs() : 0L,
+                    e != null ? e.getAttributes() : null,
+                    reachedFullMode, isFirstChunk, e != null ? e.getExitReason() : null));
+        }
+        @Override public void updateExitReason(String id, int exitReason) {
+            SessionManifest e = map.get(id);
+            if (e == null) { return; }
+            map.put(id, new SessionManifest(SessionManifest.CURRENT_SCHEMA_VERSION, id, e.getRealAgentId(),
+                    e.getSessionStartMs(), e.getLastUpdateMs(), e.getAttributes(),
+                    e.getReachedFullMode(), e.getIsFirstChunk(), Integer.valueOf(exitReason)));
+        }
     }
 
     private InMemorySessionContextStore store;

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
@@ -78,4 +78,17 @@ public class SessionContextManagerTest {
         // Must not throw.
         new SessionContextManager().snapshotCurrentSessionContext();
     }
+
+    @Test
+    public void initializeReturnsSameInstanceAndReRegistersIdempotently() {
+        try {
+            SessionContextManager first = SessionContextManager.initialize();
+            // A second initialize() (as happens on a stop/start cycle) must reuse the singleton
+            // and re-register without throwing or double-registering.
+            SessionContextManager second = SessionContextManager.initialize();
+            Assert.assertSame(first, second);
+        } finally {
+            SessionContextManager.shutdown();
+        }
+    }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
@@ -78,44 +78,4 @@ public class SessionContextManagerTest {
         // Must not throw.
         new SessionContextManager().snapshotCurrentSessionContext();
     }
-
-    @Test
-    public void backgroundedAfterSuccessfulHarvestDeletesCurrentManifest() {
-        SessionContextManager mgr = new SessionContextManager();
-        mgr.snapshotCurrentSessionContext();
-        String sessionId = AgentConfiguration.getInstance().getSessionID();
-        Assert.assertNotNull(store.get(sessionId));
-
-        mgr.onHarvestComplete();            // last harvest delivered (online 2xx)
-        mgr.applicationBackgrounded(null);  // event arg is unused by the handler
-
-        Assert.assertNull("manifest should be deleted after background + successful harvest",
-                store.get(sessionId));
-    }
-
-    @Test
-    public void backgroundedAfterOfflinePersistDeletesCurrentManifest() {
-        SessionContextManager mgr = new SessionContextManager();
-        mgr.snapshotCurrentSessionContext();
-        String sessionId = AgentConfiguration.getInstance().getSessionID();
-
-        mgr.onHarvestSendFailed();          // no network — data persisted offline
-        mgr.applicationBackgrounded(null);
-
-        Assert.assertNull("manifest should be deleted on background whether online or offline",
-                store.get(sessionId));
-    }
-
-    @Test
-    public void backgroundedAfterServerErrorKeepsManifest() {
-        SessionContextManager mgr = new SessionContextManager();
-        mgr.snapshotCurrentSessionContext();
-        String sessionId = AgentConfiguration.getInstance().getSessionID();
-
-        mgr.onHarvestError();               // server rejected (4xx/5xx) — not accepted
-        mgr.applicationBackgrounded(null);
-
-        Assert.assertNotNull("manifest must be kept when the harvest was not accepted",
-                store.get(sessionId));
-    }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionContextManagerTest.java
@@ -78,4 +78,44 @@ public class SessionContextManagerTest {
         // Must not throw.
         new SessionContextManager().snapshotCurrentSessionContext();
     }
+
+    @Test
+    public void backgroundedAfterSuccessfulHarvestDeletesCurrentManifest() {
+        SessionContextManager mgr = new SessionContextManager();
+        mgr.snapshotCurrentSessionContext();
+        String sessionId = AgentConfiguration.getInstance().getSessionID();
+        Assert.assertNotNull(store.get(sessionId));
+
+        mgr.onHarvestComplete();            // last harvest delivered (online 2xx)
+        mgr.applicationBackgrounded(null);  // event arg is unused by the handler
+
+        Assert.assertNull("manifest should be deleted after background + successful harvest",
+                store.get(sessionId));
+    }
+
+    @Test
+    public void backgroundedAfterOfflinePersistDeletesCurrentManifest() {
+        SessionContextManager mgr = new SessionContextManager();
+        mgr.snapshotCurrentSessionContext();
+        String sessionId = AgentConfiguration.getInstance().getSessionID();
+
+        mgr.onHarvestSendFailed();          // no network — data persisted offline
+        mgr.applicationBackgrounded(null);
+
+        Assert.assertNull("manifest should be deleted on background whether online or offline",
+                store.get(sessionId));
+    }
+
+    @Test
+    public void backgroundedAfterServerErrorKeepsManifest() {
+        SessionContextManager mgr = new SessionContextManager();
+        mgr.snapshotCurrentSessionContext();
+        String sessionId = AgentConfiguration.getInstance().getSessionID();
+
+        mgr.onHarvestError();               // server rejected (4xx/5xx) — not accepted
+        mgr.applicationBackgrounded(null);
+
+        Assert.assertNotNull("manifest must be kept when the harvest was not accepted",
+                store.get(sessionId));
+    }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionManifestTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionManifestTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessioncontext;
+
+import com.google.gson.JsonObject;
+import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.logging.ConsoleAgentLog;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class SessionManifestTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AgentLogManager.setAgentLog(new ConsoleAgentLog());
+    }
+
+    private static Map<String, AnalyticsAttribute> byName(Set<AnalyticsAttribute> attrs) {
+        Map<String, AnalyticsAttribute> m = new HashMap<>();
+        for (AnalyticsAttribute a : attrs) {
+            m.put(a.getName(), a);
+        }
+        return m;
+    }
+
+    @Test
+    public void roundTripsAllAttributeTypes() {
+        Set<AnalyticsAttribute> attrs = new HashSet<>();
+        attrs.add(new AnalyticsAttribute("checkout_step", "review"));
+        attrs.add(new AnalyticsAttribute("cartSize", 3.0));
+        attrs.add(new AnalyticsAttribute("premium", true));
+
+        SessionManifest original = new SessionManifest("S_A", 1234, 1000L, 2000L, attrs);
+        JsonObject json = original.toJson();
+        SessionManifest restored = SessionManifest.fromJson(json);
+
+        Assert.assertEquals("S_A", restored.getSessionId());
+        Assert.assertEquals(1234, restored.getRealAgentId());
+        Assert.assertEquals(1000L, restored.getSessionStartMs());
+        Assert.assertEquals(2000L, restored.getLastUpdateMs());
+
+        Map<String, AnalyticsAttribute> restoredAttrs = byName(restored.getAttributes());
+        Assert.assertEquals(3, restoredAttrs.size());
+        Assert.assertEquals("review", restoredAttrs.get("checkout_step").getStringValue());
+        Assert.assertEquals(3.0, restoredAttrs.get("cartSize").getDoubleValue(), 0.0);
+        Assert.assertTrue(restoredAttrs.get("premium").getBooleanValue());
+    }
+
+    @Test
+    public void legacyJsonWithoutOptionalFieldsDeserializesToDefaults() {
+        JsonObject legacy = new JsonObject();
+        legacy.addProperty("sessionId", "S_legacy");
+        legacy.addProperty("realAgentId", 7);
+
+        SessionManifest restored = SessionManifest.fromJson(legacy);
+
+        Assert.assertEquals("S_legacy", restored.getSessionId());
+        Assert.assertEquals(7, restored.getRealAgentId());
+        Assert.assertEquals(0L, restored.getSessionStartMs());
+        Assert.assertEquals(0L, restored.getLastUpdateMs());
+        Assert.assertTrue(restored.getAttributes().isEmpty());
+    }
+}

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionManifestTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessioncontext/SessionManifestTest.java
@@ -70,4 +70,29 @@ public class SessionManifestTest {
         Assert.assertEquals(0L, restored.getLastUpdateMs());
         Assert.assertTrue(restored.getAttributes().isEmpty());
     }
+
+    @Test
+    public void roundTripsInternalSrAndExitFields() {
+        SessionManifest m = new SessionManifest(
+                SessionManifest.CURRENT_SCHEMA_VERSION, "S_A", 1234, 10L, 20L,
+                new java.util.HashSet<>(), Boolean.TRUE, Boolean.FALSE, Integer.valueOf(6));
+        SessionManifest restored = SessionManifest.fromJson(m.toJson());
+
+        Assert.assertEquals(Boolean.TRUE, restored.getReachedFullMode());
+        Assert.assertEquals(Boolean.FALSE, restored.getIsFirstChunk());
+        Assert.assertEquals(Integer.valueOf(6), restored.getExitReason());
+        // Internal fields must NOT leak into the attribute object that events send.
+        Assert.assertFalse(m.toJson().getAsJsonObject("attributes").has("reachedFullMode"));
+        Assert.assertFalse(m.toJson().getAsJsonObject("attributes").has("exitReason"));
+    }
+
+    @Test
+    public void absentInternalFieldsDeserializeToNull() {
+        // The Phase-1 5-arg constructor leaves the internal fields unset.
+        SessionManifest m = new SessionManifest("S_B", 7, 0L, 0L, new java.util.HashSet<>());
+        SessionManifest restored = SessionManifest.fromJson(m.toJson());
+        Assert.assertNull(restored.getReachedFullMode());
+        Assert.assertNull(restored.getIsFirstChunk());
+        Assert.assertNull(restored.getExitReason());
+    }
 }

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -60,6 +60,8 @@ import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.metric.MetricUnit;
 import com.newrelic.agent.android.ndk.NativeReporting;
 import com.newrelic.agent.android.hybrid.FileJSErrorStore;
+import com.newrelic.agent.android.sessioncontext.FileSessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionContextManager;
 import com.newrelic.agent.android.payload.FilePayloadStore;
 import com.newrelic.agent.android.payload.PayloadController;
 import com.newrelic.agent.android.sample.MachineMeasurementConsumer;
@@ -175,6 +177,8 @@ public class AndroidAgentImpl implements
         agentConfiguration.setJsErrorStore(new FileJSErrorStore(context, agentConfiguration));
         context.deleteSharedPreferences("NRJSErrorStore");
 
+        agentConfiguration.setSessionContextStore(new FileSessionContextStore(context, agentConfiguration));
+
         ApplicationStateMonitor.getInstance().addApplicationStateListener(this);
         // used to determine when app backgrounds
         final UiBackgroundListener backgroundListener;
@@ -254,6 +258,8 @@ public class AndroidAgentImpl implements
         StatsEngine.get().inc(MetricNames.SUPPORTABILITY_CRASH_UNCAUGHT_HANDLER
                 .replace(MetricNames.TAG_NAME, getUnhandledExceptionHandlerName()));
         PayloadController.initialize(agentConfiguration);
+
+        SessionContextManager.initialize();
 
         // Set up the sampler
         Sampler.init(context);

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -1179,6 +1179,11 @@ public class AndroidAgentImpl implements
         if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
             startSessionReplayRecorder(context, agentConfiguration);
 
+            // Recover orphaned SR buffers from a prior abnormal termination. Runs here (not at SR
+            // init) so the reporter is initialized and the prior session's AEI exit reasons have
+            // already been recorded into the manifests above.
+            SessionReplay.recoverOrphans();
+
             // Re-coordinate logging override after SR reseed — mode may have changed
             SessionReplayMode currentSrMode = SessionReplay.getCurrentMode();
             reconcileLoggingOverride(currentSrMode, agentConfiguration);

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -251,28 +251,32 @@ public class ApplicationExitMonitor {
 
     /**
      * Resolve the session attributes to attach to an AEI for {@code sessionMeta}'s prior
-     * session. Prefers the frozen {@link SessionManifest} recorded for that session id.
+     * session. Prefers the frozen {@link SessionManifest} recorded for that session id — the
+     * source of truth, used even if it captured no attributes.
      *
-     * <p>If no manifest exists — most notably right after an agent upgrade, where the prior
-     * session ran under a version that never persisted session context, but also if the
-     * manifest was evicted or the session died before its first harvest — fall back to the
-     * current session's attributes. This reproduces the agent's pre-NR-575950 behavior for
-     * that transitional window rather than shipping an attribute-less event; the
-     * {@code SessionContext/Missing} metric tracks how often the fallback is taken.
+     * <p>If a prior session was mapped but its manifest is absent — most notably right after an
+     * agent upgrade, where the prior session ran under a version that never persisted session
+     * context, but also if the manifest was evicted or the session died before its first
+     * harvest — fall back to the current session's attributes. This reproduces the agent's
+     * pre-NR-575950 behavior for that transitional window rather than shipping an attribute-less
+     * event, and the {@code SessionContext/Missing} metric counts that specific case (a mapped
+     * prior session with no manifest). The metric is intentionally NOT bumped when there is no
+     * prior-session mapping at all, no store configured, or an empty session id, so it stays a
+     * clean signal for "manifest missing" rather than "nothing to look up."
      */
     Set<AnalyticsAttribute> resolveSessionAttributes(AEISessionMapper.AEISessionMeta sessionMeta) {
         SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
         if (store != null && sessionMeta != null
                 && sessionMeta.sessionId != null && !sessionMeta.sessionId.isEmpty()) {
             SessionManifest manifest = store.get(sessionMeta.sessionId);
-            if (manifest != null && manifest.getAttributes() != null && !manifest.getAttributes().isEmpty()) {
-                return manifest.getAttributes();
+            if (manifest != null) {
+                Set<AnalyticsAttribute> frozen = manifest.getAttributes();
+                return frozen == null ? Collections.emptySet() : frozen;
             }
+            // Mapped a prior session but its manifest is absent — the only case that means
+            // "manifest missing." Count it here so the metric isn't diluted by the no-mapping paths.
+            StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_MISSING);
         }
-        // No frozen snapshot for the prior session (pre-upgrade agent, evicted, or
-        // pre-first-harvest death). Fall back to the current session's attributes to match
-        // pre-NR-575950 behavior for that transitional window; tracked via the metric.
-        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_MISSING);
         AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
         return analyticsController == null ? Collections.emptySet() : analyticsController.getSessionAttributes();
     }

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -17,6 +17,7 @@ import androidx.annotation.RequiresApi;
 
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.analytics.AnalyticsEvent;
 import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.logging.AgentLog;
@@ -250,11 +251,14 @@ public class ApplicationExitMonitor {
 
     /**
      * Resolve the session attributes to attach to an AEI for {@code sessionMeta}'s prior
-     * session. Prefers the frozen {@link SessionManifest} recorded for that session id. If
-     * no manifest exists (evicted, or recorded before this feature shipped), emit the AEI
-     * with NO session attributes plus a supportability metric — never stamp the current
-     * (post-restart) session's attributes, which would re-introduce the mis-attribution
-     * this fix addresses (NR-575950).
+     * session. Prefers the frozen {@link SessionManifest} recorded for that session id.
+     *
+     * <p>If no manifest exists — most notably right after an agent upgrade, where the prior
+     * session ran under a version that never persisted session context, but also if the
+     * manifest was evicted or the session died before its first harvest — fall back to the
+     * current session's attributes. This reproduces the agent's pre-NR-575950 behavior for
+     * that transitional window rather than shipping an attribute-less event; the
+     * {@code SessionContext/Missing} metric tracks how often the fallback is taken.
      */
     Set<AnalyticsAttribute> resolveSessionAttributes(AEISessionMapper.AEISessionMeta sessionMeta) {
         SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
@@ -265,8 +269,12 @@ public class ApplicationExitMonitor {
                 return manifest.getAttributes();
             }
         }
+        // No frozen snapshot for the prior session (pre-upgrade agent, evicted, or
+        // pre-first-harvest death). Fall back to the current session's attributes to match
+        // pre-NR-575950 behavior for that transitional window; tracked via the metric.
         StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_MISSING);
-        return Collections.emptySet();
+        AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
+        return analyticsController == null ? Collections.emptySet() : analyticsController.getSessionAttributes();
     }
 
     /**

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -215,6 +215,15 @@ public class ApplicationExitMonitor {
                     log.debug("ApplicationExitMonitor: Using session meta [" + sessionMeta.sessionId + ", " + sessionMeta.realAgentId + "] for AEI pid[" + exitInfo.getPid() + "]");
                 }
 
+                // Record the OS exit reason into the prior session's manifest so the next-launch
+                // Session Replay recoverer can decide whether the buffered replay is worth uploading.
+                if (sessionMeta != null && sessionMeta.sessionId != null && !sessionMeta.sessionId.isEmpty()) {
+                    SessionContextStore scStore = AgentConfiguration.getInstance().getSessionContextStore();
+                    if (scStore != null) {
+                        scStore.updateExitReason(sessionMeta.sessionId, exitInfo.getReason());
+                    }
+                }
+
                 // finally, emit an event for the record
                 final HashMap<String, Object> eventAttributes;
                 try {

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -17,12 +17,13 @@ import androidx.annotation.RequiresApi;
 
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
-import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.analytics.AnalyticsEvent;
 import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.util.Streams;
 import com.newrelic.agent.android.error.Error;
@@ -35,6 +36,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -227,8 +229,7 @@ public class ApplicationExitMonitor {
                 StatsEngine.SUPPORTABILITY.sample(MetricNames.SUPPORTABILITY_AEI_SKIPPED, recordsSkipped.get());
 //                StatsEngine.SUPPORTABILITY.sample(MetricNames.SUPPORTABILITY_AEI_DROPPED, recordsDropped.get());
 
-                final AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
-                Error error = new Error(analyticsController.getSessionAttributes(), eventAttributes, sessionMeta);
+                Error error = new Error(resolveSessionAttributes(sessionMeta), eventAttributes, sessionMeta);
 
                 traceReporter.reportAEITrace(error.asJsonObject().toString(), exitInfo.getPid());
             }
@@ -245,6 +246,27 @@ public class ApplicationExitMonitor {
             log.warn("ApplicationExitMonitor: exit info reporting was enabled, but not supported by the current OS");
             StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_AEI_UNSUPPORTED_OS + Build.VERSION.SDK_INT);
         }
+    }
+
+    /**
+     * Resolve the session attributes to attach to an AEI for {@code sessionMeta}'s prior
+     * session. Prefers the frozen {@link SessionManifest} recorded for that session id. If
+     * no manifest exists (evicted, or recorded before this feature shipped), emit the AEI
+     * with NO session attributes plus a supportability metric — never stamp the current
+     * (post-restart) session's attributes, which would re-introduce the mis-attribution
+     * this fix addresses (NR-575950).
+     */
+    Set<AnalyticsAttribute> resolveSessionAttributes(AEISessionMapper.AEISessionMeta sessionMeta) {
+        SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+        if (store != null && sessionMeta != null
+                && sessionMeta.sessionId != null && !sessionMeta.sessionId.isEmpty()) {
+            SessionManifest manifest = store.get(sessionMeta.sessionId);
+            if (manifest != null && manifest.getAttributes() != null && !manifest.getAttributes().isEmpty()) {
+                return manifest.getAttributes();
+            }
+        }
+        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_MISSING);
+        return Collections.emptySet();
     }
 
     /**

--- a/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
@@ -20,7 +20,11 @@ import com.newrelic.agent.android.harvest.HarvestAdapter;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
 import com.newrelic.agent.android.stats.StatsEngine;
+
+import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -147,9 +151,13 @@ public class NativeReporting extends HarvestAdapter {
             StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_NDK_REPORTS_CRASH);
 
             final AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
-            final Set<AnalyticsAttribute> sessionAttributes = new HashSet<AnalyticsAttribute>() {{
-                addAll(analyticsController.getSessionAttributes());
-            }};
+            // A native crash is captured in the crashing session but flushed on the next launch
+            // (after the process dies). Attribute it to the session that actually crashed — its
+            // sessionId is embedded in the native report ("backtrace.sessionid") — by resolving
+            // that session's attributes from the SessionContextStore rather than stamping the
+            // current (relaunched) session's attributes.
+            final Set<AnalyticsAttribute> sessionAttributes =
+                    new HashSet<>(resolveCrashSessionAttributes(crashAsString, analyticsController));
 
             NativeException exceptionToHandle = new NativeCrashException(crashAsString);
 
@@ -225,6 +233,43 @@ public class NativeReporting extends HarvestAdapter {
             }
 
             return false;
+        }
+
+        /**
+         * Resolve the session attributes to attach to a native crash. When the crash originated in
+         * a prior session (its {@code sessionid} differs from the current one), use that session's
+         * frozen attributes from the {@link SessionContextStore} so the crash is attributed to the
+         * session that produced it. Falls back to the current session's attributes when the origin
+         * is unknown or has no stored manifest (e.g. it crashed before its first harvest).
+         */
+        private Set<AnalyticsAttribute> resolveCrashSessionAttributes(String crashAsString,
+                                                                      AnalyticsControllerImpl controller) {
+            final String originSessionId = extractNativeSessionId(crashAsString);
+            final String currentSessionId = AgentConfiguration.getInstance().getSessionID();
+            if (originSessionId != null && !originSessionId.isEmpty()
+                    && !originSessionId.equals(currentSessionId)) {
+                final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+                final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
+                if (manifest != null) {
+                    return manifest.getAttributes();
+                }
+                log.warn("NativeReporting: no session manifest for crash origin [" + originSessionId
+                        + "]; using current session attributes");
+            }
+            return controller.getSessionAttributes();
+        }
+
+        /** @return the originating sessionId from a native crash report ({@code backtrace.sessionid}), or null. */
+        private String extractNativeSessionId(String crashAsString) {
+            try {
+                final String sessionId = new JSONObject(crashAsString)
+                        .getJSONObject("backtrace")
+                        .optString("sessionid", null);
+                return (sessionId == null || sessionId.isEmpty()) ? null : sessionId;
+            } catch (Exception e) {
+                log.warn("NativeReporting: could not read sessionid from native report: " + e);
+                return null;
+            }
         }
 
     }

--- a/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
@@ -154,10 +154,19 @@ public class NativeReporting extends HarvestAdapter {
             // A native crash is captured in the crashing session but flushed on the next launch
             // (after the process dies). Attribute it to the session that actually crashed — its
             // sessionId is embedded in the native report ("backtrace.sessionid") — by resolving
-            // that session's attributes from the SessionContextStore rather than stamping the
-            // current (relaunched) session's attributes.
-            final Set<AnalyticsAttribute> sessionAttributes =
-                    new HashSet<>(resolveCrashSessionAttributes(crashAsString, analyticsController));
+            // that session's frozen attributes from the SessionContextStore rather than stamping
+            // the current (relaunched) session's attributes.
+            final String originSessionId = extractNativeSessionId(crashAsString);
+            final boolean fromPriorSession = originSessionId != null
+                    && !originSessionId.equals(AgentConfiguration.getInstance().getSessionID());
+            final SessionManifest originManifest = fromPriorSession ? lookupSessionManifest(originSessionId) : null;
+            final Set<AnalyticsAttribute> sessionAttributes = new HashSet<>(
+                    originManifest != null ? originManifest.getAttributes()
+                            : analyticsController.getSessionAttributes());
+
+            // sessionDuration (NR-487823): Java crashes record it but NDK crashes did not. Attach
+            // the crashed session's elapsed time so MobileCrash carries sessionDuration for NDK too.
+            addCrashSessionDuration(sessionAttributes, crashAsString, fromPriorSession, originManifest);
 
             NativeException exceptionToHandle = new NativeCrashException(crashAsString);
 
@@ -236,27 +245,60 @@ public class NativeReporting extends HarvestAdapter {
         }
 
         /**
-         * Resolve the session attributes to attach to a native crash. When the crash originated in
-         * a prior session (its {@code sessionid} differs from the current one), use that session's
-         * frozen attributes from the {@link SessionContextStore} so the crash is attributed to the
-         * session that produced it. Falls back to the current session's attributes when the origin
-         * is unknown or has no stored manifest (e.g. it crashed before its first harvest).
+         * Look up the manifest of the prior session that produced a native crash. Returns null (and
+         * logs) when none is stored — e.g. the session crashed before its first harvest — in which
+         * case the caller falls back to the current session's attributes.
          */
-        private Set<AnalyticsAttribute> resolveCrashSessionAttributes(String crashAsString,
-                                                                      AnalyticsControllerImpl controller) {
-            final String originSessionId = extractNativeSessionId(crashAsString);
-            final String currentSessionId = AgentConfiguration.getInstance().getSessionID();
-            if (originSessionId != null && !originSessionId.isEmpty()
-                    && !originSessionId.equals(currentSessionId)) {
-                final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
-                final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
-                if (manifest != null) {
-                    return manifest.getAttributes();
-                }
+        private SessionManifest lookupSessionManifest(String originSessionId) {
+            final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+            final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
+            if (manifest == null) {
                 log.warn("NativeReporting: no session manifest for crash origin [" + originSessionId
                         + "]; using current session attributes");
             }
-            return controller.getSessionAttributes();
+            return manifest;
+        }
+
+        /**
+         * Attach {@code sessionDuration} (seconds) to a native crash. For a crash reported within the
+         * current session, the live session duration applies. For one recovered from a prior session,
+         * derive it from the native crash timestamp ({@code backtrace.timestamp}, epoch seconds) minus
+         * that session's start ({@link SessionManifest#getSessionStartMs()}, epoch ms). No-op when it
+         * cannot be determined (e.g. prior session with no manifest), so the crash still reports.
+         */
+        private void addCrashSessionDuration(Set<AnalyticsAttribute> sessionAttributes, String crashAsString,
+                                             boolean fromPriorSession, SessionManifest originManifest) {
+            float durationSec = -1f;
+            if (!fromPriorSession) {
+                final long ms = Harvest.getMillisSinceStart();
+                if (ms != Harvest.INVALID_SESSION_DURATION) {
+                    durationSec = ms / 1000.0f;
+                }
+            } else if (originManifest != null && originManifest.getSessionStartMs() > 0L) {
+                final long crashSec = extractNativeTimestampSec(crashAsString);
+                if (crashSec > 0L) {
+                    // Subtract as longs (ms) before converting to float seconds. Subtracting at
+                    // epoch scale (~1.7e9) in float arithmetic would lose precision — a 32-bit
+                    // float's resolution there is ~128, so short durations would round to 0.
+                    final long durationMs = (crashSec * 1000L) - originManifest.getSessionStartMs();
+                    if (durationMs >= 0L) {
+                        durationSec = durationMs / 1000.0f;
+                    }
+                }
+            }
+            if (durationSec >= 0f) {
+                sessionAttributes.add(new AnalyticsAttribute(
+                        AnalyticsAttribute.SESSION_DURATION_ATTRIBUTE, durationSec));
+            }
+        }
+
+        /** @return the crash time from a native report ({@code backtrace.timestamp}, epoch seconds), or 0. */
+        private long extractNativeTimestampSec(String crashAsString) {
+            try {
+                return new JSONObject(crashAsString).getJSONObject("backtrace").optLong("timestamp", 0L);
+            } catch (Exception e) {
+                return 0L;
+            }
         }
 
         /** @return the originating sessionId from a native crash report ({@code backtrace.sessionid}), or null. */

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
@@ -72,6 +72,7 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
     // file manager, and re-register the Harvest listener (causing onHarvest() to fire twice
     // per cycle). Cleared in deInitialize() so onSessionRestarted can re-init normally.
     private static final AtomicBoolean isInitialized = new AtomicBoolean(false);
+    private static final AtomicBoolean orphanRecoveryDone = new AtomicBoolean(false);
 
     // Buffer for queuing frames and touch data that arrive during harvest
     private static final AtomicBoolean isHarvesting = new AtomicBoolean(false);
@@ -266,20 +267,6 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
         // Initialize file manager
         instance.fileManager = new SessionReplayFileManager(processor);
         SessionReplayFileManager.initialize(application);
-
-        // Recover any Session Replay buffers orphaned by a prior abnormal termination
-        // (force-close, ANR, crash, OOM) and re-enqueue eligible ones for upload.
-        try {
-            File srDir = SessionReplayFileManager.getSessionReplayDataStore();
-            AgentConfiguration cfg = AgentConfiguration.getInstance();
-            new SessionReplayOrphanRecoverer(
-                    srDir, cfg.getSessionContextStore(),
-                    SessionReplayReporter::reportSessionReplayData, cfg.getSessionID(),
-                    cfg.getPayloadTTL())
-                    .recover();
-        } catch (Exception e) {
-            log.error("SessionReplay: orphan recovery failed: " + e);
-        }
 
         if(mode == SessionReplayMode.ERROR) {
             // Register SessionReplay as event listener using composite pattern
@@ -580,6 +567,29 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
      * Persists the Session Replay state for the current session into the session manifest so a
      * next-launch recoverer can decide whether an orphaned {@code .tmp} buffer is worth uploading.
      */
+    /**
+     * Recover Session Replay buffers orphaned by a prior abnormal termination (force-close, ANR,
+     * crash, OOM) and re-report eligible ones for upload. Runs once per launch. Must be invoked
+     * after both {@code SessionReplayReporter} is initialized and the prior session's exit reasons
+     * have been recorded into the manifests (i.e. after the AEI harvest on harvest-connect).
+     */
+    public static void recoverOrphans() {
+        if (!orphanRecoveryDone.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            File srDir = SessionReplayFileManager.getSessionReplayDataStore();
+            AgentConfiguration cfg = AgentConfiguration.getInstance();
+            new SessionReplayOrphanRecoverer(
+                    srDir, cfg.getSessionContextStore(),
+                    SessionReplayReporter::reportSessionReplayData, cfg.getSessionID(),
+                    cfg.getPayloadTTL())
+                    .recover();
+        } catch (Exception e) {
+            log.error("SessionReplay: orphan recovery failed: " + e);
+        }
+    }
+
     private static void persistSrState(boolean reachedFullMode, boolean isFirstChunkValue) {
         try {
             SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
@@ -13,6 +13,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.analytics.AnalyticsEvent;
 import com.newrelic.agent.android.analytics.EventListener;
@@ -238,6 +239,7 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
         // Clear file after successful harvest
         fileManager.clearWorkingFileWhileRunningSession();
         isFirstChunk = false;
+        persistSrState(true, false);
         takeFullSnapshot.set(true);
 
     }
@@ -302,6 +304,8 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
         // Start sliding window timer if in ERROR mode
         if (mode == SessionReplayMode.ERROR) {
             startSlidingWindowTimer();
+        } else if (mode == SessionReplayMode.FULL) {
+            persistSrState(true, true);
         }
 
         uiThreadHandler.post(() -> {
@@ -534,6 +538,7 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
                 stopSlidingWindowTimer();
                 // Force a full snapshot to ensure we have complete data from this point forward
                 setTakeFullSnapshot(true);
+                persistSrState(true, true);
                 return true;
             }
         }
@@ -552,6 +557,22 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
             log.debug("SessionReplay: Error detected but session replay not initialized");
         }
         switchModeOnError();
+    }
+
+    /**
+     * Persists the Session Replay state for the current session into the session manifest so a
+     * next-launch recoverer can decide whether an orphaned {@code .tmp} buffer is worth uploading.
+     */
+    private static void persistSrState(boolean reachedFullMode, boolean isFirstChunkValue) {
+        try {
+            SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+            if (store != null) {
+                store.updateSessionReplayState(
+                        AgentConfiguration.getInstance().getSessionID(), reachedFullMode, isFirstChunkValue);
+            }
+        } catch (Exception e) {
+            log.error("SessionReplay: failed to persist SR state: " + e);
+        }
     }
 
     /**

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
@@ -27,6 +27,9 @@ import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.sessionReplay.capture.SessionReplayFileManager;
+import com.newrelic.agent.android.sessionReplay.recovery.SessionReplayOrphanRecoverer;
+
+import java.io.File;
 import com.newrelic.agent.android.sessionReplay.capture.SessionReplayFrame;
 import com.newrelic.agent.android.sessionReplay.capture.SessionReplayProcessor;
 import com.newrelic.agent.android.sessionReplay.capture.ViewDrawInterceptor;
@@ -263,6 +266,20 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
         // Initialize file manager
         instance.fileManager = new SessionReplayFileManager(processor);
         SessionReplayFileManager.initialize(application);
+
+        // Recover any Session Replay buffers orphaned by a prior abnormal termination
+        // (force-close, ANR, crash, OOM) and re-enqueue eligible ones for upload.
+        try {
+            File srDir = SessionReplayFileManager.getSessionReplayDataStore();
+            AgentConfiguration cfg = AgentConfiguration.getInstance();
+            new SessionReplayOrphanRecoverer(
+                    application, srDir, cfg.getSessionContextStore(),
+                    cfg.getOfflineSessionReplayStore(), cfg.getSessionID(),
+                    cfg.getPayloadTTL())
+                    .recover();
+        } catch (Exception e) {
+            log.error("SessionReplay: orphan recovery failed: " + e);
+        }
 
         if(mode == SessionReplayMode.ERROR) {
             // Register SessionReplay as event listener using composite pattern

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
@@ -273,8 +273,8 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
             File srDir = SessionReplayFileManager.getSessionReplayDataStore();
             AgentConfiguration cfg = AgentConfiguration.getInstance();
             new SessionReplayOrphanRecoverer(
-                    application, srDir, cfg.getSessionContextStore(),
-                    cfg.getOfflineSessionReplayStore(), cfg.getSessionID(),
+                    srDir, cfg.getSessionContextStore(),
+                    SessionReplayReporter::reportSessionReplayData, cfg.getSessionID(),
                     cfg.getPayloadTTL())
                     .recover();
         } catch (Exception e) {

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/capture/SessionReplayFileManager.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/capture/SessionReplayFileManager.java
@@ -91,6 +91,14 @@ public class SessionReplayFileManager {
     }
 
     /**
+     * @return the directory holding session replay {@code .tmp} buffers
+     * ({@code cacheDir/newrelic/sessionReplay/} once {@link #initialize(Application)} has run).
+     */
+    public static File getSessionReplayDataStore() {
+        return sessionReplayDataStore;
+    }
+
+    /**
      * Initializes the file writer for session replay data.
      * Creates a new file and sets up the BufferedWriter.
      */

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecoverer.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecoverer.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessionReplay.recovery;
+
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+import android.os.Build;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+import com.newrelic.agent.android.logging.AgentLog;
+import com.newrelic.agent.android.logging.AgentLogManager;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayPayload;
+import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayStore;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
+import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.Constants;
+import com.newrelic.agent.android.util.Streams;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Scans for Session Replay {@code .tmp} files left behind by a prior session that died
+ * abnormally, and (when eligible) re-enqueues their events to the offline store so the
+ * existing drain uploads them. Runs once at SR init on the next launch.
+ */
+public class SessionReplayOrphanRecoverer {
+    private static final AgentLog log = AgentLogManager.getAgentLog();
+
+    private final Context context;
+    private final File srDir;
+    private final SessionContextStore contextStore;
+    private final OfflineSessionReplayStore offlineStore;
+    private final String currentSessionId;
+    private final long payloadTtlMs;
+
+    public SessionReplayOrphanRecoverer(Context context, File srDir, SessionContextStore contextStore,
+                                        OfflineSessionReplayStore offlineStore, String currentSessionId,
+                                        long payloadTtlMs) {
+        this.context = context;
+        this.srDir = srDir;
+        this.contextStore = contextStore;
+        this.offlineStore = offlineStore;
+        this.currentSessionId = currentSessionId == null ? "" : currentSessionId;
+        this.payloadTtlMs = payloadTtlMs;
+    }
+
+    /** Reasons whose buffered replay we want to upload. */
+    private static boolean isAbnormal(Integer reason) {
+        if (reason == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return false;
+        }
+        switch (reason) {
+            case ApplicationExitInfo.REASON_ANR:
+            case ApplicationExitInfo.REASON_CRASH:
+            case ApplicationExitInfo.REASON_CRASH_NATIVE:
+            case ApplicationExitInfo.REASON_LOW_MEMORY:
+            case ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public void recover() {
+        if (srDir == null || !srDir.isDirectory() || offlineStore == null) {
+            return;
+        }
+        File[] files = srDir.listFiles((d, name) -> name.endsWith(".tmp"));
+        if (files == null) {
+            return;
+        }
+        for (File file : files) {
+            try {
+                recoverOne(file);
+            } catch (Exception e) {
+                log.error("SessionReplayOrphanRecoverer: error on [" + file.getName() + "]: " + e);
+            }
+        }
+    }
+
+    private void recoverOne(File file) {
+        String sessionId = sessionIdFromFileName(file.getName());
+        if (sessionId == null || sessionId.isEmpty() || sessionId.equals(currentSessionId)) {
+            return; // not an orphan
+        }
+
+        // Read events; derive timestamps.
+        JsonArray events = new JsonArray();
+        long[] bounds = {0L, 0L}; // first, last
+        if (!readEvents(file, events, bounds) || events.isEmpty()) {
+            delete(file);
+            return;
+        }
+
+        SessionManifest manifest = contextStore.get(sessionId);
+        Integer exitReason = manifest != null ? manifest.getExitReason() : null;
+        boolean reachedFull = manifest != null && Boolean.TRUE.equals(manifest.getReachedFullMode());
+
+        boolean eligible = isAbnormal(exitReason) || reachedFull;
+        if (!eligible) {
+            // Could be a clean ERROR-mode buffer, or the exit reason isn't recorded yet.
+            // Drop only if stale; otherwise retain for re-evaluation on a later launch.
+            if (isStale(file)) {
+                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_SESSION_REPLAY_RECOVER_STALE);
+                delete(file);
+            }
+            return;
+        }
+
+        boolean isFirstChunk = manifest == null || manifest.getIsFirstChunk() == null
+                || Boolean.TRUE.equals(manifest.getIsFirstChunk());
+
+        Map<String, String> attrs = buildRecoveredAttributes(manifest, sessionId, bounds, isFirstChunk);
+        byte[] gzipped = gzip(events.toString().getBytes());
+        long ts = file.lastModified();
+        offlineStore.store(new OfflineSessionReplayPayload(
+                UUID.randomUUID().toString(), ts, ts, attrs, gzipped));
+        StatsEngine.get().inc(MetricNames.SUPPORTABILITY_SESSION_REPLAY_RECOVERED);
+        delete(file);
+    }
+
+    private Map<String, String> buildRecoveredAttributes(SessionManifest manifest, String sessionId,
+                                                         long[] bounds, boolean isFirstChunk) {
+        AgentConfiguration cfg = AgentConfiguration.getInstance();
+        Map<String, String> attrs = new LinkedHashMap<>();
+        attrs.put(Constants.SessionReplay.ENTITY_GUID, cfg.getEntityGuid());
+        attrs.put(Constants.SessionReplay.SESSION_ID, sessionId);
+        attrs.put(Constants.SessionReplay.IS_FIRST_CHUNK, String.valueOf(isFirstChunk));
+        attrs.put(Constants.SessionReplay.HAS_META, "true");
+        attrs.put(Constants.SessionReplay.REPLAY_FIRST_TIMESTAMP, String.valueOf(bounds[0]));
+        attrs.put(Constants.SessionReplay.REPLAY_LAST_TIMESTAMP, String.valueOf(bounds[1]));
+        attrs.put(Constants.SessionReplay.RECOVERED, "true");
+        // Prior session's frozen attributes (minimal if none were captured before death).
+        Set<AnalyticsAttribute> sessionAttrs = manifest != null ? manifest.getAttributes() : new HashSet<>();
+        for (AnalyticsAttribute a : sessionAttrs) {
+            if (a.asJsonElement() != null) {
+                attrs.put(a.getName(), a.asJsonElement().getAsString());
+            }
+        }
+        return attrs;
+    }
+
+    private boolean readEvents(File file, JsonArray out, long[] bounds) {
+        Gson gson = new Gson();
+        try (BufferedReader reader = Streams.newBufferedFileReader(file)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty()) continue;
+                JsonObject frame = gson.fromJson(line, JsonObject.class);
+                if (frame.has("timestamp")) {
+                    long t = frame.get("timestamp").getAsLong();
+                    if (bounds[0] == 0L || t < bounds[0]) bounds[0] = t;
+                    if (t > bounds[1]) bounds[1] = t;
+                }
+                out.add(frame);
+            }
+            return true;
+        } catch (Exception e) {
+            log.error("SessionReplayOrphanRecoverer: corrupt orphan [" + file.getName() + "]: " + e);
+            StatsEngine.get().inc(MetricNames.SUPPORTABILITY_SESSION_REPLAY_RECOVER_CORRUPT);
+            delete(file);
+            return false;
+        }
+    }
+
+    private boolean isStale(File file) {
+        return payloadTtlMs > 0 && (System.currentTimeMillis() - file.lastModified()) > payloadTtlMs;
+    }
+
+    private void delete(File file) {
+        if (file.exists() && !file.delete()) {
+            log.debug("SessionReplayOrphanRecoverer: failed to delete [" + file.getName() + "]");
+        }
+    }
+
+    private static String sessionIdFromFileName(String name) {
+        // SESSION_REPLAY_FILE_MASK = "sessionReplaydata%s.%s" → prefix "sessionReplaydata", ext ".tmp"
+        final String prefix = String.format(Locale.US, Constants.SessionReplay.SESSION_REPLAY_FILE_MASK, "", "")
+                .replace(".", ""); // "sessionReplaydata"
+        if (name.startsWith(prefix) && name.endsWith(".tmp")) {
+            return name.substring(prefix.length(), name.length() - ".tmp".length());
+        }
+        return null;
+    }
+
+    private static byte[] gzip(byte[] data) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            try (GZIPOutputStream gz = new GZIPOutputStream(bos)) {
+                gz.write(data);
+            }
+            return bos.toByteArray();
+        } catch (Exception e) {
+            return data;
+        }
+    }
+}

--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecoverer.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecoverer.java
@@ -5,19 +5,14 @@
 package com.newrelic.agent.android.sessionReplay.recovery;
 
 import android.app.ApplicationExitInfo;
-import android.content.Context;
 import android.os.Build;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.newrelic.agent.android.AgentConfiguration;
-import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.metric.MetricNames;
-import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayPayload;
-import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayStore;
 import com.newrelic.agent.android.sessioncontext.SessionContextStore;
 import com.newrelic.agent.android.sessioncontext.SessionManifest;
 import com.newrelic.agent.android.stats.StatsEngine;
@@ -25,38 +20,42 @@ import com.newrelic.agent.android.util.Constants;
 import com.newrelic.agent.android.util.Streams;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * Scans for Session Replay {@code .tmp} files left behind by a prior session that died
- * abnormally, and (when eligible) re-enqueues their events to the offline store so the
- * existing drain uploads them. Runs once at SR init on the next launch.
+ * abnormally, and (when eligible) re-reports their events through the normal Session Replay
+ * upload path so they are uploaded on the next launch. Runs once at SR init.
+ *
+ * <p>Recovered data is uploaded directly (not via the offline store) so it is sent regardless
+ * of whether the {@code OfflineStorage} feature flag is enabled. Reporting is fire-and-forget:
+ * an orphan is removed as soon as its events are submitted. The dead session's {@code sessionId}
+ * is preserved so the replay is attributed to the session that actually produced it.
  */
 public class SessionReplayOrphanRecoverer {
     private static final AgentLog log = AgentLogManager.getAgentLog();
 
-    private final Context context;
+    /** Sink for recovered replay bytes — defaults to {@code SessionReplayReporter::reportSessionReplayData}. */
+    public interface ReplayUploader {
+        /** @return true if the payload was submitted (reporter ready), false otherwise. */
+        boolean upload(byte[] rawEventBytes, Map<String, Object> attributes);
+    }
+
     private final File srDir;
     private final SessionContextStore contextStore;
-    private final OfflineSessionReplayStore offlineStore;
+    private final ReplayUploader uploader;
     private final String currentSessionId;
     private final long payloadTtlMs;
 
-    public SessionReplayOrphanRecoverer(Context context, File srDir, SessionContextStore contextStore,
-                                        OfflineSessionReplayStore offlineStore, String currentSessionId,
+    public SessionReplayOrphanRecoverer(File srDir, SessionContextStore contextStore,
+                                        ReplayUploader uploader, String currentSessionId,
                                         long payloadTtlMs) {
-        this.context = context;
         this.srDir = srDir;
         this.contextStore = contextStore;
-        this.offlineStore = offlineStore;
+        this.uploader = uploader;
         this.currentSessionId = currentSessionId == null ? "" : currentSessionId;
         this.payloadTtlMs = payloadTtlMs;
     }
@@ -79,7 +78,7 @@ public class SessionReplayOrphanRecoverer {
     }
 
     public void recover() {
-        if (srDir == null || !srDir.isDirectory() || offlineStore == null) {
+        if (srDir == null || !srDir.isDirectory() || uploader == null) {
             return;
         }
         File[] files = srDir.listFiles((d, name) -> name.endsWith(".tmp"));
@@ -127,33 +126,30 @@ public class SessionReplayOrphanRecoverer {
         boolean isFirstChunk = manifest == null || manifest.getIsFirstChunk() == null
                 || Boolean.TRUE.equals(manifest.getIsFirstChunk());
 
-        Map<String, String> attrs = buildRecoveredAttributes(manifest, sessionId, bounds, isFirstChunk);
-        byte[] gzipped = gzip(events.toString().getBytes());
-        long ts = file.lastModified();
-        offlineStore.store(new OfflineSessionReplayPayload(
-                UUID.randomUUID().toString(), ts, ts, attrs, gzipped));
-        StatsEngine.get().inc(MetricNames.SUPPORTABILITY_SESSION_REPLAY_RECOVERED);
-        delete(file);
+        Map<String, Object> attrs = buildRecoveredAttributes(sessionId, bounds, isFirstChunk);
+
+        // Fire-and-forget direct report (not OfflineStorage-gated). Submitted → orphan removed;
+        // when OfflineStorage is enabled the reporter itself re-caches on a failed send.
+        boolean submitted = uploader.upload(events.toString().getBytes(), attrs);
+        if (submitted) {
+            StatsEngine.get().inc(MetricNames.SUPPORTABILITY_SESSION_REPLAY_RECOVERED);
+            delete(file);
+        } else {
+            // Reporter not ready yet — keep the orphan so a later launch can retry.
+            log.debug("SessionReplayOrphanRecoverer: reporter not ready, retaining [" + file.getName() + "]");
+        }
     }
 
-    private Map<String, String> buildRecoveredAttributes(SessionManifest manifest, String sessionId,
-                                                         long[] bounds, boolean isFirstChunk) {
-        AgentConfiguration cfg = AgentConfiguration.getInstance();
-        Map<String, String> attrs = new LinkedHashMap<>();
-        attrs.put(Constants.SessionReplay.ENTITY_GUID, cfg.getEntityGuid());
-        attrs.put(Constants.SessionReplay.SESSION_ID, sessionId);
-        attrs.put(Constants.SessionReplay.IS_FIRST_CHUNK, String.valueOf(isFirstChunk));
+    private Map<String, Object> buildRecoveredAttributes(String sessionId, long[] bounds, boolean isFirstChunk) {
+        Map<String, Object> attrs = new LinkedHashMap<>();
+        // Keys consumed by SessionReplaySender: timestamps, first-chunk, has-meta, and the
+        // prior session's id (sender overrides sessionId from this map) so the replay is
+        // attributed to the dead session rather than the current one.
+        attrs.put(Constants.SessionReplay.FIRST_TIMESTAMP, bounds[0]);
+        attrs.put(Constants.SessionReplay.LAST_TIMESTAMP, bounds[1]);
+        attrs.put(Constants.SessionReplay.IS_FIRST_CHUNK, isFirstChunk);
         attrs.put(Constants.SessionReplay.HAS_META, "true");
-        attrs.put(Constants.SessionReplay.REPLAY_FIRST_TIMESTAMP, String.valueOf(bounds[0]));
-        attrs.put(Constants.SessionReplay.REPLAY_LAST_TIMESTAMP, String.valueOf(bounds[1]));
-        attrs.put(Constants.SessionReplay.RECOVERED, "true");
-        // Prior session's frozen attributes (minimal if none were captured before death).
-        Set<AnalyticsAttribute> sessionAttrs = manifest != null ? manifest.getAttributes() : new HashSet<>();
-        for (AnalyticsAttribute a : sessionAttrs) {
-            if (a.asJsonElement() != null) {
-                attrs.put(a.getName(), a.asJsonElement().getAsString());
-            }
-        }
+        attrs.put(Constants.SessionReplay.SESSION_ID, sessionId);
         return attrs;
     }
 
@@ -198,17 +194,5 @@ public class SessionReplayOrphanRecoverer {
             return name.substring(prefix.length(), name.length() - ".tmp".length());
         }
         return null;
-    }
-
-    private static byte[] gzip(byte[] data) {
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            try (GZIPOutputStream gz = new GZIPOutputStream(bos)) {
-                gz.write(data);
-            }
-            return bos.toByteArray();
-        } catch (Exception e) {
-            return data;
-        }
     }
 }

--- a/agent/src/main/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStore.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStore.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonParser;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.AbstractFileStore;
+import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.util.Streams;
 
 import java.io.File;
@@ -60,7 +61,13 @@ public class FileSessionContextStore extends AbstractFileStore<SessionManifest> 
             final String json = Streams.slurpString(target, StandardCharsets.UTF_8.name());
             return deserialize(sessionId, json);
         } catch (Exception e) {
-            log.debug("FileSessionContextStore.get: cannot read [" + sessionId + "]: " + e);
+            // Corrupt/unreadable entry: delete it and count, mirroring fetchAllInternal() so a
+            // bad dead-session file can't silently yield empty attributes on every AEI lookup.
+            log.debug("FileSessionContextStore.get: corrupt entry [" + sessionId + "], deleting: " + e);
+            if (!target.delete()) {
+                log.debug("FileSessionContextStore.get: failed to delete corrupt entry [" + sessionId + "]");
+            }
+            StatsEngine.get().inc(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_CORRUPTED);
             return null;
         }
     }

--- a/agent/src/main/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStore.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStore.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessioncontext;
+
+import android.content.Context;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.payload.AbstractFileStore;
+import com.newrelic.agent.android.util.Streams;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * File-backed {@link SessionContextStore}. Stores one JSON file per session under
+ * {@code filesDir/nr_session_context_cache/}, named by the (sanitized) {@code sessionId}.
+ */
+public class FileSessionContextStore extends AbstractFileStore<SessionManifest> implements SessionContextStore {
+
+    public static final String DIR_NAME = "nr_session_context_cache";
+
+    public FileSessionContextStore(Context context, AgentConfiguration config) {
+        super(context, DIR_NAME, resolveCap(config),
+                MetricNames.SUPPORTABILITY_SESSION_CONTEXT_EVICTED,
+                MetricNames.SUPPORTABILITY_SESSION_CONTEXT_CORRUPTED,
+                "FileSessionContextStore");
+    }
+
+    private static int resolveCap(AgentConfiguration config) {
+        final int configured = config.getMaxCachedSessionContextCount();
+        return configured > 0 ? configured : AgentConfiguration.DEFAULT_MAX_CACHED_SESSION_CONTEXT_COUNT;
+    }
+
+    @Override
+    public boolean upsert(SessionManifest manifest) {
+        if (manifest == null || !manifest.isValid()) {
+            log.warn("FileSessionContextStore.upsert: null or invalid manifest");
+            return false;
+        }
+        return storeInternal(manifest);
+    }
+
+    @Override
+    public SessionManifest get(String sessionId) {
+        if (sessionId == null || sessionId.isEmpty()) {
+            return null;
+        }
+        final File target = new File(dir, safeFilename(sessionId) + FILE_SUFFIX);
+        if (!target.exists()) {
+            return null;
+        }
+        try {
+            final String json = Streams.slurpString(target, StandardCharsets.UTF_8.name());
+            return deserialize(sessionId, json);
+        } catch (Exception e) {
+            log.debug("FileSessionContextStore.get: cannot read [" + sessionId + "]: " + e);
+            return null;
+        }
+    }
+
+    @Override
+    public List<SessionManifest> fetchAll() {
+        return fetchAllInternal();
+    }
+
+    @Override
+    public void delete(String sessionId) {
+        deleteInternal(sessionId);
+    }
+
+    @Override
+    public int count() {
+        return countInternal();
+    }
+
+    @Override
+    public void clear() {
+        clearInternal();
+    }
+
+    @Override
+    protected String keyOf(SessionManifest entry) {
+        return entry.getSessionId();
+    }
+
+    @Override
+    protected String serialize(SessionManifest entry) {
+        return entry.toJson().toString();
+    }
+
+    @Override
+    protected SessionManifest deserialize(String keyFromFile, String json) throws IOException {
+        final JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+        if (root == null || !root.has(SessionManifest.KEY_SESSION_ID)) {
+            throw new IOException("missing sessionId field");
+        }
+        return SessionManifest.fromJson(root);
+    }
+}

--- a/agent/src/main/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStore.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStore.java
@@ -40,12 +40,53 @@ public class FileSessionContextStore extends AbstractFileStore<SessionManifest> 
     }
 
     @Override
-    public boolean upsert(SessionManifest manifest) {
+    public synchronized boolean upsert(SessionManifest manifest) {
         if (manifest == null || !manifest.isValid()) {
             log.warn("FileSessionContextStore.upsert: null or invalid manifest");
             return false;
         }
-        return storeInternal(manifest);
+        SessionManifest existing = get(manifest.getSessionId());
+        SessionManifest merged = (existing == null) ? manifest : new SessionManifest(
+                SessionManifest.CURRENT_SCHEMA_VERSION,
+                manifest.getSessionId(), manifest.getRealAgentId(),
+                manifest.getSessionStartMs(), manifest.getLastUpdateMs(),
+                manifest.getAttributes(),
+                manifest.getReachedFullMode() != null ? manifest.getReachedFullMode() : existing.getReachedFullMode(),
+                manifest.getIsFirstChunk() != null ? manifest.getIsFirstChunk() : existing.getIsFirstChunk(),
+                manifest.getExitReason() != null ? manifest.getExitReason() : existing.getExitReason());
+        return storeInternal(merged);
+    }
+
+    @Override
+    public synchronized void updateSessionReplayState(String sessionId, boolean reachedFullMode, boolean isFirstChunk) {
+        if (sessionId == null || sessionId.isEmpty()) {
+            return;
+        }
+        SessionManifest existing = get(sessionId);
+        long now = existing != null ? existing.getLastUpdateMs() : 0L;
+        SessionManifest merged = new SessionManifest(
+                SessionManifest.CURRENT_SCHEMA_VERSION, sessionId,
+                existing != null ? existing.getRealAgentId() : 0,
+                existing != null ? existing.getSessionStartMs() : 0L, now,
+                existing != null ? existing.getAttributes() : null,
+                reachedFullMode, isFirstChunk,
+                existing != null ? existing.getExitReason() : null);
+        storeInternal(merged);
+    }
+
+    @Override
+    public synchronized void updateExitReason(String sessionId, int exitReason) {
+        if (sessionId == null || sessionId.isEmpty()) {
+            return;
+        }
+        SessionManifest existing = get(sessionId);
+        if (existing == null) {
+            return; // No record to attach an exit reason to.
+        }
+        storeInternal(new SessionManifest(
+                SessionManifest.CURRENT_SCHEMA_VERSION, sessionId, existing.getRealAgentId(),
+                existing.getSessionStartMs(), existing.getLastUpdateMs(), existing.getAttributes(),
+                existing.getReachedFullMode(), existing.getIsFirstChunk(), Integer.valueOf(exitReason)));
     }
 
     @Override

--- a/agent/src/main/java/com/newrelic/agent/android/stores/FileEventStore.java
+++ b/agent/src/main/java/com/newrelic/agent/android/stores/FileEventStore.java
@@ -13,17 +13,33 @@ import com.newrelic.agent.android.analytics.AnalyticsEventStore;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.AbstractFileStore;
 import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.NamedThreadFactory;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * File-backed analytics event store. Stores one JSON file per event under
  * {@code filesDir/nr_event_cache/}. Filename is the event UUID; body is
  * {@code event.asJsonObject().toString()}. The UUID is recovered from the filename
  * on deserialize.
+ *
+ * <p>Writes ({@link #store}/{@link #delete}) are performed on a dedicated single-thread
+ * executor so the recording hot path (often the main thread, e.g.
+ * {@code NewRelic.recordBreadcrumb}) never blocks on disk I/O. Because both run on the
+ * same single thread, a write and the harvest-time delete of the same event stay
+ * FIFO-ordered — a write can never land after its delete and resurrect the event. Reads
+ * ({@link #fetchAll}/{@link #count}) remain synchronous; {@code fetchAll} runs at startup
+ * before any writes are queued. Callers that mutate an event around {@code store()} must
+ * pass an immutable snapshot (e.g. a clone) since serialization happens on the executor.
  */
 public class FileEventStore extends AbstractFileStore<AnalyticsEvent> implements AnalyticsEventStore {
     public static final String DIR_NAME = "nr_event_cache";
+
+    private final ExecutorService writeExecutor =
+            Executors.newSingleThreadExecutor(new NamedThreadFactory("EventStoreWriter"));
 
     public FileEventStore(Context context, AgentConfiguration config) {
         super(context, DIR_NAME, resolveCap(config),
@@ -38,13 +54,19 @@ public class FileEventStore extends AbstractFileStore<AnalyticsEvent> implements
     }
 
     @Override
-    public boolean store(AnalyticsEvent event) {
+    public boolean store(final AnalyticsEvent event) {
         if (event == null) {
             return false;
         }
-        final String eventJson = serialize(event);
-        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_EVENT_SIZE_UNCOMPRESSED, eventJson.length());
-        return storeInternal(event);
+        writeExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final String eventJson = serialize(event);
+                StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_EVENT_SIZE_UNCOMPRESSED, eventJson.length());
+                storeInternal(event);
+            }
+        });
+        return true;
     }
 
     @Override
@@ -58,16 +80,40 @@ public class FileEventStore extends AbstractFileStore<AnalyticsEvent> implements
     }
 
     @Override
-    public void delete(AnalyticsEvent event) {
+    public void delete(final AnalyticsEvent event) {
         if (event == null) {
             return;
         }
-        deleteInternal(event.getEventUUID());
+        writeExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                deleteInternal(event.getEventUUID());
+            }
+        });
     }
 
     @Override
     public void clear() {
         clearInternal();
+    }
+
+    /**
+     * Block until queued writes/deletes have drained. For graceful shutdown and tests that
+     * assert on-disk state synchronously after {@link #store}/{@link #delete}.
+     *
+     * @return true if the queue drained within {@code timeoutMs}
+     */
+    public boolean awaitWrites(long timeoutMs) {
+        try {
+            writeExecutor.submit(new Runnable() {
+                @Override
+                public void run() {
+                }
+            }).get(timeoutMs, TimeUnit.MILLISECONDS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @Override

--- a/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
@@ -37,6 +37,9 @@ import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.logging.ConsoleAgentLog;
 import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.sessioncontext.FileSessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.test.stub.StubAnalyticsAttributeStore;
 import com.newrelic.agent.android.util.Streams;
@@ -61,6 +64,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -479,6 +483,46 @@ public class ApplicationExitMonitorTest {
 
     }
 
+
+    @Test
+    public void resolveSessionAttributesUsesManifestWhenPresent() {
+        SessionContextStore store = new FileSessionContextStore(spyContext.getContext(), new AgentConfiguration());
+        AgentConfiguration.getInstance().setSessionContextStore(store);
+        try {
+            HashSet<AnalyticsAttribute> frozen = new HashSet<>();
+            frozen.add(new AnalyticsAttribute("checkout_step", "review"));
+            store.upsert(new SessionManifest("S_PRIOR", 1234, 0L, 1L, frozen));
+
+            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_PRIOR", 1234);
+            Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(meta);
+
+            Assert.assertEquals(1, resolved.size());
+            AnalyticsAttribute attr = resolved.iterator().next();
+            Assert.assertEquals("checkout_step", attr.getName());
+            Assert.assertEquals("review", attr.getStringValue());
+        } finally {
+            store.clear();
+            AgentConfiguration.getInstance().setSessionContextStore(null);
+        }
+    }
+
+    @Test
+    public void resolveSessionAttributesIsEmptyAndCountsWhenManifestMissing() {
+        SessionContextStore store = new FileSessionContextStore(spyContext.getContext(), new AgentConfiguration());
+        AgentConfiguration.getInstance().setSessionContextStore(store);
+        StatsEngine.SUPPORTABILITY.getStatsMap().clear();
+        try {
+            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_UNKNOWN", 1234);
+            Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(meta);
+
+            Assert.assertTrue(resolved.isEmpty());
+            Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap()
+                    .containsKey(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_MISSING));
+        } finally {
+            store.clear();
+            AgentConfiguration.getInstance().setSessionContextStore(null);
+        }
+    }
 
     static AtomicInteger pidCtr = new AtomicInteger(5000);
 

--- a/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
@@ -526,6 +526,25 @@ public class ApplicationExitMonitorTest {
         }
     }
 
+    @Test
+    public void resolveSessionAttributesDoesNotCountMissingWhenNoPriorMapping() {
+        SessionContextStore store = new FileSessionContextStore(spyContext.getContext(), new AgentConfiguration());
+        AgentConfiguration.getInstance().setSessionContextStore(store);
+        StatsEngine.SUPPORTABILITY.getStatsMap().clear();
+        try {
+            // No prior-session mapping at all → not a "manifest missing" case, so the metric
+            // must NOT be bumped; we still fall back to the current session's attributes.
+            Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(null);
+
+            Assert.assertEquals(AnalyticsControllerImpl.getInstance().getSessionAttributes(), resolved);
+            Assert.assertFalse(StatsEngine.SUPPORTABILITY.getStatsMap()
+                    .containsKey(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_MISSING));
+        } finally {
+            store.clear();
+            AgentConfiguration.getInstance().setSessionContextStore(null);
+        }
+    }
+
     static AtomicInteger pidCtr = new AtomicInteger(5000);
 
     void resetMocks() {

--- a/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
@@ -507,7 +507,7 @@ public class ApplicationExitMonitorTest {
     }
 
     @Test
-    public void resolveSessionAttributesIsEmptyAndCountsWhenManifestMissing() {
+    public void resolveSessionAttributesFallsBackToCurrentWhenManifestMissing() {
         SessionContextStore store = new FileSessionContextStore(spyContext.getContext(), new AgentConfiguration());
         AgentConfiguration.getInstance().setSessionContextStore(store);
         StatsEngine.SUPPORTABILITY.getStatsMap().clear();
@@ -515,7 +515,9 @@ public class ApplicationExitMonitorTest {
             AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_UNKNOWN", 1234);
             Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(meta);
 
-            Assert.assertTrue(resolved.isEmpty());
+            // No manifest (e.g. prior session ran under a pre-upgrade agent) → transitional
+            // fallback to the current session's attributes, plus the Missing metric.
+            Assert.assertEquals(AnalyticsControllerImpl.getInstance().getSessionAttributes(), resolved);
             Assert.assertTrue(StatsEngine.SUPPORTABILITY.getStatsMap()
                     .containsKey(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_MISSING));
         } finally {

--- a/agent/src/test/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecovererTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecovererTest.java
@@ -71,7 +71,6 @@ public class SessionReplayOrphanRecovererTest {
 
         Assert.assertEquals(1, uploader.uploads.size());
         Map<String, Object> attrs = uploader.uploads.get(0);
-        Assert.assertEquals("true", attrs.get("recovered"));
         // Replay must be attributed to the dead session, not the current one.
         Assert.assertEquals("S_DEAD", attrs.get("sessionId"));
         Assert.assertFalse(new File(srDir, "sessionReplaydataS_DEAD.tmp").exists());

--- a/agent/src/test/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecovererTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecovererTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessionReplay.recovery;
+
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.SpyContext;
+import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayPayload;
+import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayStore;
+import com.newrelic.agent.android.sessioncontext.FileSessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+public class SessionReplayOrphanRecovererTest {
+
+    static class InMemoryOfflineStore implements OfflineSessionReplayStore {
+        final List<OfflineSessionReplayPayload> items = new ArrayList<>();
+        @Override public boolean store(OfflineSessionReplayPayload d) { items.add(d); return true; }
+        @Override public List<OfflineSessionReplayPayload> fetchAll() { return new ArrayList<>(items); }
+        @Override public int count() { return items.size(); }
+        @Override public void clear() { items.clear(); }
+        @Override public void delete(OfflineSessionReplayPayload d) { items.remove(d); }
+    }
+
+    private Context context;
+    private File srDir;
+    private SessionContextStore ctxStore;
+    private InMemoryOfflineStore offlineStore;
+
+    private File writeOrphan(String sessionId) throws Exception {
+        File f = new File(srDir, "sessionReplaydata" + sessionId + ".tmp");
+        try (FileWriter w = new FileWriter(f)) {
+            w.write("{\"type\":2,\"timestamp\":1000}\n{\"type\":3,\"timestamp\":2000}\n");
+        }
+        return f;
+    }
+
+    @Before
+    public void setUp() {
+        context = new SpyContext().getContext();
+        srDir = new File(context.getCacheDir(), "newrelic/sessionReplay/");
+        srDir.mkdirs();
+        ctxStore = new FileSessionContextStore(context, new AgentConfiguration());
+        offlineStore = new InMemoryOfflineStore();
+        AgentConfiguration.getInstance().setSessionContextStore(ctxStore);
+        AgentConfiguration.getInstance().setOfflineSessionReplayStore(offlineStore);
+    }
+
+    @Test
+    public void recoversAbnormalExitOrphan() throws Exception {
+        writeOrphan("S_DEAD");
+        ctxStore.updateExitReason("S_DEAD", ApplicationExitInfo.REASON_ANR);
+
+        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+                .recover();
+
+        Assert.assertEquals(1, offlineStore.count());
+        Assert.assertEquals("true",
+                offlineStore.fetchAll().get(0).getAttributes().get("recovered"));
+        Assert.assertFalse(new File(srDir, "sessionReplaydataS_DEAD.tmp").exists());
+    }
+
+    @Test
+    public void recoversReachedFullModeOrphan() throws Exception {
+        writeOrphan("S_FULL");
+        ctxStore.updateSessionReplayState("S_FULL", true, true);
+
+        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+                .recover();
+
+        Assert.assertEquals(1, offlineStore.count());
+    }
+
+    @Test
+    public void retainsIneligibleCleanOrphan() throws Exception {
+        writeOrphan("S_CLEAN"); // no exit reason, never reached full
+
+        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+                .recover();
+
+        Assert.assertEquals(0, offlineStore.count());
+        Assert.assertTrue("ineligible orphan is retained for re-evaluation, not deleted",
+                new File(srDir, "sessionReplaydataS_CLEAN.tmp").exists());
+    }
+
+    @Test
+    public void skipsCurrentSession() throws Exception {
+        writeOrphan("S_CURRENT");
+        ctxStore.updateExitReason("S_CURRENT", ApplicationExitInfo.REASON_ANR);
+
+        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+                .recover();
+
+        Assert.assertEquals(0, offlineStore.count());
+    }
+}

--- a/agent/src/test/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecovererTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessionReplay/recovery/SessionReplayOrphanRecovererTest.java
@@ -9,8 +9,6 @@ import android.content.Context;
 
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.SpyContext;
-import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayPayload;
-import com.newrelic.agent.android.sessionReplay.OfflineSessionReplayStore;
 import com.newrelic.agent.android.sessioncontext.FileSessionContextStore;
 import com.newrelic.agent.android.sessioncontext.SessionContextStore;
 
@@ -24,23 +22,27 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RunWith(RobolectricTestRunner.class)
 public class SessionReplayOrphanRecovererTest {
 
-    static class InMemoryOfflineStore implements OfflineSessionReplayStore {
-        final List<OfflineSessionReplayPayload> items = new ArrayList<>();
-        @Override public boolean store(OfflineSessionReplayPayload d) { items.add(d); return true; }
-        @Override public List<OfflineSessionReplayPayload> fetchAll() { return new ArrayList<>(items); }
-        @Override public int count() { return items.size(); }
-        @Override public void clear() { items.clear(); }
-        @Override public void delete(OfflineSessionReplayPayload d) { items.remove(d); }
+    /** Capturing uploader that records each recovered payload's attributes. */
+    static class CapturingUploader implements SessionReplayOrphanRecoverer.ReplayUploader {
+        final List<Map<String, Object>> uploads = new ArrayList<>();
+        boolean result = true;
+
+        @Override
+        public boolean upload(byte[] rawEventBytes, Map<String, Object> attributes) {
+            uploads.add(attributes);
+            return result;
+        }
     }
 
     private Context context;
     private File srDir;
     private SessionContextStore ctxStore;
-    private InMemoryOfflineStore offlineStore;
+    private CapturingUploader uploader;
 
     private File writeOrphan(String sessionId) throws Exception {
         File f = new File(srDir, "sessionReplaydata" + sessionId + ".tmp");
@@ -56,9 +58,7 @@ public class SessionReplayOrphanRecovererTest {
         srDir = new File(context.getCacheDir(), "newrelic/sessionReplay/");
         srDir.mkdirs();
         ctxStore = new FileSessionContextStore(context, new AgentConfiguration());
-        offlineStore = new InMemoryOfflineStore();
-        AgentConfiguration.getInstance().setSessionContextStore(ctxStore);
-        AgentConfiguration.getInstance().setOfflineSessionReplayStore(offlineStore);
+        uploader = new CapturingUploader();
     }
 
     @Test
@@ -66,12 +66,14 @@ public class SessionReplayOrphanRecovererTest {
         writeOrphan("S_DEAD");
         ctxStore.updateExitReason("S_DEAD", ApplicationExitInfo.REASON_ANR);
 
-        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+        new SessionReplayOrphanRecoverer(srDir, ctxStore, uploader, "S_CURRENT", 86_400_000L)
                 .recover();
 
-        Assert.assertEquals(1, offlineStore.count());
-        Assert.assertEquals("true",
-                offlineStore.fetchAll().get(0).getAttributes().get("recovered"));
+        Assert.assertEquals(1, uploader.uploads.size());
+        Map<String, Object> attrs = uploader.uploads.get(0);
+        Assert.assertEquals("true", attrs.get("recovered"));
+        // Replay must be attributed to the dead session, not the current one.
+        Assert.assertEquals("S_DEAD", attrs.get("sessionId"));
         Assert.assertFalse(new File(srDir, "sessionReplaydataS_DEAD.tmp").exists());
     }
 
@@ -80,20 +82,20 @@ public class SessionReplayOrphanRecovererTest {
         writeOrphan("S_FULL");
         ctxStore.updateSessionReplayState("S_FULL", true, true);
 
-        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+        new SessionReplayOrphanRecoverer(srDir, ctxStore, uploader, "S_CURRENT", 86_400_000L)
                 .recover();
 
-        Assert.assertEquals(1, offlineStore.count());
+        Assert.assertEquals(1, uploader.uploads.size());
     }
 
     @Test
     public void retainsIneligibleCleanOrphan() throws Exception {
         writeOrphan("S_CLEAN"); // no exit reason, never reached full
 
-        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+        new SessionReplayOrphanRecoverer(srDir, ctxStore, uploader, "S_CURRENT", 86_400_000L)
                 .recover();
 
-        Assert.assertEquals(0, offlineStore.count());
+        Assert.assertEquals(0, uploader.uploads.size());
         Assert.assertTrue("ineligible orphan is retained for re-evaluation, not deleted",
                 new File(srDir, "sessionReplaydataS_CLEAN.tmp").exists());
     }
@@ -103,9 +105,23 @@ public class SessionReplayOrphanRecovererTest {
         writeOrphan("S_CURRENT");
         ctxStore.updateExitReason("S_CURRENT", ApplicationExitInfo.REASON_ANR);
 
-        new SessionReplayOrphanRecoverer(context, srDir, ctxStore, offlineStore, "S_CURRENT", 86_400_000L)
+        new SessionReplayOrphanRecoverer(srDir, ctxStore, uploader, "S_CURRENT", 86_400_000L)
                 .recover();
 
-        Assert.assertEquals(0, offlineStore.count());
+        Assert.assertEquals(0, uploader.uploads.size());
+    }
+
+    @Test
+    public void retainsOrphanWhenUploaderNotReady() throws Exception {
+        writeOrphan("S_DEAD");
+        ctxStore.updateExitReason("S_DEAD", ApplicationExitInfo.REASON_ANR);
+        uploader.result = false; // reporter not ready — submission fails
+
+        new SessionReplayOrphanRecoverer(srDir, ctxStore, uploader, "S_CURRENT", 86_400_000L)
+                .recover();
+
+        Assert.assertEquals(1, uploader.uploads.size());
+        Assert.assertTrue("orphan retained for retry when the report was not submitted",
+                new File(srDir, "sessionReplaydataS_DEAD.tmp").exists());
     }
 }

--- a/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
@@ -161,4 +161,23 @@ public class FileSessionContextStoreTest {
         Assert.assertTrue(StatsEngine.get().getStatsMap()
                 .containsKey(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_CORRUPTED));
     }
+
+    @Test
+    public void updatersMergeAndUpsertPreservesInternalFields() {
+        // SR writes its state first (no context yet) — creates a minimal record.
+        store.updateSessionReplayState("S_A", true, true);
+        // Manager upsert with null internal fields must preserve the SR state.
+        store.upsert(new SessionManifest("S_A", 9, 1L, 2L, attrs("k", "v")));
+        SessionManifest m = store.get("S_A");
+        Assert.assertEquals(Boolean.TRUE, m.getReachedFullMode());
+        Assert.assertEquals(Boolean.TRUE, m.getIsFirstChunk());
+        Assert.assertEquals(9, m.getRealAgentId());
+        Assert.assertEquals(1, m.getAttributes().size());
+        // AEI writes the exit reason, preserving SR + context.
+        store.updateExitReason("S_A", 6);
+        m = store.get("S_A");
+        Assert.assertEquals(Integer.valueOf(6), m.getExitReason());
+        Assert.assertEquals(Boolean.TRUE, m.getReachedFullMode());
+        Assert.assertEquals(1, m.getAttributes().size());
+    }
 }

--- a/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
@@ -122,6 +122,16 @@ public class FileSessionContextStoreTest {
     }
 
     @Test
+    public void defaultCapBoundsStore() {
+        Assert.assertEquals(32, AgentConfiguration.DEFAULT_MAX_CACHED_SESSION_CONTEXT_COUNT);
+        // store was created in setUp() with a default-config cap of 32.
+        for (int i = 0; i < 40; i++) {
+            store.upsert(new SessionManifest("S_" + i, 1, 0L, i + 1, attrs("k", String.valueOf(i))));
+        }
+        Assert.assertEquals(32, store.count());
+    }
+
+    @Test
     public void corruptFileIsSkippedAndCounted() throws Exception {
         store.upsert(new SessionManifest("S_A", 1, 0L, 1L, attrs("k", "a")));
 

--- a/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.newrelic.agent.android.sessioncontext;
+
+import android.content.Context;
+
+import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.SpyContext;
+import com.newrelic.agent.android.analytics.AnalyticsAttribute;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@RunWith(RobolectricTestRunner.class)
+public class FileSessionContextStoreTest {
+
+    private Context context;
+    private AgentConfiguration config;
+    private FileSessionContextStore store;
+    private File cacheDir;
+
+    private static Set<AnalyticsAttribute> attrs(String key, String value) {
+        Set<AnalyticsAttribute> s = new HashSet<>();
+        s.add(new AnalyticsAttribute(key, value));
+        return s;
+    }
+
+    @Before
+    public void setUp() {
+        context = new SpyContext().getContext();
+        config = new AgentConfiguration();
+        store = new FileSessionContextStore(context, config);
+        cacheDir = new File(context.getFilesDir(), FileSessionContextStore.DIR_NAME);
+        StatsEngine.get().getStatsMap().clear();
+        StatsEngine.SUPPORTABILITY.getStatsMap().clear();
+    }
+
+    @After
+    public void tearDown() {
+        if (store != null) {
+            store.clear();
+        }
+    }
+
+    @Test
+    public void upsert_then_get_roundTrip() {
+        SessionManifest m = new SessionManifest("S_A", 1234, 10L, 20L, attrs("checkout_step", "review"));
+        Assert.assertTrue(store.upsert(m));
+
+        SessionManifest got = store.get("S_A");
+        Assert.assertNotNull(got);
+        Assert.assertEquals("S_A", got.getSessionId());
+        Assert.assertEquals(1234, got.getRealAgentId());
+        Assert.assertEquals(1, got.getAttributes().size());
+        Assert.assertEquals("review", got.getAttributes().iterator().next().getStringValue());
+    }
+
+    @Test
+    public void upsert_sameSessionId_replaces() {
+        store.upsert(new SessionManifest("S_A", 1, 0L, 1L, attrs("step", "one")));
+        store.upsert(new SessionManifest("S_A", 1, 0L, 2L, attrs("step", "two")));
+
+        Assert.assertEquals(1, store.count());
+        Assert.assertEquals("two", store.get("S_A").getAttributes().iterator().next().getStringValue());
+    }
+
+    @Test
+    public void get_unknownSessionId_returnsNull() {
+        Assert.assertNull(store.get("does-not-exist"));
+    }
+
+    @Test
+    public void fetchAll_and_count() {
+        store.upsert(new SessionManifest("S_A", 1, 0L, 1L, attrs("k", "a")));
+        store.upsert(new SessionManifest("S_B", 1, 0L, 1L, attrs("k", "b")));
+
+        Assert.assertEquals(2, store.count());
+        List<SessionManifest> all = store.fetchAll();
+        Assert.assertEquals(2, all.size());
+    }
+
+    @Test
+    public void delete_removesOnlyTarget() {
+        store.upsert(new SessionManifest("S_A", 1, 0L, 1L, attrs("k", "a")));
+        store.upsert(new SessionManifest("S_B", 1, 0L, 1L, attrs("k", "b")));
+
+        store.delete("S_A");
+
+        Assert.assertEquals(1, store.count());
+        Assert.assertNull(store.get("S_A"));
+        Assert.assertNotNull(store.get("S_B"));
+    }
+
+    @Test
+    public void evictsOldestWhenOverCap() {
+        config.setMaxCachedSessionContextCount(2);
+        store = new FileSessionContextStore(context, config);
+
+        store.upsert(new SessionManifest("S_1", 1, 0L, 1L, attrs("k", "1")));
+        store.upsert(new SessionManifest("S_2", 1, 0L, 2L, attrs("k", "2")));
+        store.upsert(new SessionManifest("S_3", 1, 0L, 3L, attrs("k", "3")));
+
+        Assert.assertEquals(2, store.count());
+        Assert.assertTrue(StatsEngine.get().getStatsMap()
+                .containsKey(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_EVICTED));
+    }
+
+    @Test
+    public void corruptFileIsSkippedAndCounted() throws Exception {
+        store.upsert(new SessionManifest("S_A", 1, 0L, 1L, attrs("k", "a")));
+
+        File corrupt = new File(cacheDir, "corrupt" + FileSessionContextStore.FILE_SUFFIX);
+        try (OutputStream os = new FileOutputStream(corrupt, false)) {
+            os.write("{not valid json".getBytes(StandardCharsets.UTF_8));
+        }
+
+        List<SessionManifest> all = store.fetchAll();
+        Assert.assertEquals(1, all.size());
+        Assert.assertFalse(corrupt.exists());
+        Assert.assertTrue(StatsEngine.get().getStatsMap()
+                .containsKey(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_CORRUPTED));
+    }
+}

--- a/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessioncontext/FileSessionContextStoreTest.java
@@ -132,6 +132,21 @@ public class FileSessionContextStoreTest {
     }
 
     @Test
+    public void getOnCorruptFileDeletesAndCounts() throws Exception {
+        File corrupt = new File(cacheDir,
+                FileSessionContextStore.safeFilename("S_corrupt") + FileSessionContextStore.FILE_SUFFIX);
+        try (OutputStream os = new FileOutputStream(corrupt, false)) {
+            os.write("{not valid json".getBytes(StandardCharsets.UTF_8));
+        }
+        Assert.assertTrue(corrupt.exists());
+
+        Assert.assertNull(store.get("S_corrupt"));
+        Assert.assertFalse("get() must delete a corrupt entry", corrupt.exists());
+        Assert.assertTrue(StatsEngine.get().getStatsMap()
+                .containsKey(MetricNames.SUPPORTABILITY_SESSION_CONTEXT_CORRUPTED));
+    }
+
+    @Test
     public void corruptFileIsSkippedAndCounted() throws Exception {
         store.upsert(new SessionManifest("S_A", 1, 0L, 1L, attrs("k", "a")));
 

--- a/agent/src/test/java/com/newrelic/agent/android/stores/FileEventStoreTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/stores/FileEventStoreTest.java
@@ -63,6 +63,7 @@ public class FileEventStoreTest {
 
         Assert.assertTrue(store.store(a));
         Assert.assertTrue(store.store(b));
+        store.awaitWrites(5000);
         Assert.assertEquals(2, store.count());
 
         List<AnalyticsEvent> fetched = store.fetchAll();
@@ -96,6 +97,7 @@ public class FileEventStoreTest {
 
         Assert.assertEquals(3, store.count());
         Assert.assertTrue(store.store(newest));
+        store.awaitWrites(5000);
         Assert.assertEquals(3, store.count());
 
         Assert.assertTrue("eviction metric should fire",
@@ -106,6 +108,7 @@ public class FileEventStoreTest {
     public void store_writesAtomically() {
         AnalyticsEvent e = new AnalyticsEvent("atomic");
         Assert.assertTrue(store.store(e));
+        store.awaitWrites(5000);
 
         File[] jsonFiles = cacheDir.listFiles((d, n) -> n.endsWith(AbstractFileStore.FILE_SUFFIX));
         File[] tmpFiles = cacheDir.listFiles((d, n) -> n.endsWith(AbstractFileStore.TMP_SUFFIX));
@@ -135,6 +138,7 @@ public class FileEventStoreTest {
     public void fetchAll_skipsCorruptedFiles() throws IOException {
         AnalyticsEvent good = new AnalyticsEvent("good");
         Assert.assertTrue(store.store(good));
+        store.awaitWrites(5000);
 
         File corrupt = new File(cacheDir, "garbage" + AbstractFileStore.FILE_SUFFIX);
         try (OutputStream os = new FileOutputStream(corrupt)) {
@@ -154,6 +158,7 @@ public class FileEventStoreTest {
         AnalyticsEvent e = new AnalyticsEvent("dup");
         Assert.assertTrue(store.store(e));
         Assert.assertTrue(store.store(e));
+        store.awaitWrites(5000);
         Assert.assertEquals(1, store.count());
     }
 
@@ -162,6 +167,7 @@ public class FileEventStoreTest {
         AnalyticsEvent missing = new AnalyticsEvent("never");
         store.delete(missing);
         store.delete(missing);
+        store.awaitWrites(5000);
         Assert.assertEquals(0, store.count());
     }
 
@@ -169,6 +175,7 @@ public class FileEventStoreTest {
     public void clear_removesEverything() throws IOException {
         AnalyticsEvent e = new AnalyticsEvent("gone");
         Assert.assertTrue(store.store(e));
+        store.awaitWrites(5000);
         File strayTmp = new File(cacheDir, "stray" + AbstractFileStore.TMP_SUFFIX);
         try (OutputStream os = new FileOutputStream(strayTmp)) {
             os.write("tmp".getBytes(StandardCharsets.UTF_8));
@@ -232,12 +239,14 @@ public class FileEventStoreTest {
         deleter.start();
         start.countDown();
         Assert.assertTrue(done.await(10, TimeUnit.SECONDS));
+        store.awaitWrites(5000);
 
         Assert.assertEquals(0, failures.get());
         Assert.assertTrue(store.count() >= 0);
     }
 
     private void setFileMtime(AnalyticsEvent e, long mtime) {
+        store.awaitWrites(5000);
         File f = new File(cacheDir, e.getEventUUID() + AbstractFileStore.FILE_SUFFIX);
         Assert.assertTrue("Expected file to exist for " + e.getEventUUID(), f.exists());
         Assert.assertTrue("Setting mtime should succeed", f.setLastModified(mtime));


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-575950](https://newrelic.atlassian.net/browse/NR-575950)
## Jira
- [NR-575950](https://new-relic.atlassian.net/browse/NR-575950) — ANR/AEI events carry the wrong session's attributes
- Includes a small `fix(NR-485061)` needed for this branch to compile (see Callouts)

## What & Why
`MobileApplicationExit` (AEI) events are synthesized on the **next** launch from the OS exit history, but they were stamped with the **current** process's session attributes — never the attributes that were live when the prior session died. This makes `sessionId`-faceted queries on AEI events misleading.

This adds a shared, `sessionId`-keyed **`SessionContextStore`** that snapshots session context (`sessionId`, `realAgentId`, `sessionStartMs`, typed-faithful attribute set) to disk, so the AEI path can attach the **prior** session's frozen attributes on recovery.

- **`SessionManifest`** (agent-core) — the snapshot record; attributes (de)serialize via the existing `AnalyticsAttribute.asJsonElement()` / `newFromJson()` (faithful round-trip — `AnalyticsAttribute` has only STRING/DOUBLE/BOOLEAN, no int).
- **`SessionContextStore`** interface (agent-core) + **`FileSessionContextStore`** (agent) on the branch's `AbstractFileStore` — one `<sessionId>.json` per session.
- **`SessionContextManager`** (agent-core) — an **always-on** `HarvestLifecycleAware` that writes the snapshot every `onHarvest()`. Deliberately NOT on the AEI path, which is API-30+ and remote-config gated, so the store also serves future SR/event recovery.
- **`ApplicationExitMonitor`** — read side: resolves attributes from the manifest by the prior session's id. A **found** manifest is used as-is (the source of truth, even if it captured no attributes). On a real miss (a mapped prior session whose manifest is absent — e.g. it ran under a pre-upgrade agent, was evicted, or died before its first harvest) it **falls back to the current session's attributes** — matching the agent's pre-NR-575950 behavior for that transitional window rather than shipping an attribute-less event — and increments `SessionContext/Missing`.
- Bounded to **32 entries** via `AbstractFileStore` mtime eviction; the live session is re-written each harvest so it's never the one evicted. Manifests intentionally survive backgrounding so post-background force-close / process-exit AEIs still recover.

This is Phase 1 of the cross-platform session-context design (Confluence: Mobile Event Persistence CDD). Phases 2 (Session Replay, NR-572311) and 3 (event shadow, CDD) build on the same store.

## Code review fixes
- **Medium — snapshots could silently stop after an in-process stop/start.** `SessionContextManager.initialize()` previously registered the harvest listener only when first created, so after `Harvest.shutdown()`/restart (which builds a new `Harvester`) the manager was left detached and stopped writing snapshots — making the AEI fallback miss prior-session attributes. `initialize()` now **always re-registers** (idempotent: `Harvester.addHarvestListener` de-dups when the same Harvester is reused; `Harvest.addHarvestListener` queues to the pending list before init).
- **Low — `SessionContext/Missing` overcounted.** The metric now increments **only** when a valid prior `sessionId` was looked up and no manifest was found. The no-mapping paths (null `sessionMeta`, empty session id, no store configured) still fall back to current-session attributes but no longer bump the metric, so it's a clean "manifest missing" signal rather than "nothing to look up." (Also tightened: a found-but-empty manifest is now used as-is instead of falling through to current attrs, which would have re-introduced mis-attribution for that edge.)

## Callouts
- **Bundled `fix(NR-485061)`:** the base branch's `JSErrorDataControllerFeatureFlagTest` had a duplicated inner-class (bad merge) that broke `agent-core` test compilation; one commit here removes the duplicate. Flagging in case it should instead be cherry-picked directly onto the JSError work.
- **Pre-existing, not addressed here:** `agent`-module unit-test compilation is currently blocked by `FileJSErrorStoreTest` referencing a non-existent `FileJSErrorStore.BAK_SUFFIX` (a `.bak` backup feature missing from `AbstractFileStore`). That's a JSError-domain gap; until it's resolved, CI can't compile/run the `agent` unit tests (including the new SessionContext ones). `agent-core` tests are unaffected.
- Base is `feature/nr485061-JSError` (not `develop`) because this work ships with the JSError store-layer refactor it depends on.
- **Upgrade / migration window:** on the first launch after upgrading from an agent that didn't persist session context, AEIs for pre-upgrade sessions keep the correct `sessionId` (the `AEISessionMapper` format is unchanged) but have no manifest. These fall back to current-session attributes (pre-fix behavior) and self-heal after the first harvest of the new agent.

## Test plan
- New/updated unit tests (run in CI):
  - `SessionManifestTest` — typed round-trip, legacy-file defaults.
  - `SessionContextManagerTest` — snapshot writes manifest; no-store no-op; `initialize()` returns the same instance and re-registers idempotently.
  - `FileSessionContextStoreTest` — upsert/get/delete/fetchAll, 32-cap eviction, corrupt-on-`get` delete+count, corrupt-on-`fetchAll`.
  - `ApplicationExitMonitorTest` — uses manifest when present; falls back to current attrs + `Missing` metric when a mapped manifest is absent; does NOT bump `Missing` when there is no prior-session mapping.
- See the change in context: `agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java` (read side), `agent-core/src/main/java/com/newrelic/agent/android/sessioncontext/` (store + manager).
- Manual (API 30+, AEI enabled): set `NewRelic.setAttribute("checkout_step","review")` in session A → wait a harvest → trigger an ANR → relaunch, set `checkout_step="cart"` in session B → wait a harvest → query `SELECT checkout_step FROM MobileApplicationExit WHERE sessionId = '<session A>'` → expect `review`, not `cart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NR-575950]: https://new-relic.atlassian.net/browse/NR-575950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ