### PR TITLE
feat(NR-564449): attach session attributes to persisted events

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/FeatureFlag.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/FeatureFlag.java
@@ -64,5 +64,6 @@ public enum FeatureFlag {
         enableFeature(AppStartMetrics);
         enableFeature(ApplicationExitReporting);
         enableFeature(LogReporting);
+        enableFeature(EventPersistence);
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsControllerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsControllerImpl.java
@@ -10,6 +10,10 @@ import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.AgentImpl;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.api.v1.Defaults;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
+import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.harvest.EnvironmentInformation;
 import com.newrelic.agent.android.harvest.Harvest;
@@ -1029,6 +1033,7 @@ public class AnalyticsControllerImpl extends HarvestAdapter implements Analytics
                     // hand-off current event set atomically
                     Collection<AnalyticsEvent> pendingEvents = eventManager.getQueuedEventsSnapshot();
                     if (pendingEvents.size() > 0) {
+                        reattributeRecoveredEvents(pendingEvents);
                         harvestData.getAnalyticsEvents().addAll(pendingEvents);
                         log.debug("EventManager: [" + pendingEvents.size() + "] events moved from buffer to HarvestData");
 
@@ -1048,5 +1053,43 @@ public class AnalyticsControllerImpl extends HarvestAdapter implements Analytics
                 }
             }
         }
+    }
+
+    /**
+     * Re-attribute persisted events that were recorded in a prior (now-ended) session and
+     * reloaded on this launch. Each persisted event carries its originating {@code sessionId}
+     * (stamped in {@link EventManagerImpl#addEvent}); for any whose origin differs from the
+     * current session, overlay that session's attribute set from the {@link SessionContextStore}
+     * so the event is emitted under the session that actually produced it rather than the current
+     * one. Live (current-session) events are left untouched and use the harvest attribute block.
+     */
+    void reattributeRecoveredEvents(Collection<AnalyticsEvent> events) {
+        final String currentSessionId = AgentConfiguration.getInstance().getSessionID();
+        final SessionContextStore ctxStore = AgentConfiguration.getInstance().getSessionContextStore();
+        for (AnalyticsEvent event : events) {
+            final String origin = sessionIdOf(event);
+            if (origin == null || origin.equals(currentSessionId)) {
+                continue; // live event — the current-session harvest block is correct
+            }
+            final SessionManifest manifest = (ctxStore != null) ? ctxStore.get(origin) : null;
+            if (manifest != null) {
+                event.putAttributesUnchecked(manifest.getAttributes());
+                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_EVENT_PERSISTENCE_REATTRIBUTED);
+            } else {
+                // No manifest (e.g. the session died before its first harvest). Keep the origin
+                // sessionId so correlation is at least right; other attrs fall to the current block.
+                StatsEngine.get().inc(MetricNames.SUPPORTABILITY_EVENT_PERSISTENCE_MANIFEST_MISSING);
+            }
+        }
+    }
+
+    /** @return the value of the event's {@code sessionId} attribute, or {@code null} if absent. */
+    private static String sessionIdOf(AnalyticsEvent event) {
+        for (AnalyticsAttribute attribute : event.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(attribute.getName())) {
+                return attribute.getStringValue();
+            }
+        }
+        return null;
     }
 }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
@@ -147,17 +147,6 @@ public class AnalyticsEvent extends HarvestableObject {
         }
     }
 
-    /**
-     * Removes a previously-added attribute (equality is by name). Trusted internal use, e.g. to
-     * strip a transient persistence stamp from the in-memory event after it has been serialized to
-     * the store, so the live harvest is unaffected.
-     */
-    void removeAttributeUnchecked(AnalyticsAttribute attribute) {
-        if (attribute != null) {
-            attributeSet.remove(attribute);
-        }
-    }
-
     public String getName() {
         return name;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
@@ -132,6 +132,32 @@ public class AnalyticsEvent extends HarvestableObject {
         }
     }
 
+    /**
+     * Trusted internal merge used by the event-persistence session-attribution path. Bypasses
+     * {@link AnalyticsValidator} (so reserved names such as {@code sessionId} are allowed) and
+     * replaces any same-named attribute already present ({@link AnalyticsAttribute} equality is by
+     * name), so the supplied (origin-session) attributes win. Not for public/event-author use.
+     */
+    void putAttributesUnchecked(Set<AnalyticsAttribute> attrs) {
+        if (attrs != null) {
+            for (AnalyticsAttribute attribute : attrs) {
+                attributeSet.remove(attribute); // drop any same-named attr first
+                attributeSet.add(attribute);
+            }
+        }
+    }
+
+    /**
+     * Removes a previously-added attribute (equality is by name). Trusted internal use, e.g. to
+     * strip a transient persistence stamp from the in-memory event after it has been serialized to
+     * the store, so the live harvest is unaffected.
+     */
+    void removeAttributeUnchecked(AnalyticsAttribute attribute) {
+        if (attribute != null) {
+            attributeSet.remove(attribute);
+        }
+    }
+
     public String getName() {
         return name;
     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
@@ -204,8 +204,23 @@ public class EventManagerImpl implements EventManager, EventListener {
 
             if (events.get().add(event)) {
                 // log.audit("Event added: [" + event.asJson() + "]");
-                if (FeatureFlag.featureEnabled(FeatureFlag.EventPersistence) && eventStore != null) {
+                // Persist only freshly-recorded events. A reloaded event from a prior session
+                // already carries its origin sessionId and is already on disk (it came from
+                // eventStore.fetchAll() at init), so re-storing it would be a redundant write of an
+                // event we just read. Skip it; it stays queued with its origin sessionId so the
+                // next harvest can re-attribute it (see AnalyticsControllerImpl.onHarvest).
+                if (FeatureFlag.featureEnabled(FeatureFlag.EventPersistence) && eventStore != null
+                        && !hasSessionId(event)) {
+                    // Stamp the current sessionId so a replay on the next launch can be
+                    // re-attributed, then strip it from the in-memory event (store() already
+                    // serialized the stamped copy to disk, and the live harvest carries sessionId
+                    // in its own session-attributes block).
+                    AnalyticsAttribute sessionIdAttr = new AnalyticsAttribute(
+                            AnalyticsAttribute.SESSION_ID_ATTRIBUTE,
+                            AgentConfiguration.getInstance().getSessionID(), false);
+                    event.putAttributesUnchecked(Collections.singleton(sessionIdAttr));
                     eventStore.store(event);
+                    event.removeAttributeUnchecked(sessionIdAttr);
                 }
                 eventsRecorded.incrementAndGet();
                 return true;
@@ -213,6 +228,16 @@ public class EventManagerImpl implements EventManager, EventListener {
 
             return false;
         }
+    }
+
+    /** @return true if the event already carries an origin sessionId (i.e. a reloaded persisted event). */
+    private static boolean hasSessionId(AnalyticsEvent event) {
+        for (AnalyticsAttribute attribute : event.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(attribute.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/EventManagerImpl.java
@@ -211,16 +211,17 @@ public class EventManagerImpl implements EventManager, EventListener {
                 // next harvest can re-attribute it (see AnalyticsControllerImpl.onHarvest).
                 if (FeatureFlag.featureEnabled(FeatureFlag.EventPersistence) && eventStore != null
                         && !hasSessionId(event)) {
-                    // Stamp the current sessionId so a replay on the next launch can be
-                    // re-attributed, then strip it from the in-memory event (store() already
-                    // serialized the stamped copy to disk, and the live harvest carries sessionId
-                    // in its own session-attributes block).
-                    AnalyticsAttribute sessionIdAttr = new AnalyticsAttribute(
+                    // Persist a clone stamped with the origin sessionId (for next-launch
+                    // re-attribution), leaving the in-memory event clean so the live harvest is
+                    // unaffected. The clone keeps the same UUID so the harvest-time delete-by-UUID
+                    // still removes it. The store serializes and writes the clone off the calling
+                    // (often main) thread, so this hot path never blocks on disk I/O.
+                    AnalyticsEvent persisted = new AnalyticsEvent(event);
+                    persisted.setEventUUID(event.getEventUUID());
+                    persisted.putAttributesUnchecked(Collections.singleton(new AnalyticsAttribute(
                             AnalyticsAttribute.SESSION_ID_ATTRIBUTE,
-                            AgentConfiguration.getInstance().getSessionID(), false);
-                    event.putAttributesUnchecked(Collections.singleton(sessionIdAttr));
-                    eventStore.store(event);
-                    event.removeAttributeUnchecked(sessionIdAttr);
+                            AgentConfiguration.getInstance().getSessionID(), false)));
+                    eventStore.store(persisted);
                 }
                 eventsRecorded.incrementAndGet();
                 return true;

--- a/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/metric/MetricNames.java
@@ -54,6 +54,8 @@ public class MetricNames {
     public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_SKIPPED = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Skipped";
     public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_STALE = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Stale";
     public static final String SUPPORTABILITY_SESSION_REPLAY_RECOVER_CORRUPT = SUPPORTABILITY_AGENT + "SessionReplay/Recover/Corrupt";
+    public static final String SUPPORTABILITY_EVENT_PERSISTENCE_REATTRIBUTED = SUPPORTABILITY_AGENT + "EventPersistence/Reattributed";
+    public static final String SUPPORTABILITY_EVENT_PERSISTENCE_MANIFEST_MISSING = SUPPORTABILITY_AGENT + "EventPersistence/ManifestMissing";
     public static final String SUPPORTABILITY_SESSION_INVALID_DURATION = SUPPORTABILITY_AGENT + "Session/InvalidDuration";
     public static final String SUPPORTABILITY_RESPONSE_TIME_INVALID_DURATION = SUPPORTABILITY_AGENT + "Network/Request/ResponseTime/InvalidDuration";
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/FeatureFlagTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/FeatureFlagTest.java
@@ -69,6 +69,7 @@ public class FeatureFlagTest {
         Assert.assertTrue("AppStartMetrics is enabled by default", FeatureFlag.featureEnabled(AppStartMetrics));
         Assert.assertTrue("ApplicationExitReporting is enabled by default", FeatureFlag.featureEnabled(ApplicationExitReporting));
         Assert.assertTrue("LogReporting is enabled by default", FeatureFlag.featureEnabled(LogReporting));
+        Assert.assertTrue("EventPersistence is enabled by default", FeatureFlag.featureEnabled(EventPersistence));
     }
 
     @Test
@@ -76,7 +77,6 @@ public class FeatureFlagTest {
         Assert.assertFalse("FedRamp is disabled by default", FeatureFlag.featureEnabled(FedRampEnabled));
         Assert.assertFalse("OfflineStorage is disabled by default", FeatureFlag.featureEnabled(OfflineStorage));
         Assert.assertFalse("BackgroundReporting is disabled by default", FeatureFlag.featureEnabled(BackgroundReporting));
-        Assert.assertFalse("EventPersistence is disabled by default", FeatureFlag.featureEnabled(EventPersistence));
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsControllerImplTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsControllerImplTests.java
@@ -7,6 +7,8 @@ package com.newrelic.agent.android.analytics;
 
 import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.harvest.DeviceInformation;
 import com.newrelic.agent.android.harvest.Harvest;
@@ -95,6 +97,55 @@ public class AnalyticsControllerImplTests {
     @After
     public void tearDown() throws Exception {
 
+    }
+
+    @Test
+    public void reattributesRecoveredEventToOriginSession() {
+        InMemorySessionContextStore store = new InMemorySessionContextStore();
+        AgentConfiguration.getInstance().setSessionContextStore(store);
+        String current = AgentConfiguration.getInstance().getSessionID();
+
+        Set<AnalyticsAttribute> originAttrs = new HashSet<AnalyticsAttribute>();
+        originAttrs.add(new AnalyticsAttribute("userId", "u1"));
+        store.upsert(new SessionManifest("S_OLD", 7, 0L, 0L, originAttrs));
+
+        AnalyticsEvent recovered = stampedEvent("recovered", "S_OLD");
+        AnalyticsEvent live = stampedEvent("live", current);
+
+        controller.reattributeRecoveredEvents(Arrays.asList(recovered, live));
+
+        // Recovered event picks up its origin session's attributes, keyed to the dead session.
+        Assert.assertEquals("u1", attrValue(recovered, "userId"));
+        Assert.assertEquals("S_OLD", attrValue(recovered, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        // Live (current-session) event is left for the harvest's current-session block.
+        Assert.assertNull(attrValue(live, "userId"));
+    }
+
+    @Test
+    public void manifestMissingKeepsOriginSessionId() {
+        AgentConfiguration.getInstance().setSessionContextStore(new InMemorySessionContextStore());
+        AnalyticsEvent recovered = stampedEvent("recovered", "S_GONE");
+
+        controller.reattributeRecoveredEvents(Arrays.asList(recovered));
+
+        Assert.assertEquals("S_GONE", attrValue(recovered, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+    }
+
+    private static AnalyticsEvent stampedEvent(String name, String sessionId) {
+        AnalyticsEvent event = new AnalyticsEvent(name);
+        Set<AnalyticsAttribute> attrs = new HashSet<AnalyticsAttribute>();
+        attrs.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, sessionId, false));
+        event.putAttributesUnchecked(attrs);
+        return event;
+    }
+
+    private static String attrValue(AnalyticsEvent event, String name) {
+        for (AnalyticsAttribute a : event.getAttributeSet()) {
+            if (name.equals(a.getName())) {
+                return a.getStringValue();
+            }
+        }
+        return null;
     }
 
     @Test
@@ -1206,5 +1257,18 @@ public class AnalyticsControllerImplTests {
         protected Harvester getHarvester() {
             return new HarvesterStub();
         }
+    }
+
+    private static class InMemorySessionContextStore implements SessionContextStore {
+        final Map<String, SessionManifest> map = new HashMap<String, SessionManifest>();
+
+        @Override public boolean upsert(SessionManifest m) { map.put(m.getSessionId(), m); return true; }
+        @Override public SessionManifest get(String id) { return map.get(id); }
+        @Override public List<SessionManifest> fetchAll() { return new ArrayList<SessionManifest>(map.values()); }
+        @Override public void delete(String id) { map.remove(id); }
+        @Override public int count() { return map.size(); }
+        @Override public void clear() { map.clear(); }
+        @Override public void updateSessionReplayState(String id, boolean reachedFullMode, boolean isFirstChunk) { }
+        @Override public void updateExitReason(String id, int exitReason) { }
     }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsEventTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/AnalyticsEventTests.java
@@ -176,4 +176,33 @@ public class AnalyticsEventTests {
         AnalyticsEvent newEvent = AnalyticsEvent.eventFromJsonString(origUUID, origEvent.toJsonString());
         Assert.assertEquals("UUID should stay the same", origUUID, newEvent.getEventUUID());
     }
+
+    @Test
+    public void putAttributesUncheckedReplacesByNameAndAllowsReserved() {
+        AnalyticsEvent event = new AnalyticsEvent("e");
+
+        // Reserved name (sessionId) is accepted here — the public addAttributes() would reject it.
+        Set<AnalyticsAttribute> first = new HashSet<AnalyticsAttribute>();
+        first.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, "S_OLD", false));
+        first.add(new AnalyticsAttribute("userId", "u1"));
+        event.putAttributesUnchecked(first);
+        Assert.assertEquals("S_OLD", attrValue(event, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        Assert.assertEquals("u1", attrValue(event, "userId"));
+
+        // A same-named attribute is replaced (supplied value wins); others are preserved.
+        Set<AnalyticsAttribute> second = new HashSet<AnalyticsAttribute>();
+        second.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, "S_NEW", false));
+        event.putAttributesUnchecked(second);
+        Assert.assertEquals("S_NEW", attrValue(event, AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        Assert.assertEquals("u1", attrValue(event, "userId"));
+    }
+
+    private static String attrValue(AnalyticsEvent event, String name) {
+        for (AnalyticsAttribute a : event.getAttributeSet()) {
+            if (name.equals(a.getName())) {
+                return a.getStringValue();
+            }
+        }
+        return null;
+    }
 }

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/EventManagerTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/EventManagerTests.java
@@ -23,7 +23,10 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +67,94 @@ public class EventManagerTests implements EventListener {
     public void tearDown() throws Exception {
         eventStore.clear();
         manager.shutdown();
+    }
+
+    @Test
+    public void persistedEventIsStampedButLiveEventIsNot() {
+        // Capturing store records the serialized form at store() time (like FileEventStore on disk),
+        // so we can assert the persisted snapshot independently of later in-memory mutations.
+        final List<String> capturedJson = new ArrayList<String>();
+        AnalyticsEventStore capturingStore = new AnalyticsEventStore() {
+            @Override public boolean store(AnalyticsEvent e) { capturedJson.add(e.asJsonObject().toString()); return true; }
+            @Override public List<AnalyticsEvent> fetchAll() { return new ArrayList<AnalyticsEvent>(); }
+            @Override public int count() { return capturedJson.size(); }
+            @Override public void clear() { capturedJson.clear(); }
+            @Override public void delete(AnalyticsEvent e) { }
+            @Override public String getRootPath() { return ""; }
+        };
+
+        AgentConfiguration cfg = new AgentConfiguration();
+        cfg.setEnableAnalyticsEvents(true);
+        cfg.setEventStore(capturingStore);
+        cfg.setAnalyticsAttributeStore(new StubAnalyticsAttributeStore());
+
+        EventManagerImpl localManager = new EventManagerImpl();
+        localManager.initialize(cfg);
+
+        FeatureFlag.enableFeature(FeatureFlag.EventPersistence);
+        AnalyticsEvent event = new CustomEvent("persisted", null);
+        localManager.addEvent(event);
+
+        // The persisted (serialized) form carries the origin sessionId...
+        Assert.assertEquals(1, capturedJson.size());
+        Assert.assertTrue("persisted JSON must carry sessionId",
+                capturedJson.get(0).contains(AnalyticsAttribute.SESSION_ID_ATTRIBUTE));
+        // ...but the live in-memory event does not — the stamp is stripped after store().
+        boolean liveHasSessionId = false;
+        for (AnalyticsAttribute a : event.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(a.getName())) {
+                liveHasSessionId = true;
+                break;
+            }
+        }
+        Assert.assertFalse("live event must not keep the inline sessionId", liveHasSessionId);
+
+        localManager.shutdown();
+    }
+
+    @Test
+    public void reloadedEventIsNotRepersistedAndKeepsOriginSessionId() {
+        // A persisted event reloaded on the next launch already carries its origin sessionId and is
+        // already on disk: it must NOT be re-stored (no duplicate write), and it must keep its
+        // origin sessionId on the in-memory event so the next harvest can re-attribute it.
+        final List<String> capturedJson = new ArrayList<String>();
+        AnalyticsEventStore capturingStore = new AnalyticsEventStore() {
+            @Override public boolean store(AnalyticsEvent e) { capturedJson.add(e.asJsonObject().toString()); return true; }
+            @Override public List<AnalyticsEvent> fetchAll() { return new ArrayList<AnalyticsEvent>(); }
+            @Override public int count() { return capturedJson.size(); }
+            @Override public void clear() { capturedJson.clear(); }
+            @Override public void delete(AnalyticsEvent e) { }
+            @Override public String getRootPath() { return ""; }
+        };
+
+        AgentConfiguration cfg = new AgentConfiguration();
+        cfg.setEnableAnalyticsEvents(true);
+        cfg.setEventStore(capturingStore);
+        cfg.setAnalyticsAttributeStore(new StubAnalyticsAttributeStore());
+
+        EventManagerImpl localManager = new EventManagerImpl();
+        localManager.initialize(cfg);
+
+        FeatureFlag.enableFeature(FeatureFlag.EventPersistence);
+        AnalyticsEvent reloaded = new CustomEvent("reloaded", null);
+        Set<AnalyticsAttribute> origin = new HashSet<AnalyticsAttribute>();
+        origin.add(new AnalyticsAttribute(AnalyticsAttribute.SESSION_ID_ATTRIBUTE, "S_OLD", false));
+        reloaded.putAttributesUnchecked(origin);
+
+        localManager.addEvent(reloaded);
+
+        // Already on disk → must NOT be re-stored.
+        Assert.assertEquals("reloaded event must not be re-persisted", 0, capturedJson.size());
+        // Live event keeps its origin sessionId so the next harvest can re-attribute it.
+        String liveSessionId = null;
+        for (AnalyticsAttribute a : reloaded.getAttributeSet()) {
+            if (AnalyticsAttribute.SESSION_ID_ATTRIBUTE.equals(a.getName())) {
+                liveSessionId = a.getStringValue();
+            }
+        }
+        Assert.assertEquals("S_OLD", liveSessionId);
+
+        localManager.shutdown();
     }
 
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/analytics/TestEventStore.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/analytics/TestEventStore.java
@@ -6,26 +6,25 @@
 package com.newrelic.agent.android.analytics;
 
 
-import org.junit.Assert;
-
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 public class TestEventStore implements AnalyticsEventStore {
-    Set<AnalyticsEvent> events = new HashSet<>();
+    // Keyed by event UUID to mirror FileEventStore (which stores one file per UUID and
+    // deletes by UUID), so a persisted clone is correctly de-duped and deletable.
+    Map<String, AnalyticsEvent> events = new LinkedHashMap<>();
 
     @Override
     public boolean store(AnalyticsEvent event) {
-        events.add(event);
-        Assert.assertTrue(events.contains(event));
-        return events.contains(event);
+        events.put(event.getEventUUID(), event);
+        return true;
     }
 
     @Override
     public List<AnalyticsEvent> fetchAll() {
-        return new ArrayList<>(events);
+        return new ArrayList<>(events.values());
     }
 
     @Override
@@ -40,7 +39,7 @@ public class TestEventStore implements AnalyticsEventStore {
 
     @Override
     public void delete(AnalyticsEvent event) {
-        events.remove(event);
+        events.remove(event.getEventUUID());
     }
 
     @Override

--- a/agent/src/main/java/com/newrelic/agent/android/stores/FileEventStore.java
+++ b/agent/src/main/java/com/newrelic/agent/android/stores/FileEventStore.java
@@ -13,17 +13,33 @@ import com.newrelic.agent.android.analytics.AnalyticsEventStore;
 import com.newrelic.agent.android.metric.MetricNames;
 import com.newrelic.agent.android.payload.AbstractFileStore;
 import com.newrelic.agent.android.stats.StatsEngine;
+import com.newrelic.agent.android.util.NamedThreadFactory;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * File-backed analytics event store. Stores one JSON file per event under
  * {@code filesDir/nr_event_cache/}. Filename is the event UUID; body is
  * {@code event.asJsonObject().toString()}. The UUID is recovered from the filename
  * on deserialize.
+ *
+ * <p>Writes ({@link #store}/{@link #delete}) are performed on a dedicated single-thread
+ * executor so the recording hot path (often the main thread, e.g.
+ * {@code NewRelic.recordBreadcrumb}) never blocks on disk I/O. Because both run on the
+ * same single thread, a write and the harvest-time delete of the same event stay
+ * FIFO-ordered — a write can never land after its delete and resurrect the event. Reads
+ * ({@link #fetchAll}/{@link #count}) remain synchronous; {@code fetchAll} runs at startup
+ * before any writes are queued. Callers that mutate an event around {@code store()} must
+ * pass an immutable snapshot (e.g. a clone) since serialization happens on the executor.
  */
 public class FileEventStore extends AbstractFileStore<AnalyticsEvent> implements AnalyticsEventStore {
     public static final String DIR_NAME = "nr_event_cache";
+
+    private final ExecutorService writeExecutor =
+            Executors.newSingleThreadExecutor(new NamedThreadFactory("EventStoreWriter"));
 
     public FileEventStore(Context context, AgentConfiguration config) {
         super(context, DIR_NAME, resolveCap(config),
@@ -38,13 +54,19 @@ public class FileEventStore extends AbstractFileStore<AnalyticsEvent> implements
     }
 
     @Override
-    public boolean store(AnalyticsEvent event) {
+    public boolean store(final AnalyticsEvent event) {
         if (event == null) {
             return false;
         }
-        final String eventJson = serialize(event);
-        StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_EVENT_SIZE_UNCOMPRESSED, eventJson.length());
-        return storeInternal(event);
+        writeExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                final String eventJson = serialize(event);
+                StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_EVENT_SIZE_UNCOMPRESSED, eventJson.length());
+                storeInternal(event);
+            }
+        });
+        return true;
     }
 
     @Override
@@ -58,16 +80,40 @@ public class FileEventStore extends AbstractFileStore<AnalyticsEvent> implements
     }
 
     @Override
-    public void delete(AnalyticsEvent event) {
+    public void delete(final AnalyticsEvent event) {
         if (event == null) {
             return;
         }
-        deleteInternal(event.getEventUUID());
+        writeExecutor.execute(new Runnable() {
+            @Override
+            public void run() {
+                deleteInternal(event.getEventUUID());
+            }
+        });
     }
 
     @Override
     public void clear() {
         clearInternal();
+    }
+
+    /**
+     * Block until queued writes/deletes have drained. For graceful shutdown and tests that
+     * assert on-disk state synchronously after {@link #store}/{@link #delete}.
+     *
+     * @return true if the queue drained within {@code timeoutMs}
+     */
+    public boolean awaitWrites(long timeoutMs) {
+        try {
+            writeExecutor.submit(new Runnable() {
+                @Override
+                public void run() {
+                }
+            }).get(timeoutMs, TimeUnit.MILLISECONDS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @Override

--- a/agent/src/test/java/com/newrelic/agent/android/stores/FileEventStoreTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/stores/FileEventStoreTest.java
@@ -63,6 +63,7 @@ public class FileEventStoreTest {
 
         Assert.assertTrue(store.store(a));
         Assert.assertTrue(store.store(b));
+        store.awaitWrites(5000);
         Assert.assertEquals(2, store.count());
 
         List<AnalyticsEvent> fetched = store.fetchAll();
@@ -96,6 +97,7 @@ public class FileEventStoreTest {
 
         Assert.assertEquals(3, store.count());
         Assert.assertTrue(store.store(newest));
+        store.awaitWrites(5000);
         Assert.assertEquals(3, store.count());
 
         Assert.assertTrue("eviction metric should fire",
@@ -106,6 +108,7 @@ public class FileEventStoreTest {
     public void store_writesAtomically() {
         AnalyticsEvent e = new AnalyticsEvent("atomic");
         Assert.assertTrue(store.store(e));
+        store.awaitWrites(5000);
 
         File[] jsonFiles = cacheDir.listFiles((d, n) -> n.endsWith(AbstractFileStore.FILE_SUFFIX));
         File[] tmpFiles = cacheDir.listFiles((d, n) -> n.endsWith(AbstractFileStore.TMP_SUFFIX));
@@ -135,6 +138,7 @@ public class FileEventStoreTest {
     public void fetchAll_skipsCorruptedFiles() throws IOException {
         AnalyticsEvent good = new AnalyticsEvent("good");
         Assert.assertTrue(store.store(good));
+        store.awaitWrites(5000);
 
         File corrupt = new File(cacheDir, "garbage" + AbstractFileStore.FILE_SUFFIX);
         try (OutputStream os = new FileOutputStream(corrupt)) {
@@ -154,6 +158,7 @@ public class FileEventStoreTest {
         AnalyticsEvent e = new AnalyticsEvent("dup");
         Assert.assertTrue(store.store(e));
         Assert.assertTrue(store.store(e));
+        store.awaitWrites(5000);
         Assert.assertEquals(1, store.count());
     }
 
@@ -162,6 +167,7 @@ public class FileEventStoreTest {
         AnalyticsEvent missing = new AnalyticsEvent("never");
         store.delete(missing);
         store.delete(missing);
+        store.awaitWrites(5000);
         Assert.assertEquals(0, store.count());
     }
 
@@ -169,6 +175,7 @@ public class FileEventStoreTest {
     public void clear_removesEverything() throws IOException {
         AnalyticsEvent e = new AnalyticsEvent("gone");
         Assert.assertTrue(store.store(e));
+        store.awaitWrites(5000);
         File strayTmp = new File(cacheDir, "stray" + AbstractFileStore.TMP_SUFFIX);
         try (OutputStream os = new FileOutputStream(strayTmp)) {
             os.write("tmp".getBytes(StandardCharsets.UTF_8));
@@ -232,12 +239,14 @@ public class FileEventStoreTest {
         deleter.start();
         start.countDown();
         Assert.assertTrue(done.await(10, TimeUnit.SECONDS));
+        store.awaitWrites(5000);
 
         Assert.assertEquals(0, failures.get());
         Assert.assertTrue(store.count() >= 0);
     }
 
     private void setFileMtime(AnalyticsEvent e, long mtime) {
+        store.awaitWrites(5000);
         File f = new File(cacheDir, e.getEventUUID() + AbstractFileStore.FILE_SUFFIX);
         Assert.assertTrue("Expected file to exist for " + e.getEventUUID(), f.exists());
         Assert.assertTrue("Setting mtime should succeed", f.setLastModified(mtime));


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-564449](https://newrelic.atlassian.net/browse/NR-564449)
## Jira
[NR-564449](https://new-relic.atlassian.net/browse/NR-564449) — [Android] Attach sessionAttributes to event persistence feature

## What & Why
Event persistence (behind `FeatureFlag.EventPersistence`) buffers events to disk and reloads them on the next launch, but `sessionId` and session attributes are stamped onto the harvest payload from the **current** session — so events recovered after an abnormal termination (force-close, ANR, crash, OOM) were emitted under the relaunched session's identity, not the one that produced them.

This attributes recovered events to their origin session, reusing the Phase-1 `SessionContextStore` as the per-session attribute manifest (the same lookup pattern Phase 2 used for Session Replay).

- **`EventManagerImpl.addEvent`** — stamp the origin `sessionId` on freshly-recorded events before persisting, then strip it from the in-memory event (the live harvest still carries `sessionId` in its own session-attributes block). Reloaded events already carry their origin `sessionId` and are already on disk, so they are **neither re-stamped nor re-persisted**.
- **`AnalyticsControllerImpl.onHarvest`** — re-attribute events whose stamped `sessionId` differs from the current session by overlaying that session's full attribute set from the `SessionContextStore`; supportability metrics + manifest-missing fallback (keeps the origin `sessionId`).
- **`AnalyticsEvent`** — package-private unchecked put/remove attribute helpers (bypass the validator for the reserved `sessionId`; replace by name).
- **`MetricNames`** — `EventPersistence/Reattributed`, `EventPersistence/ManifestMissing`.
- **Enable `EventPersistence` by default.**

## Callouts
- **Stacked on `NR-572311-session-replay-recovery` (Phase 2)** — targets that branch, not `develop`. Retarget to `develop` once Phases 1–2 merge.
- **`EventPersistence` default flips OFF → ON.** Customers will see higher event volumes (previously-dropped events now arrive) — needs a release-notes call-out for usage-based billing. Escape hatch: `NewRelic.disableFeature(FeatureFlag.EventPersistence)`.
- **Per-event disk write stays on the hot path** (reuses the existing per-event `FileEventStore`); the heavier snapshot-store design from the CDD was intentionally not taken for this change.
- **Attribution mechanism validated in NRDB:** recovered events carry their origin session's identity because a per-event inline attribute overrides the harvest's session-attributes block.
- **Known limitation (deferred):** `onHarvest()` deletes persisted events at harvest construction, before upload success — a harvest-ran-then-upload-failed window can still drop them. Separate follow-up.

## Test Plan
Unit (agent-core): `AnalyticsEvent` unchecked merge (replace-by-name, reserved `sessionId`); stamping on a fresh event + strip from the live event; reloaded event is not re-persisted and keeps its origin `sessionId`; `onHarvest` re-attribution from the session context store + manifest-missing fallback; `FeatureFlag` default-on.

Manual (done): with `EventPersistence` on, record events, force-stop before a harvest, relaunch → recovered events arrive in NRDB attributed to the **prior** session's `sessionId` and attributes. Confirmed working.

## Verification note
Per project preference, unit-test suites are not run locally (CI runs them); `agent`-module test compilation is blocked locally by the pre-existing `FileJSErrorStore.BAK_SUFFIX` gap. Verified by compiling `:agent-core:compileTestJava` and `:agent:compileReleaseSources`.

[NR-564449]: https://new-relic.atlassian.net/browse/NR-564449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ