### PR TITLE
chore: Pin versions in action

### DIFF
--- a/.github/workflows/jira-link.yml
+++ b/.github/workflows/jira-link.yml
@@ -13,7 +13,7 @@ jobs:
   add-jira-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           JIRA_BASE_URL: https://newrelic.atlassian.net
           JIRA_LINK_MODE: body-start


### PR DESCRIPTION
Pin version in jira-link action