### PR TITLE
fix: decouple build ID generation from compile/minify caching (NR-556102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,246 @@
+# New Relic Android Agent
+
+Mobile performance monitoring agent for Android. **Two-phase architecture:** build-time bytecode instrumentation + runtime monitoring and data collection.
+
+## Modules
+
+| Module | Path | Type | Output |
+|---|---|---|---|
+| **agent-core** | `/agent-core` | Java 17 library | `agent-core-<v>.jar` (fat via Shadow) |
+| **instrumentation** | `/instrumentation` | Java 17 library | `instrumentation-<v>.jar` (ASM relocated) |
+| **agent** | `/agent` | Android library | `android-agent-<v>.aar` |
+| **plugins/gradle** | `/plugins/gradle` | Gradle plugin (Groovy + Kotlin) | `agent-gradle-plugin-<v>.jar` |
+
+Dependency chain: `agent` → `agent-core` + `instrumentation`. The Gradle plugin orchestrates build-time rewriting.
+
+### agent-core — runtime agent
+Runtime implementation, public SDK (`NewRelic.java`), data collection, harvest system, analytics, session management.
+
+Key subdirectories:
+```
+agent-core/src/main/java/com/newrelic/agent/android/
+├── crash/                    # Crash detection → .claude/rules/crash-flow.md
+├── tracing/                  # Activity/interaction tracing → .claude/rules/tracing.md
+├── harvest/                  # Data harvesting and transmission
+├── measurement/              # Performance metrics
+├── instrumentation/          # HTTP/network runtime hooks
+├── analytics/                # Events, breadcrumbs
+├── sessionReplay/            # Session replay
+└── distributedtracing/       # Trace context propagation
+```
+
+Key classes: `Agent` (singleton facade), `AndroidAgentImpl` (main impl), `AgentConfiguration`, `Harvest`, `TraceMachine`.
+
+### agent — Android wrapper
+Combines agent-core + instrumentation into an AAR. Handles Android Context integration, lifecycle callbacks, NDK bridge.
+
+```
+agent/src/main/java/com/newrelic/agent/android/
+├── instrumentation/          # Runtime hooks (OkHttp, etc.)
+├── ndk/                       # Native crash bridge
+├── rum/                       # Real User Monitoring (Activity lifecycle)
+├── stores/                    # SharedPreferences persistence
+├── sessionReplay/             # Session replay rendering
+└── webView/                   # WebView instrumentation
+```
+
+Fat JAR lands at `build/intermediates/aar_main_jar/release/classes.jar`. Shadow plugin uses multi-phase JAR build for Gson compatibility (unshaded + shaded → merged).
+
+### instrumentation — bytecode rewriter
+See **`.claude/rules/instrumentation.md`**.
+
+### plugins/gradle — build-time plugin
+See **`.claude/rules/plugin-architecture.md`**.
+
+## Path-Gated Rule Files
+
+Load the appropriate rule file before editing these areas:
+
+| Path | Rule |
+|---|---|
+| `plugins/gradle/**`, `buildconfig.gradle` | `.claude/rules/plugin-architecture.md` |
+| `instrumentation/**` | `.claude/rules/instrumentation.md` |
+| `agent-core/src/main/java/com/newrelic/agent/android/crash/**`, `agent/**/ndk/**` | `.claude/rules/crash-flow.md` |
+| `agent-core/**/tracing/**` | `.claude/rules/tracing.md` |
+
+## Build-Time vs Runtime Split
+
+**Build time:** Gradle plugin runs `NewRelicConfigTask` (generates `NEW_RELIC_BUILD_ID`), `ClassTransformer` (rewrites `isInstrumented()`, `getBuildId()`, injects Activity/network hooks), and `NewRelicMapUploadTask` (uploads ProGuard/NDK maps).
+
+**Runtime:** `NewRelic.start(context)` → `AndroidAgentImpl.init()` → harvest timer (60s) collects metrics, traces, events, crashes and POSTs to backend.
+
+### Build ID caching (NR-556102)
+
+`NewRelicConfigTask` generates a random build ID per build. It used to embed that value directly in the compiled `NewRelicConfig.java`, which busted `compileReleaseJavaWithJavac`/`compileReleaseKotlin`/`minifyReleaseWithR8` caching on every CI build (a changed source file forces a cache miss for anything that touches it). Fixed by moving the real value into a generated Android string resource (`values/com_newrelic_android_agent_config.xml`, entry `com.newrelic.android.buildId`) instead — `NewRelicConfig.java`'s `BUILD_ID` field is now a stable placeholder, so compile/minify inputs stop changing build-to-build. Wired per AGP adapter via `sources.res.addGeneratedSourceDirectory(...)` (4.x uses `registerGeneratedResFolders`). At runtime, `AndroidAgentImpl` resolves the value via `Resources.getIdentifier(...)` during `init()` and pushes it to `Agent.setBuildId(...)`; `Agent.getBuildId()` falls back to the old `NewRelicConfig` reflection path if the resource is absent (covers an old-plugin + new-agent-core version mismatch).
+
+## Data Flow Summary
+
+```
+1. BUILD TIME — plugin rewrites classes, uploads maps
+2. RUNTIME INIT — NewRelic.start(), harvest timer, crash handler
+3. RUNTIME ONGOING — activity traces, network interception, breadcrumbs; 60s harvest
+4. RUNTIME CRASH — UncaughtExceptionHandler → CrashStore → upload on next launch
+```
+
+## Key Architectural Patterns
+
+- **Null Object** — `NullAgentImpl` when instrumentation missing/disabled
+- **Facade** — `NewRelic` (public API), `Agent` (internal switchable impl)
+- **Visitor** — ASM `ClassVisitor` chain for bytecode transformation
+- **State Machine** — `TraceMachine` (trace state + thread-local)
+- **Thread-Safe Singleton** — `Agent.impl` (lock for impl switching), `StatsEngine`, `AnalyticsControllerImpl`
+- **Factory** — `VariantAdapter.register()`, `ClassVisitorFactory`
+- **Observable** — `HarvestLifecycleAware`, `ApplicationStateListener`, `TraceLifecycleAware`
+- **Strategy** — per-AGP variant adapters
+
+## Common Modification Points
+
+**Add new framework instrumentation:** see `.claude/rules/instrumentation.md`.
+
+**Add new metric:**
+1. Define in `MetricNames`
+2. Increment via `StatsEngine.get().inc(metricName)`
+3. Surface in next harvest via `MeasurementProducer`
+
+**Add new public API method:**
+1. Add static method to `NewRelic`
+2. Implement in `AndroidAgentImpl`
+3. Add null impl in `NullAgentImpl`
+4. Document in samples/tests
+
+## Runtime Configuration
+
+```java
+NewRelic.withApplicationToken(token)
+    .withLoggingEnabled(true)
+    .withLogLevel(AgentLog.INFO)
+    .withApplicationVersion("1.0.0")
+    .withApplicationFramework(ApplicationFramework.NATIVE, "version")
+    .withCrashReportingEnabled(true)
+    .start(context);
+```
+
+Build-side DSL (`newrelic { ... }`) is in `.claude/rules/plugin-architecture.md`.
+
+## Feature Flags (`FeatureFlag.java`)
+`DistributedTracing`, `InteractionTracing`, `CrashReporting`, `HandledExceptions`, `HttpResponseBodyCapture`, `NetworkRequest`, `SessionReplay`.
+
+## Key Dependencies
+
+- **agent-core:** ASM (shadowed `com.newrelic.org.objectweb.asm`), Gson (shadowed, special handling), FlatBuffers
+- **instrumentation:** ASM 9.x
+- **Build toolchain:** AGP 8.1.4 (compileSdk 34), Gradle 8.1.1, Kotlin 1.7.0, Java 17 minimum
+
+Gradle 8 migration gotchas are in `.claude/rules/plugin-architecture.md`.
+
+## Code Conventions
+
+- **New files must be written in Kotlin.** Existing Java files may be edited in place, but any newly created source or test file should be Kotlin (`.kt`). Don't rewrite existing Java just to convert it.
+
+## Testing Strategy
+
+- **Unit:** Robolectric for Activity simulation
+- **Integration:** Gradle TestKit for plugin behavior
+- **Functional:** End-to-end with sample app
+- **Instrumentation tests:** verify bytecode transformations
+
+## Investigation Checklist
+
+1. Module chain: `agent → agent-core + instrumentation`
+2. Build-time vs runtime? Was instrumentation applied? Check bytecode or `NewRelic.isInstrumented()` at runtime
+3. Trace data flow: collection → `MeasurementProducer` → `Harvest` → transmission
+4. AGP compatibility → variant adapters (`.claude/rules/plugin-architecture.md`)
+5. Shadow JAR relocations move classes to `com.newrelic.*` — affects reflection
+6. For bytecode method injection, look for `GeneratorAdapter` usage
+
+## Frequently Modified Files
+- `/agent-core/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java`
+- `/instrumentation/src/main/java/com/newrelic/agent/compile/visitor/`
+- `/plugins/gradle/src/main/groovy/com/newrelic/agent/android/`
+- `/agent-core/src/main/java/com/newrelic/agent/android/crash/`
+- `/agent-core/src/main/java/com/newrelic/agent/android/tracing/TraceMachine.java`
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+### Code Intelligence
+
+Prefer LSP over Grep/Glob/Read for code navigation:
+- `goToDefinition` / `goToImplementation` to jump to source
+- `findReferences` to see all usages across the codebase
+- `workspaceSymbol` to find where something is defined
+- `documentSymbol` to list all symbols in a file
+- `hover` for type info without reading the file
+- `incomingCalls` / `outgoingCalls` for call hierarchy
+
+Before renaming or changing a function signature, use
+`findReferences` to find all call sites first.
+
+Use Grep/Glob only for text/pattern searches (comments,
+strings, config values) where LSP doesn't help.
+
+
+After writing or editing code, check LSP diagnostics before
+moving on. Fix any type errors or missing imports immediately.
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/agent-core/src/main/java/com/newrelic/agent/android/Agent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/Agent.java
@@ -51,6 +51,12 @@ public class Agent {
         return MONO_INSTRUMENTATION_FLAG;
     }
 
+    public static void setBuildId(final String id) {
+        synchronized (implLock) {
+            buildId = id;
+        }
+    }
+
     public static String getBuildId() {
 
         synchronized (implLock) {

--- a/agent-core/src/test/java/com/newrelic/agent/android/AgentBuildIdTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/AgentBuildIdTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class AgentBuildIdTest {
+
+    @After
+    public void tearDown() {
+        Agent.setBuildId(null);
+    }
+
+    @Test
+    public void setBuildIdTakesPriorityOverReflectionFallback() {
+        Agent.setBuildId("pushed-build-id-123");
+        assertEquals("pushed-build-id-123", Agent.getBuildId());
+    }
+
+    @Test
+    public void fallsBackToReflectionWhenNotPushed() {
+        // No setBuildId() call: falls back to reflecting the NewRelicConfig test fixture
+        // at agent-core/src/test/java/com/newrelic/agent/android/NewRelicConfig.java
+        String buildId = Agent.getBuildId();
+        assertFalse(buildId.isEmpty());
+        assertTrue(buildId.matches("[0-9a-fA-F-]{36}"));
+    }
+}

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -114,7 +114,8 @@ public class AndroidAgentImpl implements
 
     // Must match NewRelicConfigTask.BUILD_ID_RESOURCE_NAME in the Gradle plugin
     // (plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy).
-    private static final String BUILD_ID_RESOURCE_NAME = "com.newrelic.android.buildId";
+    // Underscores, not periods - see newrelic_keep.xml for why.
+    private static final String BUILD_ID_RESOURCE_NAME = "com_newrelic_android_buildId";
 
     // Stored for use by static API methods (recordReplay → log activation)
     private static Context savedContext;

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.location.Address;
 import android.location.Geocoder;
 import android.location.Location;
@@ -111,6 +112,10 @@ public class AndroidAgentImpl implements
 
     private static final AgentLog log = AgentLogManager.getAgentLog();
 
+    // Must match NewRelicConfigTask.BUILD_ID_RESOURCE_NAME in the Gradle plugin
+    // (plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy).
+    private static final String BUILD_ID_RESOURCE_NAME = "com.newrelic.android.buildId";
+
     // Stored for use by static API methods (recordReplay → log activation)
     private static Context savedContext;
 
@@ -134,6 +139,9 @@ public class AndroidAgentImpl implements
         // We want an Application context, not an Activity context.
         this.context = appContext(context);
         this.agentConfiguration = agentConfiguration;
+
+        resolveBuildId(this.context);
+
         this.savedState = new SavedState(this.context);
         this.offlineStorageInstance = new OfflineStorage(context);
 
@@ -182,6 +190,29 @@ public class AndroidAgentImpl implements
         context.registerComponentCallbacks(backgroundListener);
 
         setupSession();
+    }
+
+    /**
+     * The build ID is generated at build time by NewRelicConfigTask and injected as a
+     * generated Android string resource (not compiled Java source, so it doesn't bust
+     * compile/R8 caching). Resolve it here, where a Context is available, and push it into
+     * Agent (agent-core has no Android dependency and can't read resources itself). If the
+     * resource isn't present (e.g. an older Gradle plugin version), leave Agent's build ID
+     * unset so it falls back to its existing NewRelicConfig reflection path.
+     */
+    private static void resolveBuildId(final Context context) {
+        try {
+            Resources resources = context.getResources();
+            int id = resources.getIdentifier(BUILD_ID_RESOURCE_NAME, "string", context.getPackageName());
+            if (id != 0) {
+                String buildId = resources.getString(id);
+                if (buildId != null && !buildId.isEmpty()) {
+                    Agent.setBuildId(buildId);
+                }
+            }
+        } catch (Exception e) {
+            log.debug("AndroidAgentImpl.resolveBuildId(): unable to resolve build ID resource: " + e);
+        }
     }
 
     private static void startLogReporter(Context context, AgentConfiguration agentConfiguration) {

--- a/agent/src/main/res/raw/newrelic_keep.xml
+++ b/agent/src/main/res/raw/newrelic_keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@string/com_newrelic_android_buildId,@string/com_newrelic_android_metrics" />

--- a/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
@@ -7,8 +7,12 @@ package com.newrelic.agent.android;
 
 import static com.newrelic.agent.android.analytics.AnalyticsAttribute.ACTION_TYPE_ATTRIBUTE;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.res.Resources;
 
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
@@ -97,6 +101,7 @@ public class AndroidAgentImplTest {
     @After
     public void tearDown() throws Exception {
         Agent.stop();
+        Agent.setBuildId(null);
     }
 
     @Test
@@ -127,6 +132,36 @@ public class AndroidAgentImplTest {
         Assert.assertFalse("New device info should not be equal",
                 agentImpl.getSavedState().getConnectInformation().getDeviceInformation().equals(agentImpl.getDeviceInformation()));
         Assert.assertTrue("Should update connection info on device info change", agentImpl.updateSavedConnectInformation());
+    }
+
+    @Test
+    public void testBuildIdResolvedFromGeneratedResource() throws Exception {
+        Context contextSpy = spyContext.getContext();
+        Resources resourcesSpy = spy(contextSpy.getResources());
+        // Evaluate this ahead of the stubbing calls below - calling a method on the contextSpy
+        // mock as an inline argument while resourcesSpy's stub is mid-setup confuses Mockito's
+        // stubbing tracker (UnfinishedStubbingException, hint #3: "stubbing the behaviour of
+        // another mock inside before 'thenReturn' instruction is completed").
+        String packageName = contextSpy.getPackageName();
+
+        doReturn(resourcesSpy).when(contextSpy).getResources();
+        doReturn(4242).when(resourcesSpy).getIdentifier("com.newrelic.android.buildId", "string", packageName);
+        doReturn("resource-provided-build-id").when(resourcesSpy).getString(4242);
+
+        new AndroidAgentImpl(contextSpy, agentConfig);
+
+        Assert.assertEquals("resource-provided-build-id", Agent.getBuildId());
+    }
+
+    @Test
+    public void testBuildIdFallsBackWhenResourceMissing() throws Exception {
+        // spyContext's real Robolectric resources have no matching entry, so getIdentifier()
+        // returns 0 and Agent.setBuildId() is never called - Agent.getBuildId() falls back to
+        // its existing NewRelicConfig reflection path (which finds nothing on this module's
+        // test classpath and returns "").
+        new AndroidAgentImpl(spyContext.getContext(), agentConfig);
+
+        Assert.assertEquals("", Agent.getBuildId());
     }
 
     @Test

--- a/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
@@ -145,7 +145,7 @@ public class AndroidAgentImplTest {
         String packageName = contextSpy.getPackageName();
 
         doReturn(resourcesSpy).when(contextSpy).getResources();
-        doReturn(4242).when(resourcesSpy).getIdentifier("com.newrelic.android.buildId", "string", packageName);
+        doReturn(4242).when(resourcesSpy).getIdentifier("com_newrelic_android_buildId", "string", packageName);
         doReturn("resource-provided-build-id").when(resourcesSpy).getString(4242);
 
         new AndroidAgentImpl(contextSpy, agentConfig);

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
@@ -104,6 +104,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
                     "generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
             buildIdResource.text.contains('name="com.newrelic.android.buildId"')
+            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
@@ -99,6 +99,11 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
 
             def configClass = new File(buildDir, "intermediates/javac/${var}/classes/com/newrelic/agent/android/NewRelicConfig.class")
             configClass.exists() && configClass.canRead()
+
+            def buildIdResource = new File(buildDir,
+                    "generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
+            buildIdResource.exists() && buildIdResource.canRead()
+            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
@@ -103,8 +103,8 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
             def buildIdResource = new File(buildDir,
                     "generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
-            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
-            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
+            buildIdResource.text.contains('name="com_newrelic_android_buildId"')
+            buildIdResource.text.contains('name="com_newrelic_android_metrics"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
@@ -80,6 +80,11 @@ class PluginDexGuardRegressionSpec extends PluginSpec {
 
             def configClass = new File(buildDir, "intermediates/javac/${var}/classes/com/newrelic/agent/android/NewRelicConfig.class")
             configClass.exists() && configClass.canRead()
+
+            def buildIdResource = new File(buildDir,
+                    "generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
+            buildIdResource.exists() && buildIdResource.canRead()
+            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
         }
 
         mapUploadVariants.each { var ->

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
@@ -85,6 +85,7 @@ class PluginDexGuardRegressionSpec extends PluginSpec {
                     "generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
             buildIdResource.text.contains('name="com.newrelic.android.buildId"')
+            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
         }
 
         mapUploadVariants.each { var ->

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
@@ -84,8 +84,8 @@ class PluginDexGuardRegressionSpec extends PluginSpec {
             def buildIdResource = new File(buildDir,
                     "generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
-            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
-            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
+            buildIdResource.text.contains('name="com_newrelic_android_buildId"')
+            buildIdResource.text.contains('name="com_newrelic_android_metrics"')
         }
 
         mapUploadVariants.each { var ->

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
@@ -85,6 +85,7 @@ class PluginJDK11SmokeSpec extends PluginSpec {
                     "/generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
             buildIdResource.text.contains('name="com.newrelic.android.buildId"')
+            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
@@ -84,8 +84,8 @@ class PluginJDK11SmokeSpec extends PluginSpec {
             def buildIdResource = new File(buildDir,
                     "/generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
-            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
-            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
+            buildIdResource.text.contains('name="com_newrelic_android_buildId"')
+            buildIdResource.text.contains('name="com_newrelic_android_metrics"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK11SmokeSpec.groovy
@@ -80,6 +80,11 @@ class PluginJDK11SmokeSpec extends PluginSpec {
 
             def configClass = new File(buildDir, "/intermediates/javac/${var}/classes/com/newrelic/agent/android/NewRelicConfig.class")
             configClass.exists() && configClass.canRead()
+
+            def buildIdResource = new File(buildDir,
+                    "/generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
+            buildIdResource.exists() && buildIdResource.canRead()
+            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17IntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17IntegrationSpec.groovy
@@ -142,16 +142,17 @@ class PluginJDK17IntegrationSpec extends PluginSpec {
         def preResult = runner.build()
 
         and:
-        def preBuildId = new File(buildDir, "/generated/java/newrelicConfigRelease/com/newrelic/agent/android/NewRelicConfig.java").text
+        def preBuildId = new File(buildDir, "/generated/res/newrelicConfigRelease/values/com_newrelic_android_agent_config.xml").text
 
         and:
         def postResult = runner.build()
 
         and:
-        def postBuildId = new File(buildDir, "/generated/java/newrelicConfigRelease/com/newrelic/agent/android/NewRelicConfig.java").text
+        def postBuildId = new File(buildDir, "/generated/res/newrelicConfigRelease/values/com_newrelic_android_agent_config.xml").text
 
         then:
-        preBuildId.find(~/BUILD_ID = \"(.*)\".*/) == postBuildId.find(~/BUILD_ID = \"(.*)\".*/)
+        preBuildId.find(~/name="com.newrelic.android.buildId"[^>]*>(.*)<\/string>/) ==
+                postBuildId.find(~/name="com.newrelic.android.buildId"[^>]*>(.*)<\/string>/)
 
         preResult.output.contains("Calculating task graph as no configuration cache is available for tasks:")
         preResult.output.contains("Configuration cache entry stored")

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17IntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17IntegrationSpec.groovy
@@ -154,6 +154,9 @@ class PluginJDK17IntegrationSpec extends PluginSpec {
         preBuildId.find(~/name="com.newrelic.android.buildId"[^>]*>(.*)<\/string>/) ==
                 postBuildId.find(~/name="com.newrelic.android.buildId"[^>]*>(.*)<\/string>/)
 
+        preBuildId.find(~/name="com.newrelic.android.metrics"[^>]*>(.*)<\/string>/) ==
+                postBuildId.find(~/name="com.newrelic.android.metrics"[^>]*>(.*)<\/string>/)
+
         preResult.output.contains("Calculating task graph as no configuration cache is available for tasks:")
         preResult.output.contains("Configuration cache entry stored")
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17IntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17IntegrationSpec.groovy
@@ -151,11 +151,11 @@ class PluginJDK17IntegrationSpec extends PluginSpec {
         def postBuildId = new File(buildDir, "/generated/res/newrelicConfigRelease/values/com_newrelic_android_agent_config.xml").text
 
         then:
-        preBuildId.find(~/name="com.newrelic.android.buildId"[^>]*>(.*)<\/string>/) ==
-                postBuildId.find(~/name="com.newrelic.android.buildId"[^>]*>(.*)<\/string>/)
+        preBuildId.find(~/name="com_newrelic_android_buildId"[^>]*>(.*)<\/string>/) ==
+                postBuildId.find(~/name="com_newrelic_android_buildId"[^>]*>(.*)<\/string>/)
 
-        preBuildId.find(~/name="com.newrelic.android.metrics"[^>]*>(.*)<\/string>/) ==
-                postBuildId.find(~/name="com.newrelic.android.metrics"[^>]*>(.*)<\/string>/)
+        preBuildId.find(~/name="com_newrelic_android_metrics"[^>]*>(.*)<\/string>/) ==
+                postBuildId.find(~/name="com_newrelic_android_metrics"[^>]*>(.*)<\/string>/)
 
         preResult.output.contains("Calculating task graph as no configuration cache is available for tasks:")
         preResult.output.contains("Configuration cache entry stored")

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
@@ -84,8 +84,8 @@ class PluginJDK17SmokeSpec extends PluginSpec {
             def buildIdResource = new File(buildDir,
                     "/generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
-            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
-            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
+            buildIdResource.text.contains('name="com_newrelic_android_buildId"')
+            buildIdResource.text.contains('name="com_newrelic_android_metrics"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
@@ -85,6 +85,7 @@ class PluginJDK17SmokeSpec extends PluginSpec {
                     "/generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
             buildIdResource.exists() && buildIdResource.canRead()
             buildIdResource.text.contains('name="com.newrelic.android.buildId"')
+            buildIdResource.text.contains('name="com.newrelic.android.metrics"')
         }
     }
 

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginJDK17SmokeSpec.groovy
@@ -80,6 +80,11 @@ class PluginJDK17SmokeSpec extends PluginSpec {
 
             def configClass = new File(buildDir, "/intermediates/javac/${var}/classes/com/newrelic/agent/android/NewRelicConfig.class")
             configClass.exists() && configClass.canRead()
+
+            def buildIdResource = new File(buildDir,
+                    "/generated/res/newrelicConfig${var.capitalize()}/values/com_newrelic_android_agent_config.xml")
+            buildIdResource.exists() && buildIdResource.canRead()
+            buildIdResource.text.contains('name="com.newrelic.android.buildId"')
         }
     }
 

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicConfigTaskTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicConfigTaskTest.groovy
@@ -87,6 +87,29 @@ class NewRelicConfigTaskTest extends PluginTest {
     }
 
     @Test
+    void verifyMetricsResource() {
+        provider.newRelicConfigTask()
+
+        def resourceFile = provider.getResourceOutputDir().file(NewRelicConfigTask.CONFIG_RESOURCE_FILE).get().asFile
+        def metrics = provider.getBuildMetrics().get()
+
+        Assert.assertTrue(resourceFile.exists())
+        Assert.assertTrue(resourceFile.text.contains(metrics))
+        Assert.assertTrue(resourceFile.text.contains(NewRelicConfigTask.METRICS_RESOURCE_NAME))
+    }
+
+    @Test
+    void verifyMetricsNotInCompiledSource() {
+        provider.newRelicConfigTask()
+
+        def sourceFile = provider.getSourceOutputDir().file(provider.CONFIG_CLASS).get().asFile
+        def metrics = provider.getBuildMetrics().get()
+
+        Assert.assertFalse(sourceFile.text.contains(metrics))
+        Assert.assertTrue(sourceFile.text.contains("METRICS = \"${NewRelicConfigTask.METRICS_PLACEHOLDER}\""))
+    }
+
+    @Test
     void newRelicConfigTask() {
         // @TaskAction
         provider.newRelicConfigTask()

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicConfigTaskTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/NewRelicConfigTaskTest.groovy
@@ -55,6 +55,38 @@ class NewRelicConfigTaskTest extends PluginTest {
     }
 
     @Test
+    void getResourceOutputDir() {
+        def f = provider.getResourceOutputDir().file(NewRelicConfigTask.CONFIG_RESOURCE_FILE).get().asFile
+        Assert.assertTrue(f.absolutePath.endsWith(NewRelicConfigTask.CONFIG_RESOURCE_FILE))
+
+        provider.newRelicConfigTask()
+        Assert.assertTrue(f.exists())
+    }
+
+    @Test
+    void verifyBuildIdResource() {
+        provider.newRelicConfigTask()
+
+        def resourceFile = provider.getResourceOutputDir().file(NewRelicConfigTask.CONFIG_RESOURCE_FILE).get().asFile
+        def buildId = provider.getBuildId().get()
+
+        Assert.assertTrue(resourceFile.exists())
+        Assert.assertTrue(resourceFile.text.contains(buildId))
+        Assert.assertTrue(resourceFile.text.contains(NewRelicConfigTask.BUILD_ID_RESOURCE_NAME))
+    }
+
+    @Test
+    void verifyBuildIdNotInCompiledSource() {
+        provider.newRelicConfigTask()
+
+        def sourceFile = provider.getSourceOutputDir().file(provider.CONFIG_CLASS).get().asFile
+        def buildId = provider.getBuildId().get()
+
+        Assert.assertFalse(sourceFile.text.contains(buildId))
+        Assert.assertTrue(sourceFile.text.contains("BUILD_ID = \"${NewRelicConfigTask.BUILD_ID_PLACEHOLDER}\""))
+    }
+
+    @Test
     void newRelicConfigTask() {
         // @TaskAction
         provider.newRelicConfigTask()

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
@@ -29,13 +29,18 @@ abstract class NewRelicConfigTask extends DefaultTask {
     // merges through aapt2 and never reaches javac/kotlinc/R8. Named generically (not "buildid")
     // so this same file can carry other dynamic, per-build values later without another rename.
     final static String CONFIG_RESOURCE_FILE = "values/com_newrelic_android_agent_config.xml"
-    final static String BUILD_ID_RESOURCE_NAME = "com.newrelic.android.buildId"
+
+    // Underscores, not periods: AAPT2's resource-shrinker keep/discard matching (tools:keep)
+    // works against the Java-safe symbol table, which canonicalizes periods to underscores.
+    // Using the same underscored name for the declaration avoids relying on two different
+    // spellings of the same resource across the codebase.
+    final static String BUILD_ID_RESOURCE_NAME = "com_newrelic_android_buildId"
 
     // METRICS (toolchain/environment info) can differ across CI machines even when no source
     // changed, so it's kept out of the compiled source for the same reason as BUILD_ID above -
     // otherwise it would bust remote build caching across a fleet of build agents.
     final static String METRICS_PLACEHOLDER = ""
-    final static String METRICS_RESOURCE_NAME = "com.newrelic.android.metrics"
+    final static String METRICS_RESOURCE_NAME = "com_newrelic_android_metrics"
 
     @Input
     abstract Property<String> getBuildId()      // variant buildId

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
@@ -19,6 +19,18 @@ abstract class NewRelicConfigTask extends DefaultTask {
     final static String CONFIG_CLASS = "com/newrelic/agent/android/NewRelicConfig.java"
     final static String METADATA = ".metadata"
 
+    // BUILD_ID is intentionally NOT embedded here anymore - see CONFIG_RESOURCE_FILE below.
+    // Keeping a stable placeholder (instead of the real, per-build value) means this generated
+    // source is byte-identical across builds when nothing else changed, so compileReleaseJavaWithJavac
+    // / compileReleaseKotlin / minifyReleaseWithR8 stay cache-hits.
+    final static String BUILD_ID_PLACEHOLDER = ""
+
+    // The real, per-build value lives here instead: a generated Android string resource, which
+    // merges through aapt2 and never reaches javac/kotlinc/R8. Named generically (not "buildid")
+    // so this same file can carry other dynamic, per-build values later without another rename.
+    final static String CONFIG_RESOURCE_FILE = "values/com_newrelic_android_agent_config.xml"
+    final static String BUILD_ID_RESOURCE_NAME = "com.newrelic.android.buildId"
+
     @Input
     abstract Property<String> getBuildId()      // variant buildId
 
@@ -34,6 +46,9 @@ abstract class NewRelicConfigTask extends DefaultTask {
 
     @OutputDirectory
     abstract DirectoryProperty getSourceOutputDir()
+
+    @OutputDirectory
+    abstract DirectoryProperty getResourceOutputDir()
 
     @OutputFile
     @Optional
@@ -51,7 +66,7 @@ abstract class NewRelicConfigTask extends DefaultTask {
     
                         final class NewRelicConfig {
                             static final String VERSION = "${InstrumentationAgent.getVersion()}";
-                            static final String BUILD_ID = "${buildId.get()}";
+                            static final String BUILD_ID = "${BUILD_ID_PLACEHOLDER}";
                             static final Boolean OBFUSCATED = ${minifyEnabled.getOrElse(false)};
                             static final String MAP_PROVIDER = "${mapProvider.get()}";
                             static final String METRICS = "${buildMetrics.getOrElse("")}";
@@ -63,6 +78,16 @@ abstract class NewRelicConfigTask extends DefaultTask {
             }
 
             configMetadata.get().asFile.text = buildId.get()
+
+            def resourceFile = resourceOutputDir.file(CONFIG_RESOURCE_FILE).get().asFile
+            resourceFile.with {
+                parentFile.mkdirs()
+                text = """<?xml version="1.0" encoding="utf-8"?>
+                        <resources>
+                            <string name="${BUILD_ID_RESOURCE_NAME}" translatable="false">${buildId.get()}</string>
+                        </resources>
+                        """.stripIndent()
+            }
 
         } catch (Exception e) {
             logger.error("Error encountered while configuring the New Relic plugin: ", e)

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
@@ -31,6 +31,12 @@ abstract class NewRelicConfigTask extends DefaultTask {
     final static String CONFIG_RESOURCE_FILE = "values/com_newrelic_android_agent_config.xml"
     final static String BUILD_ID_RESOURCE_NAME = "com.newrelic.android.buildId"
 
+    // METRICS (toolchain/environment info) can differ across CI machines even when no source
+    // changed, so it's kept out of the compiled source for the same reason as BUILD_ID above -
+    // otherwise it would bust remote build caching across a fleet of build agents.
+    final static String METRICS_PLACEHOLDER = ""
+    final static String METRICS_RESOURCE_NAME = "com.newrelic.android.metrics"
+
     @Input
     abstract Property<String> getBuildId()      // variant buildId
 
@@ -69,7 +75,7 @@ abstract class NewRelicConfigTask extends DefaultTask {
                             static final String BUILD_ID = "${BUILD_ID_PLACEHOLDER}";
                             static final Boolean OBFUSCATED = ${minifyEnabled.getOrElse(false)};
                             static final String MAP_PROVIDER = "${mapProvider.get()}";
-                            static final String METRICS = "${buildMetrics.getOrElse("")}";
+                            static final String METRICS = "${METRICS_PLACEHOLDER}";
                             public static String getBuildId() {
                                 return BUILD_ID;
                             }
@@ -85,6 +91,7 @@ abstract class NewRelicConfigTask extends DefaultTask {
                 text = """<?xml version="1.0" encoding="utf-8"?>
                         <resources>
                             <string name="${BUILD_ID_RESOURCE_NAME}" translatable="false">${buildId.get()}</string>
+                            <string name="${METRICS_RESOURCE_NAME}" translatable="false">${escapeXml(buildMetrics.getOrElse(""))}</string>
                         </resources>
                         """.stripIndent()
             }
@@ -92,6 +99,10 @@ abstract class NewRelicConfigTask extends DefaultTask {
         } catch (Exception e) {
             logger.error("Error encountered while configuring the New Relic plugin: ", e)
         }
+    }
+
+    private static String escapeXml(String value) {
+        value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
     }
 
     @Internal

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicConfigTask.groovy
@@ -106,7 +106,7 @@ abstract class NewRelicConfigTask extends DefaultTask {
         }
     }
 
-    private static String escapeXml(String value) {
+    static String escapeXml(String value) {
         value.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
     }
 

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -167,8 +167,10 @@ abstract class VariantAdapter {
         def configProvider = getConfigProvider(variantName) { configTask ->
             def buildType = withBuildType(variantName)
             def genSrcFolder = buildHelper.project.layout.buildDirectory.dir("generated/java/newrelicConfig${buildType.name.capitalize()}")
+            def genResFolder = buildHelper.project.layout.buildDirectory.dir("generated/res/newrelicConfig${buildType.name.capitalize()}")
 
             configTask.sourceOutputDir.set(objectFactory.directoryProperty().value(genSrcFolder))
+            configTask.resourceOutputDir.set(objectFactory.directoryProperty().value(genResFolder))
             configTask.mapProvider.set(objectFactory.property(String).value(buildHelper.getMapCompilerName()))
             configTask.minifyEnabled.set(objectFactory.property(Boolean).value(buildType.minified))
             configTask.buildMetrics.set(objectFactory.property(String).value(buildHelper.getBuildMetrics().toString()))
@@ -180,15 +182,14 @@ abstract class VariantAdapter {
             configTask.buildId.set(buildIdProvider)
 
             configTask.onlyIf {
-                def configClass = configTask.sourceOutputDir.file(NewRelicConfigTask.CONFIG_CLASS).get().asFile
-                !configClass.exists() || !configClass.text.contains(configTask.buildId.get())
+                def resourceFile = configTask.resourceOutputDir.file(NewRelicConfigTask.CONFIG_RESOURCE_FILE).get().asFile
+                !resourceFile.exists() || !resourceFile.text.contains(configTask.buildId.get())
             }
 
             configTask.outputs.upToDateWhen {
-                def meta = configTask.configMetadata.get().asFile
-                def configClass = configTask.sourceOutputDir.file(NewRelicConfigTask.CONFIG_CLASS).get().asFile
-                configClass.exists() &&
-                        configClass.text.contains(configTask.buildId.get())
+                def resourceFile = configTask.resourceOutputDir.file(NewRelicConfigTask.CONFIG_RESOURCE_FILE).get().asFile
+                resourceFile.exists() &&
+                        resourceFile.text.contains(configTask.buildId.get())
             }
         }
 

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp4/AGP4Adapter.groovy
@@ -96,6 +96,7 @@ class AGP4Adapter extends VariantAdapter {
             def buildConfigProvider = variant.getGenerateBuildConfigProvider()
             if (buildConfigProvider?.isPresent()) {
                 def genSrcFolder = buildHelper.project.layout.buildDirectory.dir("generated/source/newrelicConfig/${variant.name}")
+                def genResFolder = buildHelper.project.layout.buildDirectory.dir("generated/res/newrelicConfig/${variant.name}")
 
                 try {
                     variant.registerJavaGeneratingTask(configTaskProvider, genSrcFolder.get().asFile)
@@ -107,6 +108,15 @@ class AGP4Adapter extends VariantAdapter {
                     variant.addJavaSourceFoldersToModel(genSrcFolder.get().asFile)
                 } catch (Exception e) {
                     logger.warn("getConfigProvider: $e")
+                }
+
+                try {
+                    variant.registerGeneratedResFolders(buildHelper.project.files(genResFolder))
+                    buildHelper.project.tasks.named("generate${variantName.capitalize()}Resources") { resourceTask ->
+                        resourceTask.dependsOn(configTaskProvider)
+                    }
+                } catch (Exception e) {
+                    logger.warn("getConfigProvider: unable to register build-ID resource folder: $e")
                 }
 
                 // must manually update the Kotlin compile tasks source sets (per variant)

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP70Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP70Adapter.groovy
@@ -157,6 +157,12 @@ class AGP70Adapter extends VariantAdapter {
                 //  FIXME
                 logger.debug("${GradleVersion.current()} does not provide addGeneratedSourceDirectory() on the Java sources instance.")
             }
+
+            try {
+                variant.sources.res?.addGeneratedSourceDirectory(configProvider, { it.getResourceOutputDir() })
+            } catch (Exception ignored) {
+                logger.debug("${GradleVersion.current()} does not provide addGeneratedSourceDirectory() on the resource sources instance.")
+            }
         }
 
         buildHelper.project.afterEvaluate {

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP74Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp7/AGP74Adapter.groovy
@@ -70,6 +70,7 @@ class AGP74Adapter extends AGP70Adapter {
     def wiredWithConfigProvider(String variantName) {
         def configProvider = super.wiredWithConfigProvider(variantName)
         withVariant(variantName).sources.java.addGeneratedSourceDirectory(configProvider, { it.getSourceOutputDir() })
+        withVariant(variantName).sources.res?.addGeneratedSourceDirectory(configProvider, { it.getResourceOutputDir() })
 
         return configProvider
     }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp9/AGP90Adapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/agp9/AGP90Adapter.groovy
@@ -58,6 +58,12 @@ class AGP90Adapter extends AGP9BaseAdapter {
             } catch (Exception ignored) {
                 logger.debug("${GradleVersion.current()} does not provide addGeneratedSourceDirectory() on the Java sources instance.")
             }
+
+            try {
+                variant.sources.res?.addGeneratedSourceDirectory(configProvider, { it.getResourceOutputDir() })
+            } catch (Exception ignored) {
+                logger.debug("${GradleVersion.current()} does not provide addGeneratedSourceDirectory() on the resource sources instance.")
+            }
         }
 
         buildHelper.project.afterEvaluate {


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-556102](https://newrelic.atlassian.net/browse/NR-556102)

## Summary

`NewRelicConfigTask` embeds a fresh random build ID into the app's compiled `NewRelicConfig.java` on every build. Because that generated source feeds `compileReleaseJavaWithJavac`/`compileReleaseKotlin`, and the compiled class then feeds `minifyReleaseWithR8`, a one-line change to an unrelated string constant busts the Gradle build cache for all three tasks on every CI build — even when no source code changed.

This moves the real, still-random build ID out of compiled source and into a generated Android string resource instead, so compile/minify inputs stay stable across builds.

## What & Why

- `NewRelicConfigTask` now writes the build ID into a generated `values/com_newrelic_android_agent_config.xml` string resource (entry `com.newrelic.android.buildId`), named generically so the same file can carry other dynamic values later without another rename.
- `NewRelicConfig.java`'s `BUILD_ID` field becomes a fixed placeholder — the class still exists and compiles the same every build, it just no longer carries the per-build value.
- Each AGP adapter (4.x / 7.0 / 7.4+ / 9.0+) wires the resource directory via `sources.res.addGeneratedSourceDirectory(...)` (legacy `registerGeneratedResFolders` + manual `dependsOn` for 4.x), alongside the existing Java source wiring.
- `AndroidAgentImpl` resolves the value via `Resources.getIdentifier(...)` during `init()` (agent-core has no Android SDK dependency, so this can't happen there) and pushes it to `Agent.setBuildId(...)`.
- `Agent.getBuildId()` returns the pushed value if present, otherwise falls back to its existing `NewRelicConfig` reflection path unchanged — covers a plugin/agent-core version mismatch where an older plugin doesn't generate the resource yet.
- Same root fix as #496, via a different carrier (Android resource vs. JSON asset) — see that PR's discussion for comparison notes.

## Callouts

- **Version skew:** new agent-core + old plugin falls back cleanly (resource absent → reflection path). Old agent-core + new plugin is *not* supported — the old `Agent.java` would reflect the now-placeholder `BUILD_ID`. Plugin and agent-core ship from this repo in lockstep, so this is a documented limitation, not defensive code.
- `CLAUDE.md` gets a short new note under "Build-Time vs Runtime Split" describing this mechanism for future readers (this is also the first commit of `CLAUDE.md` into the repo).

## Test plan

- `./gradlew :plugins:gradle:test` and `:plugins:gradle:integrationTests` — green, including new `NewRelicConfigTaskTest` cases asserting the resource is written and the compiled source keeps the placeholder.
- `./gradlew :plugins:gradle:functionalTests --tests PluginJDK11SmokeSpec --tests PluginJDK17SmokeSpec` — green against a real sample-app build, including the extended "verify NewRelicConfig was injected" assertions.
- `./gradlew :agent-core:test` (new `AgentBuildIdTest`) and `:agent:testReleaseUnitTest` (new `AndroidAgentImplTest` cases) — green, covering both the resource-resolution path and the reflection fallback.
- Manual: two clean builds of `samples/agent-test-app` with `--build-cache` confirm `compileReleaseJavaWithJavac`/`compileReleaseKotlin`/`minifyReleaseWithR8` are `FROM-CACHE` on the second run, while the generated build ID itself still differs between the two builds.

[NR-556102]: https://new-relic.atlassian.net/browse/NR-556102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ