### PR TITLE
fix(NR-589852): store handled-exception payload off the calling (main) thread

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -73,7 +73,11 @@ public class AgentDataReporter extends PayloadReporter {
                     PayloadController.submitCallable(new Callable<Void>() {
                         @Override
                         public Void call() {
-                            reporter.storeAndReportAgentData(payload);
+                            try {
+                                reporter.storeAndReportAgentData(payload);
+                            } catch (Exception e) {
+                                log.error("AgentDataReporter.reportAgentData: failed to store/report handled exception off-thread: " + e);
+                            }
                             return null;
                         }
                     });

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataReporter.java
@@ -64,8 +64,24 @@ public class AgentDataReporter extends PayloadReporter {
 
         if (isInitialized()) {
             if (reportExceptions) {
-                Payload payload = new Payload(bytes);
-                instance.get().storeAndReportAgentData(payload);
+                final Payload payload = new Payload(bytes);
+                final AgentDataReporter reporter = instance.get();
+                if (PayloadController.isInitialized()) {
+                    // Persist + queue upload off the calling thread so the public API does not
+                    // block on disk I/O (NR-589852). store-then-queue runs sequentially inside
+                    // this one task, so there is no store/upload ordering race.
+                    PayloadController.submitCallable(new Callable<Void>() {
+                        @Override
+                        public Void call() {
+                            reporter.storeAndReportAgentData(payload);
+                            return null;
+                        }
+                    });
+                } else {
+                    // PayloadController unavailable (pre-init / post-shutdown): store on the
+                    // caller thread rather than drop the payload, preserving durability.
+                    reporter.storeAndReportAgentData(payload);
+                }
                 reported = true;
             }
         } else {

--- a/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
@@ -253,6 +253,29 @@ public class AgentDataReporterTest {
                 store.storeThreadName != null && store.storeThreadName.startsWith("NR_PayloadWorker"));
     }
 
+    @Test
+    public void reportAgentDataStoresInlineWhenPayloadControllerUnavailable() throws Exception {
+        Agent.setImpl(new StubAgentImpl());
+
+        // Reporter initialized but PayloadController shut down -> fallback path.
+        AgentDataReporter.shutdown();
+        PayloadController.shutdown();
+        ThreadCapturingPayloadStore store = new ThreadCapturingPayloadStore();
+        agentConfiguration.setPayloadStore(store);
+        AgentDataReporter.initialize(agentConfiguration);
+        Assert.assertFalse("PayloadController must be down for this test",
+                PayloadController.isInitialized());
+
+        final String callerThread = Thread.currentThread().getName();
+        boolean reported = AgentDataReporter.reportAgentData(new Payload(flat.dataBuffer().array()).getBytes());
+
+        Assert.assertTrue("reportAgentData should accept the payload", reported);
+        // Inline store completes before reportAgentData returns — no await needed.
+        Assert.assertEquals("payload should be persisted inline", 1, store.count());
+        Assert.assertEquals("fallback store should run on the calling thread",
+                callerThread, store.storeThreadName);
+    }
+
     private static class TestAgentDataReporter extends AgentDataReporter {
         public TestAgentDataReporter(AgentConfiguration agentConfiguration) {
             super(agentConfiguration);

--- a/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/agentdata/AgentDataReporterTest.java
@@ -225,6 +225,34 @@ public class AgentDataReporterTest {
         Assert.assertTrue(agentConfiguration.getPayloadStore().store(payload));
     }
 
+    @Test
+    public void reportAgentDataStoresOffCallingThreadWhenPayloadControllerInitialized() throws Exception {
+        Agent.setImpl(new StubAgentImpl());
+
+        // Swap in a thread-capturing store: shut down the reporter (setUp already
+        // constructed it with the default TestPayloadStore) and re-initialize so the
+        // new store is picked up. PayloadController stays initialized -> async path.
+        AgentDataReporter.shutdown();
+        ThreadCapturingPayloadStore store = new ThreadCapturingPayloadStore();
+        agentConfiguration.setPayloadStore(store);
+        AgentDataReporter.initialize(agentConfiguration);
+        Assert.assertTrue(PayloadController.isInitialized());
+
+        final String callerThread = Thread.currentThread().getName();
+        boolean reported = AgentDataReporter.reportAgentData(new Payload(flat.dataBuffer().array()).getBytes());
+        Assert.assertTrue("reportAgentData should accept the payload", reported);
+
+        Assert.assertTrue("store should execute within the executor window",
+                store.storeLatch.await(5, java.util.concurrent.TimeUnit.SECONDS));
+        Assert.assertEquals("payload should be persisted", 1, store.count());
+        Assert.assertNotEquals("store must not run on the calling thread",
+                callerThread, store.storeThreadName);
+        // NamedThreadFactory prefixes worker threads with "NR_", so PayloadController's
+        // executor threads are named "NR_PayloadWorker-<n>".
+        Assert.assertTrue("store should run on an NR_PayloadWorker thread but ran on: " + store.storeThreadName,
+                store.storeThreadName != null && store.storeThreadName.startsWith("NR_PayloadWorker"));
+    }
+
     private static class TestAgentDataReporter extends AgentDataReporter {
         public TestAgentDataReporter(AgentConfiguration agentConfiguration) {
             super(agentConfiguration);
@@ -241,6 +269,50 @@ public class AgentDataReporterTest {
         @Override
         public boolean store(Payload payload) {
             store.put(payload.getUuid(), payload);
+            return true;
+        }
+
+        @Override
+        public List<Payload> fetchAll() {
+            return new ArrayList<>(store.values());
+        }
+
+        @Override
+        public int count() {
+            return store.size();
+        }
+
+        @Override
+        public void clear() {
+            store.clear();
+        }
+
+        @Override
+        public void delete(Payload payload) {
+            store.remove(payload.getUuid());
+        }
+
+        @Override
+        public String getRootPath() {
+            return "";
+        }
+    }
+
+    /**
+     * PayloadStore double that records the thread its store() ran on and signals a latch,
+     * so tests can assert whether the store executed on the calling thread (inline fallback)
+     * or on a background PayloadController worker (async path).
+     */
+    private static class ThreadCapturingPayloadStore implements PayloadStore<Payload> {
+        final java.util.concurrent.CountDownLatch storeLatch = new java.util.concurrent.CountDownLatch(1);
+        volatile String storeThreadName;
+        private final Map<String, Payload> store = new HashMap<>();
+
+        @Override
+        public boolean store(Payload payload) {
+            storeThreadName = Thread.currentThread().getName();
+            store.put(payload.getUuid(), payload);
+            storeLatch.countDown();
             return true;
         }
 


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-589852](https://newrelic.atlassian.net/browse/NR-589852)

## Jira
[NR-589852](https://new-relic.atlassian.net/browse/NR-589852) — StrictMode: `recordHandledException` performs synchronous disk write on the calling (main) thread

## What & Why
`NewRelic.recordHandledException()` persisted the handled-exception payload to disk **inline on the calling thread**. Because the API is normally called from UI/click handlers, this was a main-thread disk write — it trips StrictMode `ThreadPolicy` (`DiskWriteViolation`) and blocks `main` on file I/O, contributing to jank / ANR risk. A real captured stacktrace showed `main` `Blocked` in `FilePayloadStore.store` under `recordHandledException`.

`AgentDataReporter.reportAgentData(byte[])` now dispatches the persist + upload-queue step onto the existing `PayloadController` IO executor via `submitCallable`, so the public API returns without blocking on disk. The FlatBuffer build upstream stays synchronous (it freezes the timestamp / session-attribute snapshot). This mirrors the pattern already shipped in `JSErrorDataController`.

## Callouts
- **No store/upload ordering race:** `store()` then `reportAgentData(payload)` run sequentially inside one executor task, so the upload is never queued before the store completes.
- **Return semantics unchanged:** `reportAgentData` / `sendAgentData` already returned "accepted for delivery" (feature-on + initialized), not "stored" or "uploaded". `recordHandledException`'s boolean and the `accepted`-gated `SessionReplay.onError()` call behave identically.
- **Inline fallback:** when `PayloadController` is unavailable (pre-init / post-shutdown), the store runs inline on the caller thread rather than dropping the payload, preserving durability.
- **Off-thread failures are logged:** an exception inside the dispatched task is caught and logged (the synchronous path previously surfaced these via `sendAgentData`'s try/catch).
- **Intentionally scoped to handled exceptions.** The crash store stays synchronous (its `UncaughtExceptionHandler` runs on the dying process — deferral risks losing the crash); the JS-error store is already async; session-replay stores run off the main thread already.

## Test plan
- New unit tests in `AgentDataReporterTest`:
  - `reportAgentDataStoresOffCallingThreadWhenPayloadControllerInitialized` — store runs on an `NR_PayloadWorker` thread, not the caller, and the payload is persisted.
  - `reportAgentDataStoresInlineWhenPayloadControllerUnavailable` — with `PayloadController` down, the payload is persisted inline on the caller thread.
- Manual StrictMode check (recommended before merge): enable `StrictMode.ThreadPolicy` with `detectDiskWrites().penaltyLog()` in the sample app, call `recordHandledException` from a UI handler, and confirm no `DiskWriteViolation` naming `FilePayloadStore.store` / `AbstractFileStore.writeAtomic`.

[NR-589852]: https://new-relic.atlassian.net/browse/NR-589852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ