### PR TITLE
fix(dexguard): register per-target map upload tasks to eliminate shared-state conflict (NR-583555)

### DIFF
--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
@@ -121,7 +121,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
         mapUploadVariants.each { var ->
             buildResult.task(":newrelicMapUploadApk${var.capitalize()}").outcome == SUCCESS
             // Check the tagged output file instead of original mapping file
-            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
+            with(new File(buildDir, "outputs/newrelic/apk/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
             }
@@ -211,7 +211,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
                 !text.contains(Proguard.NR_MAP_PREFIX)
             }
             // Check tagged output file for APK variant
-            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
+            with(new File(buildDir, "outputs/newrelic/apk/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
             }
@@ -248,7 +248,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
         mapUploadVariants.each { var ->
             buildResult.task(":newrelicMapUploadApk${var.capitalize()}").outcome == SUCCESS
             // APK mapping is tagged with the NR build ID and copied to the tagged output
-            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
+            with(new File(buildDir, "outputs/newrelic/apk/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
             }

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardIntegrationSpec.groovy
@@ -119,7 +119,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
         expect:
         filteredOutput.contains("Maps will be tagged and uploaded for variants [")
         mapUploadVariants.each { var ->
-            buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
+            buildResult.task(":newrelicMapUploadApk${var.capitalize()}").outcome == SUCCESS
             // Check the tagged output file instead of original mapping file
             with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()
@@ -153,18 +153,18 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
             buildResult.task(":dexguardApk${var.capitalize()}").outcome == SUCCESS
         }
         mapUploadVariants.each { var ->
-            buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
+            buildResult.task(":newrelicMapUploadApk${var.capitalize()}").outcome == SUCCESS
         }
     }
 
     def "verify dexguard mapping configuration"() {
         expect:
         mapUploadVariants.each { var ->
-            buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
+            buildResult.task(":newrelicMapUploadApk${var.capitalize()}").outcome == SUCCESS
         }
 
         ["release", "debug"].each { var ->
-            buildResult.task(":newrelicMapUpload${var.capitalize()}") == null
+            buildResult.task(":newrelicMapUploadApk${var.capitalize()}") == null
         }
     }
 
@@ -172,7 +172,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
         expect:
         ["release"].each { var ->
             buildResult.task(":dexguardApk${var.capitalize()}").outcome == SUCCESS
-            buildResult.task(":newrelicMapUpload${var.capitalize()}") == null
+            buildResult.task(":newrelicMapUploadApk${var.capitalize()}") == null
             with(new File(buildDir, "outputs/dexguard/mapping/apk/${var}/mapping.txt")) {
                 !text.contains(Proguard.NR_MAP_PREFIX)
             }
@@ -204,7 +204,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
             buildResult.task(":dexguardAab${var.capitalize()}").outcome == SUCCESS
         }
         mapUploadVariants.each { var ->
-            buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
+            buildResult.task(":newrelicMapUploadBundle${var.capitalize()}").outcome == SUCCESS
             // Bundle mapping should not be tagged (only APK mapping is tagged)
             with(new File(buildDir, "outputs/dexguard/mapping/bundle/release/mapping.txt")) {
                 exists()
@@ -246,7 +246,7 @@ class PluginDexGuardIntegrationSpec extends PluginSpec {
             buildResult.task(":${DexGuardHelper.DEXGUARD_APK_TASK}${var.capitalize()}").outcome == SUCCESS
         }
         mapUploadVariants.each { var ->
-            buildResult.task(":newrelicMapUpload${var.capitalize()}").outcome == SUCCESS
+            buildResult.task(":newrelicMapUploadApk${var.capitalize()}").outcome == SUCCESS
             // APK mapping is tagged with the NR build ID and copied to the tagged output
             with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
@@ -91,7 +91,7 @@ class PluginDexGuardRegressionSpec extends PluginSpec {
         mapUploadVariants.each { var ->
             buildResult.task(":newrelicMapUploadApk${var.capitalize()}")?.outcome == SUCCESS
             // Check the tagged output file instead of original mapping file
-            with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
+            with(new File(buildDir, "outputs/newrelic/apk/${var}/mapping.txt")) {
                 exists()
                 text.contains(Proguard.NR_MAP_PREFIX)
             }

--- a/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
+++ b/plugins/gradle/src/functional/groovy/com/newrelic/agent/android/PluginDexGuardRegressionSpec.groovy
@@ -89,8 +89,7 @@ class PluginDexGuardRegressionSpec extends PluginSpec {
         }
 
         mapUploadVariants.each { var ->
-            buildResult.task(":newrelicMapUpload${var.capitalize()}")?.outcome == SUCCESS ||
-                    buildResult.task(":newrelicMapUploadDexguard${var.capitalize()}")?.outcome == SUCCESS
+            buildResult.task(":newrelicMapUploadApk${var.capitalize()}")?.outcome == SUCCESS
             // Check the tagged output file instead of original mapping file
             with(new File(buildDir, "outputs/newrelic/${var}/mapping.txt")) {
                 exists()

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -118,7 +118,9 @@ class DexGuardHelperTest extends PluginTest {
     void wireDexGuardMapProviders_apkOnly_wiresApkTaskOnly() {
         project.tasks.register("dexguardApkRelease")
 
-        dexGuardHelper.wireDexGuardMapProviders("release")
+        def taskTypeTargets = [(DexGuardHelper.DEXGUARD_APK_TASK): "apk", (DexGuardHelper.DEXGUARD_AAB_TASK): "bundle", (DexGuardHelper.DEXGUARD_BUNDLE_TASK): "bundle"]
+        def wiredTaskNames = taskTypeTargets.keySet().collect { it + "Release" }.toSet()
+        dexGuardHelper.wireDexGuardPackagingTasks("release", taskTypeTargets, wiredTaskNames)
 
         def apkUpload = buildHelper.project.tasks.named("newrelicMapUploadApkRelease", NewRelicMapUploadTask.class)
         Assert.assertNotNull(apkUpload)
@@ -136,7 +138,9 @@ class DexGuardHelperTest extends PluginTest {
     void wireDexGuardMapProviders_bundleOnly_wiresBundleTaskOnly() {
         project.tasks.register("dexguardAabRelease")
 
-        dexGuardHelper.wireDexGuardMapProviders("release")
+        def taskTypeTargets = [(DexGuardHelper.DEXGUARD_APK_TASK): "apk", (DexGuardHelper.DEXGUARD_AAB_TASK): "bundle", (DexGuardHelper.DEXGUARD_BUNDLE_TASK): "bundle"]
+        def wiredTaskNames = taskTypeTargets.keySet().collect { it + "Release" }.toSet()
+        dexGuardHelper.wireDexGuardPackagingTasks("release", taskTypeTargets, wiredTaskNames)
 
         def bundleUpload = buildHelper.project.tasks.named("newrelicMapUploadBundleRelease", NewRelicMapUploadTask.class)
         Assert.assertNotNull(bundleUpload)
@@ -155,7 +159,9 @@ class DexGuardHelperTest extends PluginTest {
         def apkTask = project.tasks.register("dexguardApkRelease")
         def bundleTask = project.tasks.register("dexguardAabRelease")
 
-        dexGuardHelper.wireDexGuardMapProviders("release")
+        def taskTypeTargets = [(DexGuardHelper.DEXGUARD_APK_TASK): "apk", (DexGuardHelper.DEXGUARD_AAB_TASK): "bundle", (DexGuardHelper.DEXGUARD_BUNDLE_TASK): "bundle"]
+        def wiredTaskNames = taskTypeTargets.keySet().collect { it + "Release" }.toSet()
+        dexGuardHelper.wireDexGuardPackagingTasks("release", taskTypeTargets, wiredTaskNames)
 
         def apkUpload = buildHelper.project.tasks.named("newrelicMapUploadApkRelease", NewRelicMapUploadTask.class).get()
         def bundleUpload = buildHelper.project.tasks.named("newrelicMapUploadBundleRelease", NewRelicMapUploadTask.class).get()
@@ -172,6 +178,22 @@ class DexGuardHelperTest extends PluginTest {
         Assert.assertFalse(apkUpload.taskDependencies.getDependencies(apkUpload).contains(bundleTask.get()))
         Assert.assertTrue(bundleUpload.taskDependencies.getDependencies(bundleUpload).contains(bundleTask.get()))
         Assert.assertFalse(bundleUpload.taskDependencies.getDependencies(bundleUpload).contains(apkTask.get()))
+    }
+
+    @Test
+    void wireDexGuardMapProviders_onAlreadyEvaluatedProject_doesNotThrow() {
+        // Production always calls wireDexGuardMapProviders() from within the New Relic
+        // plugin's own project.afterEvaluate, so project.state.executed is already true
+        // and the deferred buildHelper.project.afterEvaluate{} registration inside it is
+        // the only branch that ever runs for real builds. In this test, the fake
+        // ProjectBuilder project is already fully evaluated AND sealed (PluginTest's
+        // beforeEach forces evaluation), so registering another afterEvaluate callback
+        // throws InvalidUserCodeException. That exception must be silently absorbed by
+        // wireDexGuardMapProviders' own try/catch — calling the public method directly
+        // here must complete without throwing (it simply no-ops the deferred wiring).
+        project.tasks.register("dexguardApkRelease")
+
+        dexGuardHelper.wireDexGuardMapProviders("release")
     }
 
     @Test

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -220,6 +220,7 @@ class DexGuardHelperTest extends PluginTest {
 
         Assert.assertEquals("newrelicMapUploadApkRelease", apkProvider.get().name)
         Assert.assertEquals("newrelicMapUploadBundleRelease", bundleProvider.get().name)
+        Assert.assertNotSame(apkProvider.get(), bundleProvider.get())
 
         def apkMappingPath = apkProvider.get().mappingFile.get().asFile.absolutePath
         def bundleMappingPath = bundleProvider.get().mappingFile.get().asFile.absolutePath
@@ -228,9 +229,29 @@ class DexGuardHelperTest extends PluginTest {
         Assert.assertTrue(bundleMappingPath.contains("/bundle/"))
         Assert.assertNotEquals(apkMappingPath, bundleMappingPath)
 
-        // re-fetching the apk provider must not have been mutated by configuring the bundle one
+        // re-registering the apk provider is idempotent: it returns the same task
+        // (registerOrNamed falls back to tasks.named() the second time) still configured
+        // with its own apk mapping file, not the bundle one
         Assert.assertTrue(buildHelper.variantAdapter.wiredWithMapUploadProvider("release", "apk")
                 .get().mappingFile.get().asFile.absolutePath.contains("/apk/"))
+    }
+
+    @Test
+    void wiredWithMapUploadProvider_perTarget_honorsVariantConfigurationOverride() {
+        def customMappingFile = new File(tmpProjectDir.root, "custom/release/mapping.txt")
+        def conf = buildHelper.project.objects.newInstance(VariantConfiguration.class, "release").tap {
+            uploadMappingFile = true
+            mappingFile = customMappingFile
+        }
+        buildHelper.extension.variantConfigurations.add(conf)
+
+        def apkProvider = buildHelper.variantAdapter.wiredWithMapUploadProvider("release", "apk")
+        def resolvedPath = apkProvider.get().mappingFile.get().asFile.absolutePath
+
+        // a user-supplied variantConfigurations.mappingFile override must win over the
+        // DexGuard-resolved, per-target path
+        Assert.assertEquals(customMappingFile.absolutePath, resolvedPath)
+        Assert.assertFalse(resolvedPath.contains("/dexguard/"))
     }
 
 }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -306,6 +306,15 @@ class DexGuardHelperTest extends PluginTest {
         // with its own apk mapping file, not the bundle one
         Assert.assertTrue(buildHelper.variantAdapter.wiredWithMapUploadProvider("release", "apk")
                 .get().mappingFile.get().asFile.absolutePath.contains("/apk/"))
+
+        // each target's *tagged output* copy must also be distinct, or the APK and
+        // Bundle tasks overwrite each other's tagged mapping.txt on disk (NR-583555)
+        def apkTaggedPath = apkProvider.get().getTaggedMappingFile().absolutePath
+        def bundleTaggedPath = bundleProvider.get().getTaggedMappingFile().absolutePath
+
+        Assert.assertTrue(apkTaggedPath.contains("/apk/"))
+        Assert.assertTrue(bundleTaggedPath.contains("/bundle/"))
+        Assert.assertNotEquals(apkTaggedPath, bundleTaggedPath)
     }
 
     @Test

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -30,6 +30,11 @@ class DexGuardHelperTest extends PluginTest {
         dexGuardHelper = Mockito.spy(DexGuardHelper.register(buildHelper))
         Mockito.when(dexGuardHelper.getEnabled()).thenReturn(true)
         Mockito.when(dexGuardHelper.getCurrentVersion()). thenReturn(DexGuardHelper.minSupportedVersion)
+
+        // VariantAdapter holds a reference to the original (un-spied) BuildHelper instance
+        // created when the "newrelic" plugin was applied, so it never sees the enabled/DexGuard-9
+        // dexGuardHelper spy above unless it's wired onto that original instance too.
+        plugin.buildHelper.withDexGuardHelper(dexGuardHelper)
     }
 
     @Test
@@ -206,6 +211,26 @@ class DexGuardHelperTest extends PluginTest {
                 Assert.assertTrue("Configuration should complete without conflicts", true)
             }
         }
+    }
+
+    @Test
+    void wiredWithMapUploadProvider_perTarget_usesDistinctTasksAndMappingFiles() {
+        def apkProvider = buildHelper.variantAdapter.wiredWithMapUploadProvider("release", "apk")
+        def bundleProvider = buildHelper.variantAdapter.wiredWithMapUploadProvider("release", "bundle")
+
+        Assert.assertEquals("newrelicMapUploadApkRelease", apkProvider.get().name)
+        Assert.assertEquals("newrelicMapUploadBundleRelease", bundleProvider.get().name)
+
+        def apkMappingPath = apkProvider.get().mappingFile.get().asFile.absolutePath
+        def bundleMappingPath = bundleProvider.get().mappingFile.get().asFile.absolutePath
+
+        Assert.assertTrue(apkMappingPath.contains("/apk/"))
+        Assert.assertTrue(bundleMappingPath.contains("/bundle/"))
+        Assert.assertNotEquals(apkMappingPath, bundleMappingPath)
+
+        // re-fetching the apk provider must not have been mutated by configuring the bundle one
+        Assert.assertTrue(buildHelper.variantAdapter.wiredWithMapUploadProvider("release", "apk")
+                .get().mappingFile.get().asFile.absolutePath.contains("/apk/"))
     }
 
 }

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -115,13 +115,63 @@ class DexGuardHelperTest extends PluginTest {
     }
 
     @Test
-    void wireDexGuardMapProviders() {
-        Assert.assertEquals(3, buildHelper.variantAdapter.getVariantValues().size())
-        buildHelper.variantAdapter.getVariantValues().each { variant ->
-            if (buildHelper.extension.shouldIncludeMapUpload(variant.name)) {
-                Assert.assertNotNull(buildHelper.project.tasks.named("${NewRelicMapUploadTask.NAME}${variant.name.capitalize()}", NewRelicMapUploadTask.class))
-            }
+    void wireDexGuardMapProviders_apkOnly_wiresApkTaskOnly() {
+        project.tasks.register("dexguardApkRelease")
+
+        dexGuardHelper.wireDexGuardMapProviders("release")
+
+        def apkUpload = buildHelper.project.tasks.named("newrelicMapUploadApkRelease", NewRelicMapUploadTask.class)
+        Assert.assertNotNull(apkUpload)
+        Assert.assertTrue(apkUpload.get().mappingFile.get().asFile.absolutePath.contains("/apk/"))
+
+        try {
+            buildHelper.project.tasks.named("newrelicMapUploadBundleRelease")
+            Assert.fail("bundle upload task should not have been created when no dexguardAab/dexguardBundle task exists")
+        } catch (org.gradle.api.UnknownTaskException ignored) {
+            // expected
         }
+    }
+
+    @Test
+    void wireDexGuardMapProviders_bundleOnly_wiresBundleTaskOnly() {
+        project.tasks.register("dexguardAabRelease")
+
+        dexGuardHelper.wireDexGuardMapProviders("release")
+
+        def bundleUpload = buildHelper.project.tasks.named("newrelicMapUploadBundleRelease", NewRelicMapUploadTask.class)
+        Assert.assertNotNull(bundleUpload)
+        Assert.assertTrue(bundleUpload.get().mappingFile.get().asFile.absolutePath.contains("/bundle/"))
+
+        try {
+            buildHelper.project.tasks.named("newrelicMapUploadApkRelease")
+            Assert.fail("apk upload task should not have been created when no dexguardApk task exists")
+        } catch (org.gradle.api.UnknownTaskException ignored) {
+            // expected
+        }
+    }
+
+    @Test
+    void wireDexGuardMapProviders_bothApkAndBundle_wiresBothIndependently() {
+        def apkTask = project.tasks.register("dexguardApkRelease")
+        def bundleTask = project.tasks.register("dexguardAabRelease")
+
+        dexGuardHelper.wireDexGuardMapProviders("release")
+
+        def apkUpload = buildHelper.project.tasks.named("newrelicMapUploadApkRelease", NewRelicMapUploadTask.class).get()
+        def bundleUpload = buildHelper.project.tasks.named("newrelicMapUploadBundleRelease", NewRelicMapUploadTask.class).get()
+
+        // each upload task has its own, distinct, correctly-targeted mapping file
+        def apkMappingPath = apkUpload.mappingFile.get().asFile.absolutePath
+        def bundleMappingPath = bundleUpload.mappingFile.get().asFile.absolutePath
+        Assert.assertTrue(apkMappingPath.contains("/apk/"))
+        Assert.assertTrue(bundleMappingPath.contains("/bundle/"))
+        Assert.assertNotEquals(apkMappingPath, bundleMappingPath)
+
+        // each upload task depends on its own packaging task, not the other one's
+        Assert.assertTrue(apkUpload.taskDependencies.getDependencies(apkUpload).contains(apkTask.get()))
+        Assert.assertFalse(apkUpload.taskDependencies.getDependencies(apkUpload).contains(bundleTask.get()))
+        Assert.assertTrue(bundleUpload.taskDependencies.getDependencies(bundleUpload).contains(bundleTask.get()))
+        Assert.assertFalse(bundleUpload.taskDependencies.getDependencies(bundleUpload).contains(apkTask.get()))
     }
 
     @Test

--- a/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
+++ b/plugins/gradle/src/integration/groovy/com/newrelic/agent/android/DexGuardHelperTest.groovy
@@ -64,6 +64,18 @@ class DexGuardHelperTest extends PluginTest {
     }
 
     @Test
+    void getMappingFileProviderForTarget() {
+        Assert.assertTrue(dexGuardHelper.isDexGuard9())
+
+        def apkPath = dexGuardHelper.getMappingFileProvider("release", "apk").getAsFile().get().getAbsolutePath()
+        def bundlePath = dexGuardHelper.getMappingFileProvider("release", "bundle").getAsFile().get().getAbsolutePath()
+
+        Assert.assertTrue(apkPath.contains("/dexguard/mapping/apk/"))
+        Assert.assertTrue(bundlePath.contains("/dexguard/mapping/bundle/"))
+        Assert.assertNotEquals(apkPath, bundlePath)
+    }
+
+    @Test
     void configureDexGuard() {
         dexGuardHelper.configureDexGuard()
         Assert.assertEquals(3, buildHelper.variantAdapter.getVariantValues().size())

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/DexGuardHelper.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/DexGuardHelper.groovy
@@ -95,10 +95,14 @@ class DexGuardHelper {
 
     /**
      * Returns a RegularFile property representing the correct mapping file location
-     * @param variantDirName
+     * @param variantName
+     * @param target "apk", "bundle", or "aar" — the DexGuard packaging target this
+     *               mapping file belongs to. Defaults to the literal placeholder
+     *               "<target>" for backward compatibility with callers that don't
+     *               know the target yet (legacy/generic resolution).
      * @return RegularFileProperty
      */
-    RegularFileProperty getMappingFileProvider(String variantName) {
+    RegularFileProperty getMappingFileProvider(String variantName, String target = "<target>") {
         def variant = buildHelper.variantAdapter.withVariant(variantName)
 
         logger.lifecycle("DexGuardHelper.getMappingFileProvider: Variant object name: ${variant?.name}")
@@ -106,7 +110,6 @@ class DexGuardHelper {
         logger.lifecycle("DexGuardHelper.getMappingFileProvider: Variant buildType: ${variant?.buildType}")
 
         if (isDexGuard9()) {
-            // caller must replace target with [apk, bundle]
             // Construct path based on whether variant has a flavor
             def pathSegment
             if (variant.flavorName && !variant.flavorName.isEmpty()) {
@@ -119,7 +122,7 @@ class DexGuardHelper {
                 logger.lifecycle("DexGuardHelper.getMappingFileProvider: Variant has no flavor, pathSegment: ${pathSegment}")
             }
 
-            def finalPath = "outputs/dexguard/mapping/<target>/${pathSegment}/mapping.txt"
+            def finalPath = "outputs/dexguard/mapping/${target}/${pathSegment}/mapping.txt"
             logger.lifecycle("DexGuardHelper.getMappingFileProvider: Final mapping path: ${finalPath}")
 
             return objectFactory.fileProperty().value(buildHelper.project.layout

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/DexGuardHelper.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/DexGuardHelper.groovy
@@ -138,34 +138,37 @@ class DexGuardHelper {
 
     protected wireDexGuardMapProviders(String variantName) {
         try {
-            // create a map upload task for this variant
-            buildHelper.variantAdapter.wiredWithMapUploadProvider(variantName)
+            def vnc = variantName.capitalize()
 
-            buildHelper.project.afterEvaluate {
-                // Use priority-based selection to prevent dual execution of APK and AAB tasks
-                def primaryTaskType = determinePrimaryDexGuardTaskType()
-                def wiredTaskNames = [primaryTaskType].collect { it + variantName.capitalize() }
+            // Applications may produce both an APK and an AAB/bundle output in the
+            // same build, so every applicable DexGuard packaging task type is wired
+            // to its own dedicated map-upload task — never a shared one. Libraries
+            // only ever produce an AAR. Both "dexguardAab" and "dexguardBundle" task
+            // prefixes map to the same "bundle" target: different DexGuard plugin
+            // versions name the bundle-packaging task differently.
+            def taskTypeTargets = buildHelper.checkLibrary() ?
+                    [(DEXGUARD_AAR_TASK): "aar"] :
+                    [(DEXGUARD_APK_TASK): "apk", (DEXGUARD_AAB_TASK): "bundle", (DEXGUARD_BUNDLE_TASK): "bundle"]
 
-                logger.debug("DexGuard: Selected primary task type '${primaryTaskType}' for variant '${variantName}'")
+            def wiredTaskNames = taskTypeTargets.keySet().collect { it + vnc }.toSet()
 
-                buildHelper.wireTaskProviderToDependencyNames(wiredTaskNames.toSet()) { taskProvider ->
-                    if (taskProvider.name.startsWith(DEXGUARD_APK_TASK)) {
-                        finalizeMapUploadProvider(taskProvider, variantName) {
-                            it.replace("<target>", "apk")
-                        }
-                    } else if (taskProvider.name.startsWith(DEXGUARD_BUNDLE_TASK)) {
-                        finalizeMapUploadProvider(taskProvider, variantName) {
-                            it.replace("<target>", "bundle")
-                        }
-                    } else if (taskProvider.name.startsWith(DEXGUARD_AAB_TASK)) {
-                        finalizeMapUploadProvider(taskProvider, variantName) {
-                            it.replace("<target>", "bundle")
-                        }
-                    } else if (taskProvider.name.startsWith(DEXGUARD_AAR_TASK)) {
-                        // AAR tasks don't need target replacement as they use different path structure
-                        finalizeMapUploadProvider(taskProvider, variantName)
-                    }
+            def wireAction = {
+                buildHelper.wireTaskProviderToDependencyNames(wiredTaskNames) { taskProvider ->
+                    def taskType = taskTypeTargets.keySet().find { taskProvider.name.startsWith(it) }
+                    finalizeMapUploadProvider(taskProvider, variantName, taskTypeTargets[taskType])
                 }
+            }
+
+            // The normal call path (configureDexGuard(), from within the plugin's own
+            // project.afterEvaluate) runs before the project is fully evaluated, so
+            // deferring via afterEvaluate is required to see DexGuard's packaging tasks.
+            // But if this is invoked after evaluation has already completed, calling
+            // afterEvaluate again would throw — wire immediately instead, since any
+            // DexGuard task that will ever exist for this variant already does.
+            if (buildHelper.project.state.executed) {
+                wireAction()
+            } else {
+                buildHelper.project.afterEvaluate(wireAction)
             }
 
         } catch (Exception e) {
@@ -230,27 +233,19 @@ class DexGuardHelper {
         }
     }
 
-    void finalizeMapUploadProvider(TaskProvider dependencyTaskProvider, String variantName, Closure closure = null) {
+    void finalizeMapUploadProvider(TaskProvider dependencyTaskProvider, String variantName, String target = "") {
         try {
-            def mapUploadTaskProvider = buildHelper.variantAdapter.getMapUploadProvider(variantName)
+            def mapUploadTaskProvider = buildHelper.variantAdapter.wiredWithMapUploadProvider(variantName, target)
 
             mapUploadTaskProvider.configure { mapUploadTask ->
                 mapUploadTask.dependsOn(dependencyTaskProvider)
                 try {
-                    // update the map file path if needed
-                    if (closure) {
-                        def mapPath = closure(mapUploadTask.mappingFile.get().asFile.absolutePath)
-                        mapUploadTask.mappingFile.set(buildHelper.project.file(mapPath))
-                    }
-
                     if (!mapUploadTask.buildId.isPresent()) {
                         mapUploadTask.buildId.set(BuildId.getBuildId(variantName))
                     }
-
                 } catch (Exception e) {
                     logger.error("finalizeMapUploadProvider: $e")
                 }
-
             }
 
             dependencyTaskProvider.configure {
@@ -261,41 +256,6 @@ class DexGuardHelper {
             // task for this variant not available or other configuration error
             logger.error("finalizeMapUploadProvider: $e")
         }
-    }
-
-    /**
-     * Determines the primary DexGuard task type to wire.
-     *
-     * Libraries always produce AARs. For applications we select APK vs AAB based on the
-     * tasks the user actually requested, so the map upload is wired to whatever packaging
-     * output is being built. (Previously this always chose AAB for applications, which meant
-     * APK-only builds such as {@code dexguardApkRelease} never triggered the map upload.)
-     *
-     * A single task type is returned (rather than wiring both APK and AAB) to avoid the
-     * shared map-upload task having its mapping-file path reconfigured by two packaging
-     * branches in the same build. AAB is only chosen when a bundle/AAB build is requested
-     * without an accompanying APK build; otherwise we default to APK, which matches the
-     * output of {@code assemble}/{@code build}.
-     *
-     * @return The primary DexGuard task type constant
-     */
-    private String determinePrimaryDexGuardTaskType() {
-        // Libraries need AAR tasks for proper artifact generation
-        if (buildHelper.checkLibrary()) {
-            return DEXGUARD_AAR_TASK
-        }
-
-        if (buildHelper.checkApplication()) {
-            def requestedTasks = buildHelper.project.gradle.startParameter.taskNames*.toLowerCase()
-            def wantsBundle = requestedTasks.any { it.contains("bundle") || it.contains("aab") }
-            def wantsApk = requestedTasks.any { it.contains("assemble") || it.contains("apk") }
-
-            // Prefer AAB only for a bundle-only build; otherwise default to APK.
-            return (wantsBundle && !wantsApk) ? DEXGUARD_AAB_TASK : DEXGUARD_APK_TASK
-        }
-
-        // Safe fallback to APK for unknown project types
-        return DEXGUARD_APK_TASK
     }
 
     static Set<String> wiredTaskNames(String vnc) {

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/DexGuardHelper.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/DexGuardHelper.groovy
@@ -152,29 +152,21 @@ class DexGuardHelper {
 
             def wiredTaskNames = taskTypeTargets.keySet().collect { it + vnc }.toSet()
 
-            def wireAction = {
-                buildHelper.wireTaskProviderToDependencyNames(wiredTaskNames) { taskProvider ->
-                    def taskType = taskTypeTargets.keySet().find { taskProvider.name.startsWith(it) }
-                    finalizeMapUploadProvider(taskProvider, variantName, taskTypeTargets[taskType])
-                }
-            }
-
-            // The normal call path (configureDexGuard(), from within the plugin's own
-            // project.afterEvaluate) runs before the project is fully evaluated, so
-            // deferring via afterEvaluate is required to see DexGuard's packaging tasks.
-            // But if this is invoked after evaluation has already completed, calling
-            // afterEvaluate again would throw — wire immediately instead, since any
-            // DexGuard task that will ever exist for this variant already does.
-            if (buildHelper.project.state.executed) {
-                wireAction()
-            } else {
-                buildHelper.project.afterEvaluate(wireAction)
+            buildHelper.project.afterEvaluate {
+                wireDexGuardPackagingTasks(variantName, taskTypeTargets, wiredTaskNames)
             }
 
         } catch (Exception e) {
             // DexGuard task hasn't been created
             logger.error("configureDexGuard: " + e)
             logger.error(DEXGUARD_PLUGIN_ORDER_ERROR_MSG)
+        }
+    }
+
+    protected wireDexGuardPackagingTasks(String variantName, Map taskTypeTargets, Set<String> wiredTaskNames) {
+        buildHelper.wireTaskProviderToDependencyNames(wiredTaskNames) { taskProvider ->
+            def taskType = taskTypeTargets.keySet().find { taskProvider.name.startsWith(it) }
+            finalizeMapUploadProvider(taskProvider, variantName, taskTypeTargets[taskType])
         }
     }
 

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/NewRelicMapUploadTask.groovy
@@ -36,6 +36,18 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
     @Input
     abstract Property<String> getMapProvider()      // [proguard, r8, dexguard]
 
+    /**
+     * DexGuard packaging target ("apk", "bundle", "aar") this task's tagged
+     * output belongs to. Empty for the generic (non-DexGuard) map upload,
+     * which keeps its original, unqualified output path. Distinguishing the
+     * tagged output by target — not just variant — prevents the APK and
+     * Bundle/AAB map-upload tasks for the same variant from overwriting each
+     * other's tagged mapping.txt (NR-583555).
+     */
+    @Input
+    @org.gradle.api.tasks.Optional
+    abstract Property<String> getTarget()
+
     @Internal
     abstract DirectoryProperty getProjectRoot()
 
@@ -51,7 +63,11 @@ abstract class NewRelicMapUploadTask extends DefaultTask {
      */
     @OutputFile
     File getTaggedMappingFile() {
-        return buildDirectory.file("outputs/newrelic/" + variantName.get() + "/mapping.txt").get().asFile
+        def targetSegment = target.getOrElse("")
+        def path = targetSegment ?
+                "outputs/newrelic/${targetSegment}/${variantName.get()}/mapping.txt" :
+                "outputs/newrelic/${variantName.get()}/mapping.txt"
+        return buildDirectory.file(path).get().asFile
     }
 
     @Internal

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -196,9 +196,15 @@ abstract class VariantAdapter {
         return configProvider
     }
 
-    def wiredWithMapUploadProvider(String variantName) {
-        def mapUploadProvider = getMapUploadProvider(variantName) { mapUploadTask ->
-            def variantMap = getMappingFileProvider(variantName)
+    def wiredWithMapUploadProvider(String variantName, String target = "") {
+        def taskName = target ?
+                "${NewRelicMapUploadTask.NAME}${target.capitalize()}${variantName.capitalize()}" :
+                "${NewRelicMapUploadTask.NAME}${variantName.capitalize()}"
+
+        def mapUploadProvider = registerOrNamed(taskName, NewRelicMapUploadTask.class) { mapUploadTask ->
+            def variantMap = target ?
+                    buildHelper.dexguardHelper.getMappingFileProvider(variantName, target) :
+                    getMappingFileProvider(variantName)
             def uuid = objectFactory.property(String).value(BuildId.getBuildId(variantName))
 
             mapUploadTask.mappingFile.set(variantMap)
@@ -305,8 +311,9 @@ abstract class VariantAdapter {
             wiredWithConfigProvider(variantName)
         }
 
-        if (shouldUploadVariantMap(variantName)) {
-            // register map upload task(s)
+        if (shouldUploadVariantMap(variantName) && !(buildHelper.dexguardHelper?.enabled)) {
+            // register map upload task(s). DexGuard builds are wired separately,
+            // per packaging target, by DexGuardHelper.wireDexGuardMapProviders().
             wiredWithMapUploadProvider(variantName)
         }
     }

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -201,10 +201,30 @@ abstract class VariantAdapter {
                 "${NewRelicMapUploadTask.NAME}${target.capitalize()}${variantName.capitalize()}" :
                 "${NewRelicMapUploadTask.NAME}${variantName.capitalize()}"
 
+        // bypasses the abstract getMapUploadProvider — all three adapter implementations are
+        // identical one-liners; keeping name construction here avoids threading `target` through
+        // every adapter subclass
         def mapUploadProvider = registerOrNamed(taskName, NewRelicMapUploadTask.class) { mapUploadTask ->
-            def variantMap = target ?
-                    buildHelper.dexguardHelper.getMappingFileProvider(variantName, target) :
-                    getMappingFileProvider(variantName)
+            def variantMap
+            if (target) {
+                // honor a user-supplied variantConfigurations.mappingFile override before
+                // falling back to the DexGuard-resolved, per-target path — same precedence as
+                // AGP70Adapter.getMappingFileProvider / AGP9BaseAdapter.getMappingFileProvider
+                def variant = withVariant(variantName)
+                def variantConfiguration = buildHelper.extension.variantConfigurations.findByName(variantName)
+
+                if (variantConfiguration && variantConfiguration.mappingFile) {
+                    def variantMappingFilePath = variantConfiguration.mappingFile.getAbsolutePath()
+                            .replace("<name>", variant.name)
+                            .replace("<dirName>", variant.name)
+
+                    variantMap = objectFactory.fileProperty().fileValue(buildHelper.project.file(variantMappingFilePath))
+                } else {
+                    variantMap = buildHelper.dexguardHelper?.getMappingFileProvider(variantName, target)
+                }
+            } else {
+                variantMap = getMappingFileProvider(variantName)
+            }
             def uuid = objectFactory.property(String).value(BuildId.getBuildId(variantName))
 
             mapUploadTask.mappingFile.set(variantMap)

--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/VariantAdapter.groovy
@@ -234,6 +234,7 @@ abstract class VariantAdapter {
             mapUploadTask.buildId.convention(uuid)
             mapUploadTask.variantName.set(objectFactory.property(String).value(variantName))
             mapUploadTask.mapProvider.set(objectFactory.property(String).value(buildHelper.getMapCompilerName()))
+            mapUploadTask.target.set(target)
 
             mapUploadTask.onlyIf {
                 // Execute the task only if the given spec is satisfied. The spec will


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-583555](https://newrelic.atlassian.net/browse/NR-583555)

## Jira
[NR-583555](https://new-relic.atlassian.net/browse/NR-583555)

## What & Why
Follow-up to NR-564988 (PR #575). `DexGuardHelper` wired a single, shared `newrelicMapUpload<Variant>` task per variant and reconfigured its `mappingFile` property depending on whether the APK or AAB/Bundle DexGuard packaging task ran. When only one target was requested this worked, but:
- If a build requests **both** APK and AAB outputs, the last-configured branch's mapping file wins — the other target's mapping never uploads correctly.
- The previous fix (NR-564988) worked around this by picking a single "primary" task type based on the requested Gradle tasks, which still meant only one target's map upload could ever run.

This PR removes the single-task/single-selection model: every DexGuard packaging task that actually exists for a variant (`dexguardApk<Variant>`, `dexguardAab<Variant>`/`dexguardBundle<Variant>`, `dexguardAar<Variant>`) is now finalized by its own dedicated map-upload task (`newrelicMapUploadApk<Variant>` / `newrelicMapUploadBundle<Variant>`), each with its own immutable, correctly-resolved mapping-file path. No shared mutable state, no "last one wins."

## Callouts
- Task naming change: DexGuard builds now produce `newrelicMapUploadApk<Variant>` / `newrelicMapUploadBundle<Variant>` instead of the previous shared `newrelicMapUpload<Variant>`. The non-DexGuard (plain R8/Proguard) task name is unchanged.
- `VariantAdapter.assembleDataModel` no longer registers the generic map-upload task when DexGuard is enabled — `DexGuardHelper` owns map-upload task creation entirely for DexGuard builds now.
- `DexGuardHelper.determinePrimaryDexGuardTaskType()` is removed.
- Functional specs (`PluginDexGuardIntegrationSpec`, `PluginDexGuardRegressionSpec`) are updated for the new task names but require a real DexGuard license/Maven token to execute (`-Dintegrations=dexguard` / `-Dregressions=dexguard` + `DEXGUARD_LICENSE`/`DEXGUARD_MAVENTOKEN` env vars) — not run in this PR's CI, please run manually against a DexGuard-licensed environment before release if possible.

## Test plan
- New unit tests in `DexGuardHelperTest` cover APK-only, Bundle-only, and APK+Bundle-together wiring, asserting distinct task names, distinct mapping-file paths, and correct `dependsOn` wiring per target.
- `./gradlew :plugins:gradle:test :plugins:gradle:integrationTests` passes.
- Functional specs updated for correctness (see Callouts) but not executed here.

[NR-583555]: https://new-relic.atlassian.net/browse/NR-583555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ