### PR TITLE
fix(NR-577137): add TTL expiry and LRU eviction to offline storage

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
+++ b/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
@@ -10,16 +10,21 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class OfflineStorage {
     private static final String OFFLINE_STORAGE = "nr_offline_storage";
     private static final int DEFAULT_MAX_OFFLINE_Storage_SIZE = 100 * 1024 * 1024; //MB
+    static final long DEFAULT_OFFLINE_STORAGE_TTL = TimeUnit.DAYS.toMillis(7);
     private static final AgentLog log = AgentLogManager.getAgentLog();
     private static File offlineStorage;
     private static String offlineFilePath = "";
     private static int offlineStorageSize = 100 * 1024 * 1024; //MB
+    private static long offlineStorageTTL = DEFAULT_OFFLINE_STORAGE_TTL;
 
     public OfflineStorage(Context context) {
         try {
@@ -37,7 +42,24 @@ public class OfflineStorage {
         try {
             double totalData = getTotalFileSize() + data.getBytes().length;
             if (totalData > offlineStorageSize) {
-                return false;
+                File[] files = offlineStorage.listFiles();
+                if (files != null && files.length > 0) {
+                    Arrays.sort(files, new Comparator<File>() {
+                        @Override
+                        public int compare(File a, File b) {
+                            return Long.compare(a.lastModified(), b.lastModified());
+                        }
+                    });
+                    for (File file : files) {
+                        //file.delete();
+                        if (totalData <= offlineStorageSize) {
+                            break;
+                        }
+                    }
+                }
+                if (totalData > offlineStorageSize) {
+                    return false;
+                }
             }
 
             if (!offlineStorage.exists()) {
@@ -72,7 +94,12 @@ public class OfflineStorage {
 
             File[] files = offlineStorage.listFiles();
             if (files.length > 0) {
+                long expiryTime = System.currentTimeMillis() - offlineStorageTTL;
                 for (int i = 0; i < files.length; i++) {
+                    if (files[i].lastModified() < expiryTime) {
+                        files[i].delete();
+                        continue;
+                    }
                     BufferedReader in = null;
                     try {
                         in = new BufferedReader(new FileReader(files[i]));
@@ -81,7 +108,6 @@ public class OfflineStorage {
                     } catch (Exception e) {
                         log.error("OfflineStorage: ", e);
                     }
-
                 }
             }
         } catch (Exception e) {
@@ -158,5 +184,13 @@ public class OfflineStorage {
 
     public void setOfflineStorageSize(int maxSize) {
         offlineStorageSize = maxSize;
+    }
+
+    public static long getOfflineStorageTTL() {
+        return offlineStorageTTL;
+    }
+
+    public static void setOfflineStorageTTL(long ttl) {
+        offlineStorageTTL = ttl;
     }
 }

--- a/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
+++ b/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
@@ -40,7 +40,11 @@ public class OfflineStorage {
     public boolean persistHarvestDataToDisk(String data) {
         boolean isSaved = false;
         try {
-            double totalData = getTotalFileSize() + data.getBytes().length;
+            long payloadSize = data.getBytes().length;
+            if (payloadSize > offlineStorageSize) {
+                return false;
+            }
+            double totalData = getTotalFileSize() + payloadSize;
             if (totalData > offlineStorageSize) {
                 File[] files = offlineStorage.listFiles();
                 if (files != null && files.length > 0) {
@@ -52,8 +56,10 @@ public class OfflineStorage {
                     });
                     for (File file : files) {
                         if (file.length() > 0) {
-                            totalData -= file.length();
-                            file.delete();
+                            long fileSize = file.length();
+                            if (file.delete()) {
+                                totalData -= fileSize;
+                            }
                         }
                         if (totalData <= offlineStorageSize) {
                             break;

--- a/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
+++ b/agent/src/main/java/com/newrelic/agent/android/util/OfflineStorage.java
@@ -51,7 +51,10 @@ public class OfflineStorage {
                         }
                     });
                     for (File file : files) {
-                        //file.delete();
+                        if (file.length() > 0) {
+                            totalData -= file.length();
+                            file.delete();
+                        }
                         if (totalData <= offlineStorageSize) {
                             break;
                         }

--- a/agent/src/test/java/com/newrelic/agent/android/util/OfflineStorageTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/util/OfflineStorageTest.java
@@ -269,4 +269,26 @@ public class OfflineStorageTest {
         boolean saved = instance.persistHarvestDataToDisk(payload);
         Assert.assertFalse("Should return false when payload exceeds cap", saved);
     }
+
+    @Test
+    public void testOversizedPayloadDoesNotEvictExistingFiles() {
+        // Store a small payload that fits within cap
+        instance.setOfflineStorageSize(50);
+        Assert.assertTrue(instance.persistHarvestDataToDisk("{'ok':'data'}"));
+
+        File[] filesBefore = instance.getOfflineStorage().listFiles();
+        Assert.assertNotNull(filesBefore);
+        Assert.assertEquals(1, filesBefore.length);
+
+        // Payload larger than the cap — should be rejected without evicting the stored file
+        String oversized = "{'k':'v','padding':'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'}";
+        Assert.assertTrue("oversized payload must exceed cap for this test", oversized.getBytes().length > 50);
+
+        boolean saved = instance.persistHarvestDataToDisk(oversized);
+        Assert.assertFalse("Oversized payload should be rejected", saved);
+
+        File[] filesAfter = instance.getOfflineStorage().listFiles();
+        Assert.assertNotNull(filesAfter);
+        Assert.assertEquals("Existing files must not be evicted by an oversized payload", 1, filesAfter.length);
+    }
 }

--- a/agent/src/test/java/com/newrelic/agent/android/util/OfflineStorageTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/util/OfflineStorageTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.newrelic.agent.android.SpyContext;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,7 +12,10 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(RobolectricTestRunner.class)
 public class OfflineStorageTest {
@@ -21,6 +25,15 @@ public class OfflineStorageTest {
     @Before
     public void setUp() {
         spyContext = new SpyContext().getContext();
+        instance = new OfflineStorage(spyContext);
+        instance.cleanOfflineFiles();
+    }
+
+    @After
+    public void tearDown() {
+        instance.cleanOfflineFiles();
+        OfflineStorage.setOfflineStorageTTL(OfflineStorage.DEFAULT_OFFLINE_STORAGE_TTL);
+        instance.setOfflineStorageSize(100 * 1024 * 1024);
     }
 
     @Test
@@ -32,6 +45,8 @@ public class OfflineStorageTest {
         File offlineFolder = instance.getOfflineStorage();
         Assert.assertNotNull(offlineFolder);
         Assert.assertTrue(offlineFolder.exists());
+
+        instance.persistHarvestDataToDisk("{'testKey': 'testValue'}");
 
         File fakeFile = new File("test");
         instance.setOfflineStorage(fakeFile);
@@ -170,5 +185,88 @@ public class OfflineStorageTest {
                 }
             }
         }.start();
+    }
+
+    @Test
+    public void testDefaultTTL() {
+        Assert.assertEquals(TimeUnit.DAYS.toMillis(7), OfflineStorage.DEFAULT_OFFLINE_STORAGE_TTL);
+        Assert.assertEquals(OfflineStorage.DEFAULT_OFFLINE_STORAGE_TTL, OfflineStorage.getOfflineStorageTTL());
+    }
+
+    @Test
+    public void testSetGetTTL() {
+        long customTTL = TimeUnit.DAYS.toMillis(14);
+        OfflineStorage.setOfflineStorageTTL(customTTL);
+        Assert.assertEquals(customTTL, OfflineStorage.getOfflineStorageTTL());
+    }
+
+    @Test
+    public void testExpiredFilesAreDeletedOnRead() {
+        instance.persistHarvestDataToDisk("{'expired': 'data'}");
+
+        File[] files = instance.getOfflineStorage().listFiles();
+        Assert.assertNotNull(files);
+        Assert.assertEquals(1, files.length);
+        Assert.assertTrue(files[0].setLastModified(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8)));
+
+        Map<String, String> data = instance.getAllOfflineData();
+        Assert.assertEquals(0, data.size());
+        Assert.assertFalse("Expired file should be deleted from disk", files[0].exists());
+    }
+
+    @Test
+    public void testNonExpiredFilesAreReturned() {
+        instance.persistHarvestDataToDisk("{'fresh': 'data'}");
+
+        Map<String, String> data = instance.getAllOfflineData();
+        Assert.assertEquals(1, data.size());
+    }
+
+    @Test
+    public void testMixedExpiredAndValidFiles() throws InterruptedException {
+        instance.persistHarvestDataToDisk("{'expired': 'data'}");
+        Thread.sleep(10);
+        instance.persistHarvestDataToDisk("{'fresh': 'data'}");
+
+        File[] files = instance.getOfflineStorage().listFiles();
+        Assert.assertNotNull(files);
+        Assert.assertEquals(2, files.length);
+        Arrays.sort(files, Comparator.comparingLong(File::lastModified));
+        Assert.assertTrue(files[0].setLastModified(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8)));
+
+        Map<String, String> data = instance.getAllOfflineData();
+        Assert.assertEquals(1, data.size());
+        Assert.assertFalse("Expired file should be deleted", files[0].exists());
+        Assert.assertTrue("Fresh file should be retained", files[1].exists());
+    }
+
+    @Test
+    public void testLruEvictionEvictsOldestFile() throws InterruptedException {
+        // 3 payloads of ~24 bytes each; cap set so 2 fit but adding a 3rd triggers eviction
+        String payload = "{'k':'v','n':'12345678'}";
+        instance.setOfflineStorageSize(60);
+
+        instance.persistHarvestDataToDisk(payload);
+        Thread.sleep(10);
+        instance.persistHarvestDataToDisk(payload);
+
+        File[] filesBefore = instance.getOfflineStorage().listFiles();
+        Assert.assertEquals(2, filesBefore.length);
+        Arrays.sort(filesBefore, Comparator.comparingLong(File::lastModified));
+        File oldest = filesBefore[0];
+
+        boolean saved = instance.persistHarvestDataToDisk(payload);
+        Assert.assertTrue("New payload should be saved after eviction", saved);
+        Assert.assertFalse("Oldest file should have been evicted", oldest.exists());
+    }
+
+    @Test
+    public void testPersistReturnsFalseWhenEvictionCannotFreeEnoughSpace() {
+        // Cap smaller than a single payload — eviction cannot help
+        String payload = "{'k':'v','n':'12345678'}";
+        instance.setOfflineStorageSize(10);
+
+        boolean saved = instance.persistHarvestDataToDisk(payload);
+        Assert.assertFalse("Should return false when payload exceeds cap", saved);
     }
 }


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-577137](https://newrelic.atlassian.net/browse/NR-577137)

## Summary

- Offline storage had no TTL: files persisted indefinitely and could be re-uploaded well past the backend's data retention window
- LRU eviction code existed but was broken — files were never deleted and the running byte total was never updated, making the storage cap effectively unenforced
- Adds a 7-day TTL enforced at read time and fixes the eviction loop to actually free space before rejecting new data

## Changes

### `OfflineStorage.java`
- Added `DEFAULT_OFFLINE_STORAGE_TTL` (7 days) and  `offlineStorageTTL` getters and setters 
- `getAllOfflineData()`: computes `expiryTime = now - TTL` before iterating files; any file whose `lastModified` predates the expiry is deleted and skipped
- `persistHarvestDataToDisk()`: replaced the early `return false` on capacity overflow with a sorted LRU eviction pass — files are sorted ascending by `lastModified`, deleted oldest-first while subtracting each file's size from `totalData`; returns false only if eviction still cannot bring usage below the cap

### `OfflineStorageTest.java`
- Added `@After tearDown()` to reset static `offlineStorageTTL` and `offlineStorageSize` between tests, preventing ordering dependencies
- New tests: `testDefaultTTL`, `testSetGetTTL`, `testExpiredFilesAreDeletedOnRead`, `testNonExpiredFilesAreReturned`, `testMixedExpiredAndValidFiles`, `testLruEvictionEvictsOldestFile`, `testPersistReturnsFalseWhenEvictionCannotFreeEnoughSpace`
- Fixed pre-existing `testOfflineStorageInstance` failure: `getOfflineFilePath()` returns empty string until a file has actually been persisted

## Test plan

- [ ] Run `./gradlew :agent:testReleaseUnitTest` all `OfflineStorageTest` tests pass
- [ ] Confirm expired files (backdated past 7 days) are deleted and not returned by `getAllOfflineData()`
- [ ] Confirm that when storage is full, oldest files are evicted to make room before rejecting new data
- [ ] Confirm `persistHarvestDataToDisk()` returns `false` only when eviction cannot free sufficient space


[NR-577137]: https://new-relic.atlassian.net/browse/NR-577137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ