### PR TITLE
fix: use pull_request_target for Jira link action on fork PRs

### DIFF
--- a/.github/workflows/jira-link.yml
+++ b/.github/workflows/jira-link.yml
@@ -1,6 +1,6 @@
 name: Add JIRA Links
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened]
 
   workflow_dispatch:


### PR DESCRIPTION
The add-jira-links workflow was failing with 'Resource not accessible by integration' when triggered by PRs opened from forks. This is a GitHub security restriction: the pull_request event runs in the context of the fork, so GITHUB_TOKEN is restricted to read-only even when pull-requests: write is declared in the workflow permissions block.

Switching to pull_request_target runs the workflow in the context of the base repository instead, giving GITHUB_TOKEN the write access needed to update the PR body with the Jira link. This is safe because the jira-pr-link-action only reads the PR title/body and updates it via the GitHub API — it does not check out or execute any code from the fork.