### PR TITLE
NR-572276 remove payload/crash data if response is 400 403

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -23,6 +23,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.net.ssl.HttpsURLConnection;
+
 public class AgentDataReporter extends PayloadReporter {
     protected static final AtomicReference<AgentDataReporter> instance = new AtomicReference<>(null);
     private static boolean reportExceptions = false;
@@ -139,25 +141,7 @@ public class AgentDataReporter extends PayloadReporter {
         Future future = PayloadController.submitPayload(payloadSender, new PayloadSender.CompletionHandler() {
             @Override
             public void onResponse(PayloadSender payloadSender) {
-                if (payloadSender.isSuccessfulResponse()) {
-                    if (payloadStore != null) {
-                        payloadStore.delete(payloadSender.getPayload());
-                    }
-
-                    //add supportability metrics
-                    DeviceInformation deviceInformation = Agent.getDeviceInformation();
-                    String name = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
-                            .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
-                            .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
-                            .replace(MetricNames.TAG_SUBDESTINATION, "f");
-                    StatsEngine.get().sampleMetricDataUsage(name, payloadSender.getPayload().getBytes().length, 0);
-                } else {
-                    // sender will remain in store and retry every harvest cycle
-                    //Offline storage: No network at all, don't send back data
-                    if (FeatureFlag.featureEnabled(FeatureFlag.OfflineStorage)) {
-                        log.warn("AgentDataReporter didn't send due to lack of network connection");
-                    }
-                }
+                onAgentDataResponse(payloadSender);
             }
 
             @Override
@@ -178,6 +162,34 @@ public class AgentDataReporter extends PayloadReporter {
         }
 
         return reportAgentData(payload);
+    }
+
+    void onAgentDataResponse(PayloadSender payloadSender) {
+        if (payloadSender.isSuccessfulResponse()) {
+            if (payloadStore != null) {
+                payloadStore.delete(payloadSender.getPayload());
+            }
+
+            //add supportability metrics
+            DeviceInformation deviceInformation = Agent.getDeviceInformation();
+            String name = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
+                    .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
+                    .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
+                    .replace(MetricNames.TAG_SUBDESTINATION, "f");
+            StatsEngine.get().sampleMetricDataUsage(name, payloadSender.getPayload().getBytes().length, 0);
+        } else {
+            if (payloadSender.getResponseCode() == HttpsURLConnection.HTTP_BAD_REQUEST || payloadSender.getResponseCode() == HttpsURLConnection.HTTP_FORBIDDEN) {
+                if (payloadStore != null) {
+                    payloadStore.delete(payloadSender.getPayload());
+                }
+            } else {
+                // sender will remain in store and retry every harvest cycle
+                //Offline storage: No network at all, don't send back data
+                if (FeatureFlag.featureEnabled(FeatureFlag.OfflineStorage)) {
+                    log.warn("AgentDataReporter didn't send due to lack of network connection");
+                }
+            }
+        }
     }
 
     protected boolean isPayloadStale(Payload payload) {

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -19,11 +19,10 @@ import com.newrelic.agent.android.payload.PayloadStore;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.util.Constants;
 
+import java.net.HttpURLConnection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.net.ssl.HttpsURLConnection;
 
 public class AgentDataReporter extends PayloadReporter {
     protected static final AtomicReference<AgentDataReporter> instance = new AtomicReference<>(null);
@@ -133,7 +132,7 @@ public class AgentDataReporter extends PayloadReporter {
                     .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
                     .replace(MetricNames.TAG_SUBDESTINATION, "f");
             StatsEngine.notice().inc(name);
-            payloadStore.delete(payload);
+            deletePayload(payload);
             log.error("Unable to upload handled exceptions because payload is larger than 1 MB, handled exceptions are discarded.");
             return null;
         }
@@ -166,10 +165,7 @@ public class AgentDataReporter extends PayloadReporter {
 
     void onAgentDataResponse(PayloadSender payloadSender) {
         if (payloadSender.isSuccessfulResponse()) {
-            if (payloadStore != null) {
-                payloadStore.delete(payloadSender.getPayload());
-            }
-
+            deletePayload(payloadSender.getPayload());
             //add supportability metrics
             DeviceInformation deviceInformation = Agent.getDeviceInformation();
             String name = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
@@ -178,10 +174,9 @@ public class AgentDataReporter extends PayloadReporter {
                     .replace(MetricNames.TAG_SUBDESTINATION, "f");
             StatsEngine.get().sampleMetricDataUsage(name, payloadSender.getPayload().getBytes().length, 0);
         } else {
-            if (payloadSender.getResponseCode() == HttpsURLConnection.HTTP_BAD_REQUEST || payloadSender.getResponseCode() == HttpsURLConnection.HTTP_FORBIDDEN) {
-                if (payloadStore != null) {
-                    payloadStore.delete(payloadSender.getPayload());
-                }
+            if (payloadSender.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST ||
+                payloadSender.getResponseCode() == HttpURLConnection.HTTP_FORBIDDEN) {
+                    deletePayload(payloadSender.getPayload());
             } else {
                 // sender will remain in store and retry every harvest cycle
                 //Offline storage: No network at all, don't send back data
@@ -192,9 +187,14 @@ public class AgentDataReporter extends PayloadReporter {
         }
     }
 
+    void deletePayload(Payload payload) {
+        if (payloadStore != null) {
+            payloadStore.delete(payload);
+        }
+    }
     protected boolean isPayloadStale(Payload payload) {
         if (payload.isStale(agentConfiguration.getPayloadTTL())) {
-            payloadStore.delete(payload);
+            deletePayload(payload);
             log.info("Payload [" + payload.getUuid() + "] has become stale, and has been removed");
             StatsEngine.get().inc(MetricNames.SUPPORTABILITY_PAYLOAD_REMOVED_STALE);
             return true;

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataSender.java
@@ -76,7 +76,6 @@ public class AgentDataSender extends PayloadSender {
             case HttpURLConnection.HTTP_BAD_REQUEST:
             case HttpURLConnection.HTTP_FORBIDDEN:
                 onFailedUpload("The data payload [" + payload.getUuid() + "] was rejected and will be deleted - Response code [" + responseCode + "]");
-                StatsEngine.get().sampleTimeMs(MetricNames.SUPPORTABILITY_HEX_FAILED_UPLOAD, timer.peek());
 
                 StatsEngine.get().inc(MetricNames.SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE);
                 break;

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataSender.java
@@ -69,9 +69,16 @@ public class AgentDataSender extends PayloadSender {
                 break;
 
             case HttpsURLConnection.HTTP_INTERNAL_ERROR:
+                onFailedUpload("The data payload [" + payload.getUuid() + "] was rejected and will be deleted - Response code [" + responseCode + "]");
+                StatsEngine.get().sampleTimeMs(MetricNames.SUPPORTABILITY_HEX_FAILED_UPLOAD, timer.peek());
+                break;
+
+            case HttpURLConnection.HTTP_BAD_REQUEST:
             case HttpURLConnection.HTTP_FORBIDDEN:
                 onFailedUpload("The data payload [" + payload.getUuid() + "] was rejected and will be deleted - Response code [" + responseCode + "]");
                 StatsEngine.get().sampleTimeMs(MetricNames.SUPPORTABILITY_HEX_FAILED_UPLOAD, timer.peek());
+
+                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE);
                 break;
 
             default:

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
@@ -22,6 +22,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.net.ssl.HttpsURLConnection;
+
 public class CrashReporter extends PayloadReporter {
     protected static AtomicReference<CrashReporter> instance = new AtomicReference<>(null);
 
@@ -144,24 +146,7 @@ public class CrashReporter extends PayloadReporter {
                     final PayloadSender.CompletionHandler completionHandler = new PayloadSender.CompletionHandler() {
                         @Override
                         public void onResponse(PayloadSender payloadSender) {
-                            if (payloadSender.isSuccessfulResponse()) {
-                                if (crashStore != null) {
-                                    crashStore.delete(crash);
-                                }
-
-                                //add supportability metrics
-                                DeviceInformation deviceInformation = Agent.getDeviceInformation();
-                                String name = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
-                                        .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
-                                        .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
-                                        .replace(MetricNames.TAG_SUBDESTINATION, "mobile_crash");
-                                StatsEngine.get().sampleMetricDataUsage(name, crash.asJsonObject().toString().getBytes().length, 0);
-                            } else {
-                                //Offline storage: No network at all, don't send back data
-                                if (FeatureFlag.featureEnabled(FeatureFlag.OfflineStorage)) {
-                                    log.warn("CrashReporter didn't send due to lack of network connection");
-                                }
-                            }
+                            onCrashResponse(payloadSender, crash);
                         }
 
                         @Override
@@ -185,6 +170,32 @@ public class CrashReporter extends PayloadReporter {
         }
 
         return null;
+    }
+
+    void onCrashResponse(PayloadSender payloadSender, Crash crash) {
+        if (payloadSender.isSuccessfulResponse()) {
+            if (crashStore != null) {
+                crashStore.delete(crash);
+            }
+
+            //add supportability metrics
+            DeviceInformation deviceInformation = Agent.getDeviceInformation();
+            String name = MetricNames.SUPPORTABILITY_SUBDESTINATION_OUTPUT_BYTES
+                    .replace(MetricNames.TAG_FRAMEWORK, deviceInformation.getApplicationFramework().name())
+                    .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
+                    .replace(MetricNames.TAG_SUBDESTINATION, "mobile_crash");
+            StatsEngine.get().sampleMetricDataUsage(name, crash.asJsonObject().toString().getBytes().length, 0);
+        } else {
+            if (payloadSender.getResponseCode() == HttpsURLConnection.HTTP_BAD_REQUEST || payloadSender.getResponseCode() == HttpsURLConnection.HTTP_FORBIDDEN) {
+                if (crashStore != null) {
+                    crashStore.delete(crash);
+                }
+            } else {
+                if (FeatureFlag.featureEnabled(FeatureFlag.OfflineStorage)) {
+                    log.warn("CrashReporter didn't send due to lack of network connection");
+                }
+            }
+        }
     }
 
     public void storeAndReportCrash(Crash crash,boolean isNativeCrashReport) {

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
@@ -18,11 +18,11 @@ import com.newrelic.agent.android.sessionReplay.CrashSessionReplayHandler;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.util.Constants;
 
+import java.net.HttpURLConnection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.net.ssl.HttpsURLConnection;
 
 public class CrashReporter extends PayloadReporter {
     protected static AtomicReference<CrashReporter> instance = new AtomicReference<>(null);
@@ -107,7 +107,7 @@ public class CrashReporter extends PayloadReporter {
         if (crashStore != null) {
             for (Crash crash : crashStore.fetchAll()) {
                 if (crash.isStale()) {
-                    crashStore.delete(crash);
+                    deleteCrash(crash);
                     log.info("CrashReporter: Crash [" + crash.getUuid().toString() + "] has become stale, and has been removed");
                     StatsEngine.get().inc(MetricNames.SUPPORTABILITY_CRASH_REMOVED_STALE);
                 } else {
@@ -138,7 +138,7 @@ public class CrashReporter extends PayloadReporter {
                                 .replace(MetricNames.TAG_DESTINATION, MetricNames.METRIC_DATA_USAGE_COLLECTOR)
                                 .replace(MetricNames.TAG_SUBDESTINATION, "mobile_crash");
                         StatsEngine.notice().inc(name);
-                        crashStore.delete(crash);
+                        deleteCrash(crash);
                         log.error("Unable to upload crashes because payload is larger than 1 MB, crash report is discarded.");
                         return null;
                     }
@@ -172,11 +172,15 @@ public class CrashReporter extends PayloadReporter {
         return null;
     }
 
+    void deleteCrash(Crash crash) {
+        if (crashStore != null) {
+            crashStore.delete(crash);
+        }
+    }
+
     void onCrashResponse(PayloadSender payloadSender, Crash crash) {
         if (payloadSender.isSuccessfulResponse()) {
-            if (crashStore != null) {
-                crashStore.delete(crash);
-            }
+            deleteCrash(crash);
 
             //add supportability metrics
             DeviceInformation deviceInformation = Agent.getDeviceInformation();
@@ -186,10 +190,8 @@ public class CrashReporter extends PayloadReporter {
                     .replace(MetricNames.TAG_SUBDESTINATION, "mobile_crash");
             StatsEngine.get().sampleMetricDataUsage(name, crash.asJsonObject().toString().getBytes().length, 0);
         } else {
-            if (payloadSender.getResponseCode() == HttpsURLConnection.HTTP_BAD_REQUEST || payloadSender.getResponseCode() == HttpsURLConnection.HTTP_FORBIDDEN) {
-                if (crashStore != null) {
-                    crashStore.delete(crash);
-                }
+            if (payloadSender.getResponseCode() == HttpURLConnection.HTTP_BAD_REQUEST || payloadSender.getResponseCode() == HttpURLConnection.HTTP_FORBIDDEN) {
+                deleteCrash(crash);
             } else {
                 if (FeatureFlag.featureEnabled(FeatureFlag.OfflineStorage)) {
                     log.warn("CrashReporter didn't send due to lack of network connection");

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashSender.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashSender.java
@@ -87,6 +87,12 @@ public class CrashSender extends PayloadSender {
                 onFailedUpload("The request to submit the payload [" + payload.getUuid() + "] was has timed out - (will try again later) - Response code [" + responseCode + "]");
                 break;
 
+            case HttpsURLConnection.HTTP_FORBIDDEN:
+            case HttpsURLConnection.HTTP_BAD_REQUEST:
+                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_REJECTED_DEVICE_OFFLINE);
+                onFailedUpload("The crash was rejected - Response code " + connection.getResponseCode());
+                break;
+
             case HttpsURLConnection.HTTP_INTERNAL_ERROR:
                 StatsEngine.get().inc(MetricNames.SUPPORTABILITY_CRASH_REMOVED_REJECTED);
                 onFailedUpload("The crash was rejected and will be deleted - Response code " + connection.getResponseCode());

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -44,6 +44,8 @@ public class MetricNames {
     public static final String SUPPORTABILITY_CONFIGURATION_CHANGED = SUPPORTABILITY_AGENT + "Configuration/Updated";
     public static final String SUPPORTABILITY_PAYLOAD_REMOVED_STALE = SUPPORTABILITY_AGENT + "Payload/Removed/Stale";
     public static final String SUPPORTABILITY_PAYLOAD_EVICTED = SUPPORTABILITY_AGENT + "Payload/Removed/Evicted";
+    public static final String SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE = SUPPORTABILITY_AGENT + "Offline/Rejected";
+
     public static final String SUPPORTABILITY_PAYLOAD_CORRUPTED = SUPPORTABILITY_AGENT + "Payload/Corrupted";
     public static final String SUPPORTABILITY_SESSION_INVALID_DURATION = SUPPORTABILITY_AGENT + "Session/InvalidDuration";
     public static final String SUPPORTABILITY_RESPONSE_TIME_INVALID_DURATION = SUPPORTABILITY_AGENT + "Network/Request/ResponseTime/InvalidDuration";
@@ -51,6 +53,7 @@ public class MetricNames {
     public static final String SUPPORTABILITY_CRASH = SUPPORTABILITY_AGENT + "Crash/";
     public static final String SUPPORTABILITY_CRASH_RECURSIVE_HANDLER = SUPPORTABILITY_CRASH + "UncaughtExceptionHandler/Recursion";
     public static final String SUPPORTABILITY_CRASH_UNCAUGHT_HANDLER = SUPPORTABILITY_AGENT + "UncaughtExceptionHandler/<name>";
+    public static final String SUPPORTABILITY_CRASH_UPLOAD_REJECTED_DEVICE_OFFLINE = SUPPORTABILITY_CRASH + "Offline/Rejected";
     public static final String SUPPORTABILITY_CRASH_UPLOAD_TIME = SUPPORTABILITY_CRASH + "UploadTime";
     public static final String SUPPORTABILITY_CRASH_UPLOAD_TIMEOUT = SUPPORTABILITY_CRASH + "UploadTimeOut";
     public static final String SUPPORTABILITY_CRASH_UPLOAD_THROTTLED = SUPPORTABILITY_CRASH + "UploadThrottled";

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -44,7 +44,7 @@ public class MetricNames {
     public static final String SUPPORTABILITY_CONFIGURATION_CHANGED = SUPPORTABILITY_AGENT + "Configuration/Updated";
     public static final String SUPPORTABILITY_PAYLOAD_REMOVED_STALE = SUPPORTABILITY_AGENT + "Payload/Removed/Stale";
     public static final String SUPPORTABILITY_PAYLOAD_EVICTED = SUPPORTABILITY_AGENT + "Payload/Removed/Evicted";
-    public static final String SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE = SUPPORTABILITY_AGENT + "Offline/Rejected";
+    public static final String SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE = SUPPORTABILITY_AGENT + "Payload/Offline/Rejected";
 
     public static final String SUPPORTABILITY_PAYLOAD_CORRUPTED = SUPPORTABILITY_AGENT + "Payload/Corrupted";
     public static final String SUPPORTABILITY_SESSION_INVALID_DURATION = SUPPORTABILITY_AGENT + "Session/InvalidDuration";

--- a/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
@@ -60,6 +60,7 @@ public class AgentDataReporterTest {
         FeatureFlag.enableFeature(FeatureFlag.HandledExceptions);
 
         PayloadController.initialize(agentConfiguration);
+        AgentDataReporter.initialize(agentConfiguration);
 
         final Map<String, Object> sessionAttributes = new HashMap<String, Object>() {{
             put("a string", "hello");
@@ -93,6 +94,7 @@ public class AgentDataReporterTest {
 
     @After
     public void tearDown() throws Exception {
+        AgentDataReporter.shutdown();
         Agent.stop();
     }
 
@@ -193,6 +195,22 @@ public class AgentDataReporterTest {
             reporter.onAgentDataResponse(mockSender);
             Assert.assertEquals("Payload should be retained on " + code, 1, agentConfiguration.getPayloadStore().count());
         }
+    }
+
+    @Test
+    public void testSuccessfulResponseDeletesPayloadFromStore() throws Exception {
+        Agent.setImpl(new StubAgentImpl());
+        AgentDataReporter reporter = AgentDataReporter.initialize(agentConfiguration);
+        Payload payload = new Payload(flat.dataBuffer().array());
+        agentConfiguration.getPayloadStore().store(payload);
+        Assert.assertEquals(1, agentConfiguration.getPayloadStore().count());
+
+        PayloadSender mockSender = Mockito.mock(PayloadSender.class);
+        Mockito.when(mockSender.isSuccessfulResponse()).thenReturn(true);
+        Mockito.when(mockSender.getPayload()).thenReturn(payload);
+
+        reporter.onAgentDataResponse(mockSender);
+        Assert.assertEquals("Payload should be deleted on success", 0, agentConfiguration.getPayloadStore().count());
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
@@ -18,18 +18,30 @@ import com.newrelic.agent.android.payload.PayloadController;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.test.stub.StubAgentImpl;
 import com.newrelic.agent.android.test.stub.StubAnalyticsAttributeStore;
+import com.newrelic.agent.android.util.Constants;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import com.newrelic.agent.android.payload.PayloadSender;
+import com.newrelic.agent.android.payload.PayloadStore;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Future;
 
 public class AgentDataReporterTest {
     private static AgentConfiguration agentConfiguration;
@@ -44,6 +56,7 @@ public class AgentDataReporterTest {
         agentConfiguration.setReportHandledExceptions(true);
         agentConfiguration.setAnalyticsAttributeStore(new StubAnalyticsAttributeStore());
 
+        agentConfiguration.setPayloadStore(new TestPayloadStore());
         FeatureFlag.enableFeature(FeatureFlag.HandledExceptions);
 
         PayloadController.initialize(agentConfiguration);
@@ -117,6 +130,72 @@ public class AgentDataReporterTest {
     }
 
     @Test
+    public void reportAgentDataReturnsFuture() throws Exception {
+        Agent.setImpl(new StubAgentImpl());
+        AgentDataReporter reporter = AgentDataReporter.initialize(agentConfiguration);
+
+        // PayloadController queues payloads by default (opportunisticUploads=false), which returns
+        // null from submitPayload. Enable opportunistic uploads so a Future is returned instead.
+        java.lang.reflect.Field field = PayloadController.class.getDeclaredField("opportunisticUploads");
+        field.setAccessible(true);
+        field.set(null, true);
+
+        Payload payload = new Payload(flat.dataBuffer().array());
+        Future future = reporter.reportAgentData(payload);
+        Assert.assertNotNull("reportAgentData should return a non-null Future", future);
+    }
+
+    @Test
+    public void reportAgentDataReturnsNullWhenPayloadOversized() throws Exception {
+        Agent.setImpl(new StubAgentImpl());
+        AgentDataReporter reporter = AgentDataReporter.initialize(agentConfiguration);
+
+        byte[] oversized = new byte[(int) Constants.Network.MAX_PAYLOAD_SIZE + 1];
+        Payload payload = new Payload(oversized);
+        Future future = reporter.reportAgentData(payload);
+        Assert.assertNull("reportAgentData should return null for oversized payload", future);
+    }
+
+    @Test
+    public void testPermanentlyRejectedPayloadDeletedFromStore() throws Exception {
+        AgentDataReporter reporter = AgentDataReporter.initialize(agentConfiguration);
+        Payload payload = new Payload(flat.dataBuffer().array());
+        agentConfiguration.getPayloadStore().store(payload);
+        Assert.assertEquals(1, agentConfiguration.getPayloadStore().count());
+
+        PayloadSender mockSender = Mockito.mock(PayloadSender.class);
+        Mockito.when(mockSender.isSuccessfulResponse()).thenReturn(false);
+        Mockito.when(mockSender.getPayload()).thenReturn(payload);
+
+        Mockito.when(mockSender.getResponseCode()).thenReturn(HttpsURLConnection.HTTP_FORBIDDEN);
+        reporter.onAgentDataResponse(mockSender);
+        Assert.assertEquals("Payload should be deleted on 403", 0, agentConfiguration.getPayloadStore().count());
+
+        agentConfiguration.getPayloadStore().store(payload);
+        Mockito.when(mockSender.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
+        reporter.onAgentDataResponse(mockSender);
+        Assert.assertEquals("Payload should be deleted on 400", 0, agentConfiguration.getPayloadStore().count());
+    }
+
+    @Test
+    public void testTransientErrorRetainsPayloadInStore() throws Exception {
+        AgentDataReporter reporter = AgentDataReporter.initialize(agentConfiguration);
+        Payload payload = new Payload(flat.dataBuffer().array());
+        agentConfiguration.getPayloadStore().store(payload);
+        Assert.assertEquals(1, agentConfiguration.getPayloadStore().count());
+
+        PayloadSender mockSender = Mockito.mock(PayloadSender.class);
+        Mockito.when(mockSender.isSuccessfulResponse()).thenReturn(false);
+        Mockito.when(mockSender.getPayload()).thenReturn(payload);
+
+        for (int code : new int[]{HttpURLConnection.HTTP_CLIENT_TIMEOUT, 429, HttpURLConnection.HTTP_UNAVAILABLE}) {
+            Mockito.when(mockSender.getResponseCode()).thenReturn(code);
+            reporter.onAgentDataResponse(mockSender);
+            Assert.assertEquals("Payload should be retained on " + code, 1, agentConfiguration.getPayloadStore().count());
+        }
+    }
+
+    @Test
     public void reportSavedAgentData() throws Exception {
     }
 
@@ -137,6 +216,36 @@ public class AgentDataReporterTest {
 
         public boolean isRunning() {
             return isStarted.get();
+        }
+    }
+
+    private static class TestPayloadStore implements PayloadStore<Payload> {
+        private final Map<String, Payload> store = new HashMap<>();
+
+        @Override
+        public boolean store(Payload payload) {
+            store.put(payload.getUuid(), payload);
+            return true;
+        }
+
+        @Override
+        public List<Payload> fetchAll() {
+            return new ArrayList<>(store.values());
+        }
+
+        @Override
+        public int count() {
+            return store.size();
+        }
+
+        @Override
+        public void clear() {
+            store.clear();
+        }
+
+        @Override
+        public void delete(Payload payload) {
+            store.remove(payload.getUuid());
         }
     }
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
@@ -29,8 +29,6 @@ import org.mockito.Mockito;
 import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 
-import javax.net.ssl.HttpsURLConnection;
-
 import com.newrelic.agent.android.payload.PayloadSender;
 import com.newrelic.agent.android.payload.PayloadStore;
 
@@ -169,7 +167,7 @@ public class AgentDataReporterTest {
         Mockito.when(mockSender.isSuccessfulResponse()).thenReturn(false);
         Mockito.when(mockSender.getPayload()).thenReturn(payload);
 
-        Mockito.when(mockSender.getResponseCode()).thenReturn(HttpsURLConnection.HTTP_FORBIDDEN);
+        Mockito.when(mockSender.getResponseCode()).thenReturn(HttpURLConnection.HTTP_FORBIDDEN);
         reporter.onAgentDataResponse(mockSender);
         Assert.assertEquals("Payload should be deleted on 403", 0, agentConfiguration.getPayloadStore().count());
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataSenderTest.java
@@ -192,4 +192,27 @@ public class AgentDataSenderTest {
         verify(agentDataSender, atLeastOnce()).onFailedUpload(anyString());
     }
 
+    @Test
+    public void testRejectedUpload() throws Exception {
+        AgentDataSender agentDataSender = spy(new AgentDataSender(flat.dataBuffer().slice().array(), agentConfiguration));
+        HttpURLConnection connection = getMockedConnection(agentDataSender);
+
+        Mockito.doReturn(HttpsURLConnection.HTTP_FORBIDDEN).when(connection).getResponseCode();
+        agentDataSender.onRequestResponse(connection);
+        Assert.assertTrue("Should record rejected metric on 403",
+                StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE));
+
+        StatsEngine.get().getStatsMap().clear();
+        Mockito.doReturn(HttpURLConnection.HTTP_BAD_REQUEST).when(connection).getResponseCode();
+        agentDataSender.onRequestResponse(connection);
+        Assert.assertTrue("Should record rejected metric on 400",
+                StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE));
+
+        StatsEngine.get().getStatsMap().clear();
+        Mockito.doReturn(HttpsURLConnection.HTTP_INTERNAL_ERROR).when(connection).getResponseCode();
+        agentDataSender.onRequestResponse(connection);
+        Assert.assertFalse("Should not record rejected metric on 500",
+                StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE));
+    }
+
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashReporterTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashReporterTests.java
@@ -220,6 +220,20 @@ public class CrashReporterTests {
     }
 
     @Test
+    public void testSuccessfulCrashDeletedFromStore() {
+        Agent.setImpl(new StubAgentImpl());
+        Crash testCrash = new Crash(new RuntimeException("successful upload"));
+        crashStore.store(testCrash);
+        Assert.assertEquals(1, crashStore.count());
+
+        PayloadSender mockSender = Mockito.mock(PayloadSender.class);
+        Mockito.when(mockSender.isSuccessfulResponse()).thenReturn(true);
+
+        crashReporter.onCrashResponse(mockSender, testCrash);
+        Assert.assertEquals("Crash should be deleted on success", 0, crashStore.count());
+    }
+
+    @Test
     public void testFailedCrashUpload() throws Exception {
         HttpURLConnection connection = getMockedConnection();
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashReporterTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashReporterTests.java
@@ -177,7 +177,7 @@ public class CrashReporterTests {
     }
 
     @Test
-    public void testOfflineCrashUpload() throws Exception {
+    public void testPermanentlyRejectedCrashLogged() throws Exception {
         HttpURLConnection connection = getMockedConnection();
         Mockito.doReturn(HttpsURLConnection.HTTP_FORBIDDEN).when(connection).getResponseCode();
         crashSender.onRequestResponse(connection);

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashReporterTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashReporterTests.java
@@ -15,6 +15,7 @@ import com.newrelic.agent.android.harvest.DataToken;
 import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.PayloadController;
+import com.newrelic.agent.android.payload.PayloadSender;
 import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.test.mock.Providers;
 import com.newrelic.agent.android.test.stub.StubAgentImpl;
@@ -173,6 +174,49 @@ public class CrashReporterTests {
         Mockito.doReturn(HttpsURLConnection.HTTP_CREATED).when(connection).getResponseCode();
         crashSender.onRequestResponse(connection);
         Assert.assertFalse("Should not contain 202 supportability metric", StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_TIME));
+    }
+
+    @Test
+    public void testOfflineCrashUpload() throws Exception {
+        HttpURLConnection connection = getMockedConnection();
+        Mockito.doReturn(HttpsURLConnection.HTTP_FORBIDDEN).when(connection).getResponseCode();
+        crashSender.onRequestResponse(connection);
+        Assert.assertTrue("Should contain 403 supportability metric", StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_REJECTED_DEVICE_OFFLINE));
+    }
+
+    @Test
+    public void testPermanentlyRejectedCrashDeletedFromStore() {
+        Crash testCrash = new Crash(new RuntimeException("permanently rejected"));
+        crashStore.store(testCrash);
+        Assert.assertEquals(1, crashStore.count());
+
+        PayloadSender mockSender = Mockito.mock(PayloadSender.class);
+        Mockito.when(mockSender.isSuccessfulResponse()).thenReturn(false);
+
+        Mockito.when(mockSender.getResponseCode()).thenReturn(HttpsURLConnection.HTTP_FORBIDDEN);
+        crashReporter.onCrashResponse(mockSender, testCrash);
+        Assert.assertEquals("Crash should be deleted on 403", 0, crashStore.count());
+
+        crashStore.store(testCrash);
+        Mockito.when(mockSender.getResponseCode()).thenReturn(HttpsURLConnection.HTTP_BAD_REQUEST);
+        crashReporter.onCrashResponse(mockSender, testCrash);
+        Assert.assertEquals("Crash should be deleted on 400", 0, crashStore.count());
+    }
+
+    @Test
+    public void testTransientErrorRetainsCrashInStore() {
+        Crash testCrash = new Crash(new RuntimeException("transient error"));
+        crashStore.store(testCrash);
+        Assert.assertEquals(1, crashStore.count());
+
+        PayloadSender mockSender = Mockito.mock(PayloadSender.class);
+        Mockito.when(mockSender.isSuccessfulResponse()).thenReturn(false);
+
+        for (int code : new int[]{HttpURLConnection.HTTP_CLIENT_TIMEOUT, 429, HttpURLConnection.HTTP_UNAVAILABLE}) {
+            Mockito.when(mockSender.getResponseCode()).thenReturn(code);
+            crashReporter.onCrashResponse(mockSender, testCrash);
+            Assert.assertEquals("Crash should be retained on " + code, 1, crashStore.count());
+        }
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
@@ -111,7 +111,6 @@ public class CrashSenderTest {
 
     @Test
     public void testFailedUpload() throws Exception {
-        CrashSender crashSender = spy(new CrashSender(crash, agentConfiguration));
 
         crashSender.onFailedUpload("Upload failure");
         Assert.assertTrue("Should contain 500 supportability metric", StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_FAILED_UPLOAD));
@@ -120,7 +119,6 @@ public class CrashSenderTest {
 
     @Test
     public void testRequestException() throws Exception {
-        CrashSender crashSender = spy(new CrashSender(crash, agentConfiguration));
         Mockito.doReturn(null).when(crashSender).getConnection();
         crashSender.call();
         verify(crashSender, atLeastOnce()).onFailedUpload(any(String.class));

--- a/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/crash/CrashSenderTest.java
@@ -101,7 +101,12 @@ public class CrashSenderTest {
         Mockito.reset();
         Mockito.doReturn(HttpsURLConnection.HTTP_BAD_REQUEST).when(connection).getResponseCode();
         crashSender.onRequestResponse(connection);
-        verify(crashSender, atLeastOnce()).onFailedUpload(anyString());
+        Assert.assertTrue("Should contain 400 supportability metric", StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_REJECTED_DEVICE_OFFLINE));
+
+        Mockito.reset();
+        Mockito.doReturn(HttpsURLConnection.HTTP_FORBIDDEN).when(connection).getResponseCode();
+        crashSender.onRequestResponse(connection);
+        Assert.assertTrue("Should contain 403 supportability metric", StatsEngine.get().getStatsMap().containsKey(MetricNames.SUPPORTABILITY_CRASH_UPLOAD_REJECTED_DEVICE_OFFLINE));
     }
 
     @Test


### PR DESCRIPTION
Jira Ticket: [NR-572276](https://new-relic.atlassian.net/browse/NR-572276)

fix(NR-572276): Permanently discard crash and payload data on HTTP 400/403 responses

## Summary

Previously, when the New Relic ingest endpoint returned a `400 Bad Request` or `403 Forbidden` response for a crash report or handled-exception payload, the agent retained the data in its store and retried it on every subsequent harvest cycle. This created an infinite retry loop for data the server will never accept.

This PR fixes that by permanently deleting stored crash and payload data when a `400` or `403` response is received, matching the existing behavior for oversized payloads.

## Changes

- **`CrashReporter`**: Added `onCrashResponse()` and `deleteCrash()` helpers. On `400`/`403`, the stored crash is deleted. On other non-success responses (e.g., no network), the existing offline-storage retry behavior is preserved.
- **`AgentDataReporter`**: Same pattern — added `onAgentDataResponse()` and `deletePayload()`. Deletes the payload on `400`/`403`; retains and retries on other failures.
- **`AgentDataSender`**: Separated `400`/`403` case from `500` in the response code switch, recording a `SUPPORTABILITY_PAYLOAD_REJECTED_DEVICE_OFFLINE` metric for permanent rejections.
- **Tests**: Added coverage for the `400`/`403` permanent-rejection path and for the success-path payload deletion in both `CrashReporter` and `AgentDataReporter`.

## Test plan
- [x] Unit tests pass: `./gradlew agent-core:test`
- [x] Manually verify crash data is not re-uploaded after a `403` response
- [x] Confirm `400`/`403` paths emit the expected supportability metric

[NR-572276]: https://new-relic.atlassian.net/browse/NR-572276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ