### PR TITLE
fix(NR-581961): attribute native crashes to their origin session

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
@@ -20,7 +20,11 @@ import com.newrelic.agent.android.harvest.HarvestAdapter;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.sessioncontext.SessionContextStore;
+import com.newrelic.agent.android.sessioncontext.SessionManifest;
 import com.newrelic.agent.android.stats.StatsEngine;
+
+import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -147,9 +151,13 @@ public class NativeReporting extends HarvestAdapter {
             StatsEngine.SUPPORTABILITY.inc(MetricNames.SUPPORTABILITY_NDK_REPORTS_CRASH);
 
             final AnalyticsControllerImpl analyticsController = AnalyticsControllerImpl.getInstance();
-            final Set<AnalyticsAttribute> sessionAttributes = new HashSet<AnalyticsAttribute>() {{
-                addAll(analyticsController.getSessionAttributes());
-            }};
+            // A native crash is captured in the crashing session but flushed on the next launch
+            // (after the process dies). Attribute it to the session that actually crashed — its
+            // sessionId is embedded in the native report ("backtrace.sessionid") — by resolving
+            // that session's attributes from the SessionContextStore rather than stamping the
+            // current (relaunched) session's attributes.
+            final Set<AnalyticsAttribute> sessionAttributes =
+                    new HashSet<>(resolveCrashSessionAttributes(crashAsString, analyticsController));
 
             NativeException exceptionToHandle = new NativeCrashException(crashAsString);
 
@@ -225,6 +233,43 @@ public class NativeReporting extends HarvestAdapter {
             }
 
             return false;
+        }
+
+        /**
+         * Resolve the session attributes to attach to a native crash. When the crash originated in
+         * a prior session (its {@code sessionid} differs from the current one), use that session's
+         * frozen attributes from the {@link SessionContextStore} so the crash is attributed to the
+         * session that produced it. Falls back to the current session's attributes when the origin
+         * is unknown or has no stored manifest (e.g. it crashed before its first harvest).
+         */
+        private Set<AnalyticsAttribute> resolveCrashSessionAttributes(String crashAsString,
+                                                                      AnalyticsControllerImpl controller) {
+            final String originSessionId = extractNativeSessionId(crashAsString);
+            final String currentSessionId = AgentConfiguration.getInstance().getSessionID();
+            if (originSessionId != null && !originSessionId.isEmpty()
+                    && !originSessionId.equals(currentSessionId)) {
+                final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+                final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
+                if (manifest != null) {
+                    return manifest.getAttributes();
+                }
+                log.warn("NativeReporting: no session manifest for crash origin [" + originSessionId
+                        + "]; using current session attributes");
+            }
+            return controller.getSessionAttributes();
+        }
+
+        /** @return the originating sessionId from a native crash report ({@code backtrace.sessionid}), or null. */
+        private String extractNativeSessionId(String crashAsString) {
+            try {
+                final String sessionId = new JSONObject(crashAsString)
+                        .getJSONObject("backtrace")
+                        .optString("sessionid", null);
+                return (sessionId == null || sessionId.isEmpty()) ? null : sessionId;
+            } catch (Exception e) {
+                log.warn("NativeReporting: could not read sessionid from native report: " + e);
+                return null;
+            }
         }
 
     }

--- a/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
@@ -154,10 +154,19 @@ public class NativeReporting extends HarvestAdapter {
             // A native crash is captured in the crashing session but flushed on the next launch
             // (after the process dies). Attribute it to the session that actually crashed — its
             // sessionId is embedded in the native report ("backtrace.sessionid") — by resolving
-            // that session's attributes from the SessionContextStore rather than stamping the
-            // current (relaunched) session's attributes.
-            final Set<AnalyticsAttribute> sessionAttributes =
-                    new HashSet<>(resolveCrashSessionAttributes(crashAsString, analyticsController));
+            // that session's frozen attributes from the SessionContextStore rather than stamping
+            // the current (relaunched) session's attributes.
+            final String originSessionId = extractNativeSessionId(crashAsString);
+            final boolean fromPriorSession = originSessionId != null
+                    && !originSessionId.equals(AgentConfiguration.getInstance().getSessionID());
+            final SessionManifest originManifest = fromPriorSession ? lookupSessionManifest(originSessionId) : null;
+            final Set<AnalyticsAttribute> sessionAttributes = new HashSet<>(
+                    originManifest != null ? originManifest.getAttributes()
+                            : analyticsController.getSessionAttributes());
+
+            // sessionDuration (NR-487823): Java crashes record it but NDK crashes did not. Attach
+            // the crashed session's elapsed time so MobileCrash carries sessionDuration for NDK too.
+            addCrashSessionDuration(sessionAttributes, crashAsString, fromPriorSession, originManifest);
 
             NativeException exceptionToHandle = new NativeCrashException(crashAsString);
 
@@ -236,27 +245,60 @@ public class NativeReporting extends HarvestAdapter {
         }
 
         /**
-         * Resolve the session attributes to attach to a native crash. When the crash originated in
-         * a prior session (its {@code sessionid} differs from the current one), use that session's
-         * frozen attributes from the {@link SessionContextStore} so the crash is attributed to the
-         * session that produced it. Falls back to the current session's attributes when the origin
-         * is unknown or has no stored manifest (e.g. it crashed before its first harvest).
+         * Look up the manifest of the prior session that produced a native crash. Returns null (and
+         * logs) when none is stored — e.g. the session crashed before its first harvest — in which
+         * case the caller falls back to the current session's attributes.
          */
-        private Set<AnalyticsAttribute> resolveCrashSessionAttributes(String crashAsString,
-                                                                      AnalyticsControllerImpl controller) {
-            final String originSessionId = extractNativeSessionId(crashAsString);
-            final String currentSessionId = AgentConfiguration.getInstance().getSessionID();
-            if (originSessionId != null && !originSessionId.isEmpty()
-                    && !originSessionId.equals(currentSessionId)) {
-                final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
-                final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
-                if (manifest != null) {
-                    return manifest.getAttributes();
-                }
+        private SessionManifest lookupSessionManifest(String originSessionId) {
+            final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+            final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
+            if (manifest == null) {
                 log.warn("NativeReporting: no session manifest for crash origin [" + originSessionId
                         + "]; using current session attributes");
             }
-            return controller.getSessionAttributes();
+            return manifest;
+        }
+
+        /**
+         * Attach {@code sessionDuration} (seconds) to a native crash. For a crash reported within the
+         * current session, the live session duration applies. For one recovered from a prior session,
+         * derive it from the native crash timestamp ({@code backtrace.timestamp}, epoch seconds) minus
+         * that session's start ({@link SessionManifest#getSessionStartMs()}, epoch ms). No-op when it
+         * cannot be determined (e.g. prior session with no manifest), so the crash still reports.
+         */
+        private void addCrashSessionDuration(Set<AnalyticsAttribute> sessionAttributes, String crashAsString,
+                                             boolean fromPriorSession, SessionManifest originManifest) {
+            float durationSec = -1f;
+            if (!fromPriorSession) {
+                final long ms = Harvest.getMillisSinceStart();
+                if (ms != Harvest.INVALID_SESSION_DURATION) {
+                    durationSec = ms / 1000.0f;
+                }
+            } else if (originManifest != null && originManifest.getSessionStartMs() > 0L) {
+                final long crashSec = extractNativeTimestampSec(crashAsString);
+                if (crashSec > 0L) {
+                    // Subtract as longs (ms) before converting to float seconds. Subtracting at
+                    // epoch scale (~1.7e9) in float arithmetic would lose precision — a 32-bit
+                    // float's resolution there is ~128, so short durations would round to 0.
+                    final long durationMs = (crashSec * 1000L) - originManifest.getSessionStartMs();
+                    if (durationMs >= 0L) {
+                        durationSec = durationMs / 1000.0f;
+                    }
+                }
+            }
+            if (durationSec >= 0f) {
+                sessionAttributes.add(new AnalyticsAttribute(
+                        AnalyticsAttribute.SESSION_DURATION_ATTRIBUTE, durationSec));
+            }
+        }
+
+        /** @return the crash time from a native report ({@code backtrace.timestamp}, epoch seconds), or 0. */
+        private long extractNativeTimestampSec(String crashAsString) {
+            try {
+                return new JSONObject(crashAsString).getJSONObject("backtrace").optLong("timestamp", 0L);
+            } catch (Exception e) {
+                return 0L;
+            }
         }
 
         /** @return the originating sessionId from a native crash report ({@code backtrace.sessionid}), or null. */


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-581961](https://newrelic.atlassian.net/browse/NR-581961)
## Jira
[NR-581961](https://new-relic.atlassian.net/browse/NR-581961) — [Android] Native crashes attributed to the relaunched session instead of the session that crashed

## What & Why
A native (NDK) crash is captured in the crashing session, but because the process dies it is flushed on the **next launch** (`NativeReporting.onHarvestStart` → `flushPendingReports`). `onNativeCrash` built the crash's session attributes from `AnalyticsControllerImpl.getSessionAttributes()` — the **current (relaunched)** session — so the crash landed in NRDB under the wrong `sessionId`/attributes.

The native report already embeds the crashing session's id at `backtrace.sessionid` (written natively from `ManagedContext.sessionId`), but the Java side never read it. This parses it and, when it differs from the current session, resolves that session's attributes from the Phase‑1 `SessionContextStore` (`AgentConfiguration.getSessionContextStore().get(originSessionId)`), falling back to the current session's attributes when the origin is unknown or has no stored manifest (e.g. it crashed before its first harvest).

Same attribution pattern used for event persistence (NR-564449) and Session Replay recovery (NR-572311).

## Callouts
- **Stacked on `NR-575950-session-context-store` (Phase 1)** — that's the only dependency (the `SessionContextStore`). Independent of the SR-recovery and event-persistence branches. Retarget to `develop` once Phase 1 merges.
- **Out of scope:** `onNativeException` / `onApplicationNotResponding` (native unhandled exception / native ANR) go through `AgentDataController.sendAgentData` and have a similar current-session-attribution issue — to be tracked separately.

## Test Plan
Manual (API with NDK): trigger a native crash in session A (kills the process), relaunch (session B) → on the next harvest the native crash arrives in NRDB attributed to session A's `sessionId` and attributes, not B's. With no stored manifest for A, the crash still reports (current-session fallback) rather than being dropped.

## Verification note
Per project preference, unit-test suites are not run locally; verified by compiling `:agent:compileReleaseSources`.

[NR-581961]: https://new-relic.atlassian.net/browse/NR-581961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ