### PR TITLE
fix(NR-581977): record sessionDuration for NDK crashes

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
+++ b/agent/src/main/java/com/newrelic/agent/android/ndk/NativeReporting.java
@@ -154,10 +154,19 @@ public class NativeReporting extends HarvestAdapter {
             // A native crash is captured in the crashing session but flushed on the next launch
             // (after the process dies). Attribute it to the session that actually crashed — its
             // sessionId is embedded in the native report ("backtrace.sessionid") — by resolving
-            // that session's attributes from the SessionContextStore rather than stamping the
-            // current (relaunched) session's attributes.
-            final Set<AnalyticsAttribute> sessionAttributes =
-                    new HashSet<>(resolveCrashSessionAttributes(crashAsString, analyticsController));
+            // that session's frozen attributes from the SessionContextStore rather than stamping
+            // the current (relaunched) session's attributes.
+            final String originSessionId = extractNativeSessionId(crashAsString);
+            final boolean fromPriorSession = originSessionId != null
+                    && !originSessionId.equals(AgentConfiguration.getInstance().getSessionID());
+            final SessionManifest originManifest = fromPriorSession ? lookupSessionManifest(originSessionId) : null;
+            final Set<AnalyticsAttribute> sessionAttributes = new HashSet<>(
+                    originManifest != null ? originManifest.getAttributes()
+                            : analyticsController.getSessionAttributes());
+
+            // sessionDuration (NR-487823): Java crashes record it but NDK crashes did not. Attach
+            // the crashed session's elapsed time so MobileCrash carries sessionDuration for NDK too.
+            addCrashSessionDuration(sessionAttributes, crashAsString, fromPriorSession, originManifest);
 
             NativeException exceptionToHandle = new NativeCrashException(crashAsString);
 
@@ -236,27 +245,60 @@ public class NativeReporting extends HarvestAdapter {
         }
 
         /**
-         * Resolve the session attributes to attach to a native crash. When the crash originated in
-         * a prior session (its {@code sessionid} differs from the current one), use that session's
-         * frozen attributes from the {@link SessionContextStore} so the crash is attributed to the
-         * session that produced it. Falls back to the current session's attributes when the origin
-         * is unknown or has no stored manifest (e.g. it crashed before its first harvest).
+         * Look up the manifest of the prior session that produced a native crash. Returns null (and
+         * logs) when none is stored — e.g. the session crashed before its first harvest — in which
+         * case the caller falls back to the current session's attributes.
          */
-        private Set<AnalyticsAttribute> resolveCrashSessionAttributes(String crashAsString,
-                                                                      AnalyticsControllerImpl controller) {
-            final String originSessionId = extractNativeSessionId(crashAsString);
-            final String currentSessionId = AgentConfiguration.getInstance().getSessionID();
-            if (originSessionId != null && !originSessionId.isEmpty()
-                    && !originSessionId.equals(currentSessionId)) {
-                final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
-                final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
-                if (manifest != null) {
-                    return manifest.getAttributes();
-                }
+        private SessionManifest lookupSessionManifest(String originSessionId) {
+            final SessionContextStore store = AgentConfiguration.getInstance().getSessionContextStore();
+            final SessionManifest manifest = (store != null) ? store.get(originSessionId) : null;
+            if (manifest == null) {
                 log.warn("NativeReporting: no session manifest for crash origin [" + originSessionId
                         + "]; using current session attributes");
             }
-            return controller.getSessionAttributes();
+            return manifest;
+        }
+
+        /**
+         * Attach {@code sessionDuration} (seconds) to a native crash. For a crash reported within the
+         * current session, the live session duration applies. For one recovered from a prior session,
+         * derive it from the native crash timestamp ({@code backtrace.timestamp}, epoch seconds) minus
+         * that session's start ({@link SessionManifest#getSessionStartMs()}, epoch ms). No-op when it
+         * cannot be determined (e.g. prior session with no manifest), so the crash still reports.
+         */
+        private void addCrashSessionDuration(Set<AnalyticsAttribute> sessionAttributes, String crashAsString,
+                                             boolean fromPriorSession, SessionManifest originManifest) {
+            float durationSec = -1f;
+            if (!fromPriorSession) {
+                final long ms = Harvest.getMillisSinceStart();
+                if (ms != Harvest.INVALID_SESSION_DURATION) {
+                    durationSec = ms / 1000.0f;
+                }
+            } else if (originManifest != null && originManifest.getSessionStartMs() > 0L) {
+                final long crashSec = extractNativeTimestampSec(crashAsString);
+                if (crashSec > 0L) {
+                    // Subtract as longs (ms) before converting to float seconds. Subtracting at
+                    // epoch scale (~1.7e9) in float arithmetic would lose precision — a 32-bit
+                    // float's resolution there is ~128, so short durations would round to 0.
+                    final long durationMs = (crashSec * 1000L) - originManifest.getSessionStartMs();
+                    if (durationMs >= 0L) {
+                        durationSec = durationMs / 1000.0f;
+                    }
+                }
+            }
+            if (durationSec >= 0f) {
+                sessionAttributes.add(new AnalyticsAttribute(
+                        AnalyticsAttribute.SESSION_DURATION_ATTRIBUTE, durationSec));
+            }
+        }
+
+        /** @return the crash time from a native report ({@code backtrace.timestamp}, epoch seconds), or 0. */
+        private long extractNativeTimestampSec(String crashAsString) {
+            try {
+                return new JSONObject(crashAsString).getJSONObject("backtrace").optLong("timestamp", 0L);
+            } catch (Exception e) {
+                return 0L;
+            }
         }
 
         /** @return the originating sessionId from a native crash report ({@code backtrace.sessionid}), or null. */


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-581977](https://newrelic.atlassian.net/browse/NR-581977)
## Jira
[NR-581977](https://new-relic.atlassian.net/browse/NR-581977) — engineering bug from GTSE [NR-487823](https://new-relic.atlassian.net/browse/NR-487823) (*Missing sessionDuration attribute for NDK crashes*).

## What & Why
`MobileCrash` events for Java-exception crashes carry `sessionDuration`, but NDK (native) crashes did not — customers couldn't tell how long a session ran before a native crash. The native path (`onNativeCrash`) never set it, and because a native crash is flushed on the **next launch** (the process died), `Harvest.getMillisSinceStart()` at flush time would be the *relaunched* session, not the crashed one.

This computes the crashed session's elapsed time and attaches `sessionDuration`:
- Native report crash time: `backtrace.timestamp` (epoch **seconds**, `time(0)`).
- Crashed session's start: `SessionManifest.getSessionStartMs()` (epoch **ms**) from the Phase‑1 `SessionContextStore`, resolved via the report's origin `sessionId` (NR-581961).
- `sessionDuration = backtrace.timestamp − sessionStartMs/1000`, **computed in `long` (ms) then converted to float seconds**.
- Same-session crash → live `Harvest.getMillisSinceStart()`. Undeterminable (prior session, no manifest) → omitted, so the crash still reports.

## Callouts
- **Stacked on `NR-581961-native-crash-session-attribution`** — reuses its origin-session resolution. That in turn stacks on Phase 1 (`NR-575950`). Retarget down the chain as each merges.
- **Precision gotcha (the bug behind the initial `0.0`):** subtracting epoch-scale values (~1.7e9) in 32‑bit `float` has ~128 resolution, so short durations round to `0.0`. The subtraction is therefore done in `long` first; only the small elapsed result is cast to `float`.

## Test Plan
Manual (NDK): trigger a native crash in session A after the app has run for N seconds; relaunch (session B). On the next harvest the `MobileCrash` event for the native crash carries `sessionDuration ≈ N` (the crashed session's elapsed time), not `0.0` and not session B's duration.

## Verification note
Per project preference, unit-test suites are not run locally; verified by compiling `:agent:compileReleaseSources`.

[NR-581977]: https://new-relic.atlassian.net/browse/NR-581977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-487823]: https://new-relic.atlassian.net/browse/NR-487823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ