### PR TITLE
fix(rum): measure cold start to first frame (TTID) instead of launch-activity resume (NR-593759)

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
+++ b/agent/src/main/java/com/newrelic/agent/android/rum/AppApplicationLifeCycle.java
@@ -8,10 +8,14 @@ package com.newrelic.agent.android.rum;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Process;
 import android.os.SystemClock;
+import android.view.View;
+import android.view.ViewTreeObserver;
 
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.FeatureFlag;
@@ -35,6 +39,11 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
     private static boolean isActivityChangingConfig = false;
     private static boolean isForegrounded = false;
     private static boolean isBackgrounded = false;
+    // Latches true if the app is backgrounded before the first frame is drawn. In that case the
+    // cold-start (TTID) sample would include the backgrounded duration, so it is invalidated.
+    // Unambiguous: no activity handoff precedes the first frame, so a zero-activity state before
+    // the first draw is always a real user-backgrounding.
+    private static boolean backgroundedBeforeFirstDraw = false;
     private static int activityReferences = 0;
 
     private static AgentConfiguration agentConfiguration = new AgentConfiguration();
@@ -59,6 +68,11 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
         // ClassCastException with Microsoft Intune MAM's MAMContext wrapper
 
         AppTracer.getInstance().setAppOnCreateTime(SystemClock.uptimeMillis());
+        // Cold-start (TTID) start anchor: true process-creation time on API 24+, otherwise fall
+        // back to the content-provider init time (the earliest hook the agent has).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            AppTracer.getInstance().setProcessStartTime(Process.getStartUptimeMillis());
+        }
         if (this.context instanceof Application) {
             ((Application) this.context).registerActivityLifecycleCallbacks(this);
             // Captures end of Application.onCreate(): ContentProvider.onCreate runs inside
@@ -95,6 +109,9 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
                 tracer.setFirstActivityName(activity.getLocalClassName());
                 tracer.setFirstActivityReferrer(activity.getReferrer() + "");
                 tracer.setFirstActivityIntent(activity.getIntent());
+                // Cold start ends when the first frame is drawn (TTID). Watch the first activity's
+                // decor view for its first draw.
+                registerFirstFrameListener(activity);
             }
             log.debug("App launch time onActivityCreated " + new Date().getTime());
         } catch (Exception ex) {
@@ -129,24 +146,18 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
 
             log.debug(activity.getLocalClassName());
             AppTracer tracer = AppTracer.getInstance();
-            if (!firstActivityResumed
-                    && (agentConfiguration.getLaunchActivityClassName() == null
-                    || (agentConfiguration.getLaunchActivityClassName().equalsIgnoreCase(activity.getLocalClassName())))) {
-                firstActivityResumed = true;
+            if (isForegrounded) {
+                // Hot start: the app returned to the foreground from the background.
+                isForegrounded = false;
                 tracer.setFirstActivityResumeTime(SystemClock.uptimeMillis());
                 AppStartUpMetrics metrics = new AppStartUpMetrics();
-                if (tracer.isColdStart()) {
-                    StatsEngine.get().sample(MetricNames.APP_LAUNCH_COLD, metrics.getColdStartTime() / 1000.0f);
-                }
+                StatsEngine.get().sample(MetricNames.APP_LAUNCH_HOT, metrics.getHotStartTime() / 1000.0f);
                 log.debug("App launch time " + metrics.toString());
-            } else {
-                if (isForegrounded) {
-                    isForegrounded = false;
-                    tracer.setFirstActivityResumeTime(SystemClock.uptimeMillis());
-                    AppStartUpMetrics metrics = new AppStartUpMetrics();
-                    StatsEngine.get().sample(MetricNames.APP_LAUNCH_HOT, metrics.getHotStartTime() / 1000.0f);
-                    log.debug("App launch time " + metrics.toString());
-                }
+            } else if (!firstActivityResumed) {
+                // First resume of the cold session. Cold start (TTID) is measured at the first
+                // frame, not here; this only records the resume time for sub-timings/debug.
+                firstActivityResumed = true;
+                tracer.setFirstActivityResumeTime(SystemClock.uptimeMillis());
             }
         } catch (Exception ex) {
             log.error("App launch time exception: " + ex);
@@ -164,6 +175,11 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
         isActivityChangingConfig = activity.isChangingConfigurations();
         if (--activityReferences == 0 && !isActivityChangingConfig) {
             isBackgrounded = true;
+            if (!firstDrawInvoked) {
+                // Backgrounded before the first frame was drawn: the cold-start (TTID) sample
+                // would include the backgrounded time, so mark it invalid.
+                backgroundedBeforeFirstDraw = true;
+            }
         }
     }
 
@@ -185,6 +201,72 @@ public class AppApplicationLifeCycle implements Application.ActivityLifecycleCal
     @Override
     public void applicationBackgrounded(ApplicationStateEvent applicationStateEvent) {
         log.debug("App launch time applicationBackgrounded" + new Date().getTime());
+    }
+
+    /**
+     * Registers a one-shot listener on the activity's decor view that fires when the first frame
+     * is drawn, marking the end of the cold-start (TTID) window.
+     */
+    private void registerFirstFrameListener(final Activity activity) {
+        try {
+            final View decorView = activity.getWindow().getDecorView();
+            final ViewTreeObserver viewTreeObserver = decorView.getViewTreeObserver();
+            if (!viewTreeObserver.isAlive()) {
+                return;
+            }
+            viewTreeObserver.addOnDrawListener(new ViewTreeObserver.OnDrawListener() {
+                @Override
+                public void onDraw() {
+                    if (firstDrawInvoked) {
+                        return;
+                    }
+                    // Guarded: onDraw() runs during the view draw pass, so an uncaught exception
+                    // here would surface in rendering. A metric must never crash the UI.
+                    try {
+                        firstDrawInvoked = true;
+                        AppTracer.getInstance().setFirstDrawTime(SystemClock.uptimeMillis());
+                        sampleColdStart();
+                        // A listener cannot be removed from within onDraw(); post the removal.
+                        final ViewTreeObserver.OnDrawListener self = this;
+                        decorView.post(() -> {
+                            ViewTreeObserver vto = decorView.getViewTreeObserver();
+                            if (vto.isAlive()) {
+                                vto.removeOnDrawListener(self);
+                            }
+                        });
+                    } catch (Exception ex) {
+                        log.error("App launch time exception in first-frame listener: " + ex);
+                    }
+                }
+            });
+        } catch (Exception ex) {
+            log.error("App launch time exception registering first-frame listener: " + ex);
+        }
+    }
+
+    /**
+     * Samples the cold-start (TTID) metric if this launch qualifies. Invoked once, from the
+     * first-frame callback.
+     */
+    static void sampleColdStart() {
+        if (!FeatureFlag.featureEnabled(FeatureFlag.AppStartMetrics)) {
+            log.verbose("App launch time feature is not enabled.");
+            return;
+        }
+        AppTracer tracer = AppTracer.getInstance();
+        AppStartUpMetrics metrics = new AppStartUpMetrics();
+        if (shouldRecordColdStart(tracer.isColdStart(), backgroundedBeforeFirstDraw)) {
+            StatsEngine.get().sample(MetricNames.APP_LAUNCH_COLD, metrics.getColdStartTime() / 1000.0f);
+        }
+        log.debug("App launch time " + metrics.toString());
+    }
+
+    /**
+     * A cold-start sample is recorded only when this is a genuine cold start and the app was not
+     * backgrounded before the first frame drew (which would inflate the measurement).
+     */
+    static boolean shouldRecordColdStart(boolean isColdStart, boolean backgroundedBeforeFirstDraw) {
+        return isColdStart && !backgroundedBeforeFirstDraw;
     }
 
     private String emptyIfNull(String s) {

--- a/agent/src/main/java/com/newrelic/agent/android/rum/AppStartUpMetrics.java
+++ b/agent/src/main/java/com/newrelic/agent/android/rum/AppStartUpMetrics.java
@@ -28,8 +28,12 @@ public class AppStartUpMetrics {
                 : 0L;
         this.firstActivityCreateToResume =
                 tracer.getFirstActivityResumeTime() - tracer.getFirstActivityCreatedTime();
-        this.coldStartTime =
-                tracer.getFirstActivityResumeTime() - tracer.getContentProviderStartedTime();
+        // Cold start = Time To Initial Display (TTID): process creation → first frame drawn.
+        // Guarded so an unset firstDrawTime yields 0 rather than a negative value.
+        long firstDraw = tracer.getFirstDrawTime();
+        this.coldStartTime = firstDraw > 0
+                ? firstDraw - tracer.getProcessStartTime()
+                : 0L;
         this.hotStartTime = firstActivityStart > 0
                 ? tracer.getFirstActivityResumeTime() - firstActivityStart
                 : 0L;

--- a/agent/src/main/java/com/newrelic/agent/android/rum/AppTracer.java
+++ b/agent/src/main/java/com/newrelic/agent/android/rum/AppTracer.java
@@ -16,6 +16,7 @@ public final class AppTracer {
     private static final AtomicReference<AppTracer> instance = new AtomicReference<>(new AppTracer());
 
     private static Long contentProviderStartedTime = 0L;
+    private static Long processStartTime = 0L;
     private static Long appOnCreateTime = 0L;
     private static Long appOnCreateEndTime = 0L;
     private static Long firstDrawTime = 0L;
@@ -50,6 +51,21 @@ public final class AppTracer {
 
     public void setContentProviderStartedTime(Long contentProviderStartedTime) {
         AppTracer.contentProviderStartedTime = contentProviderStartedTime;
+    }
+
+    /**
+     * Process-creation time on the {@link SystemClock#uptimeMillis()} clock, used as the
+     * cold-start (TTID) start anchor. Falls back to {@link #getContentProviderStartedTime()}
+     * when the true process-start time is unavailable (below API 24 or not yet set).
+     */
+    public Long getProcessStartTime() {
+        return processStartTime != null && processStartTime > 0
+                ? processStartTime
+                : contentProviderStartedTime;
+    }
+
+    public void setProcessStartTime(Long processStartTime) {
+        AppTracer.processStartTime = processStartTime;
     }
 
     public Long getAppOnCreateTime() {

--- a/agent/src/test/java/com/newrelic/agent/android/rum/AppApplicationLifeCycleTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/rum/AppApplicationLifeCycleTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.rum;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Field;
+
+@RunWith(RobolectricTestRunner.class)
+public class AppApplicationLifeCycleTest {
+
+    private AppApplicationLifeCycle lifecycle;
+
+    @Before
+    public void setUp() throws Exception {
+        resetStatic("firstDrawInvoked", false);
+        resetStatic("firstActivityCreated", false);
+        resetStatic("firstActivityResumed", false);
+        resetStatic("isActivityChangingConfig", false);
+        resetStatic("isForegrounded", false);
+        resetStatic("isBackgrounded", false);
+        resetStatic("backgroundedBeforeFirstDraw", false);
+        resetStatic("activityReferences", 0);
+
+        StatsEngine.get().getStatsMap().clear();
+
+        AppTracer tracer = AppTracer.getInstance();
+        tracer.setContentProviderStartedTime(0L);
+        tracer.setProcessStartTime(0L);
+        tracer.setFirstActivityStartTime(0L);
+        tracer.setFirstActivityResumeTime(0L);
+        tracer.setFirstDrawTime(0L);
+        tracer.setIsColdStart(true);
+
+        lifecycle = new AppApplicationLifeCycle();
+    }
+
+    private static void resetStatic(String fieldName, Object value) throws Exception {
+        Field field = AppApplicationLifeCycle.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    private static boolean getStaticBoolean(String fieldName) throws Exception {
+        Field field = AppApplicationLifeCycle.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.getBoolean(null);
+    }
+
+    private static Activity activityNamed(String localClassName) {
+        Activity activity = mock(Activity.class);
+        when(activity.getLocalClassName()).thenReturn(localClassName);
+        when(activity.isChangingConfigurations()).thenReturn(false);
+        return activity;
+    }
+
+    // --- cold-start recording decision (pure) ---
+
+    @Test
+    public void shouldRecordColdStart_forGenuineColdStartNotBackgrounded() {
+        Assert.assertTrue(AppApplicationLifeCycle.shouldRecordColdStart(true, false));
+    }
+
+    @Test
+    public void shouldNotRecordColdStart_whenBackgroundedBeforeFirstFrame() {
+        Assert.assertFalse(AppApplicationLifeCycle.shouldRecordColdStart(true, true));
+    }
+
+    @Test
+    public void shouldNotRecordColdStart_whenNotAColdStart() {
+        Assert.assertFalse(AppApplicationLifeCycle.shouldRecordColdStart(false, false));
+    }
+
+    // --- cold-start sampling (integration through StatsEngine) ---
+
+    @Test
+    public void sampleColdStart_recordsColdMetric_forNormalColdStart() {
+        AppTracer tracer = AppTracer.getInstance();
+        tracer.setIsColdStart(true);
+        tracer.setProcessStartTime(100L);
+        tracer.setFirstDrawTime(1600L);
+
+        AppApplicationLifeCycle.sampleColdStart();
+
+        Assert.assertTrue("AppLaunch/Cold should be recorded to first frame on a normal cold start",
+                StatsEngine.get().getStatsMap().containsKey(MetricNames.APP_LAUNCH_COLD));
+    }
+
+    @Test
+    public void sampleColdStart_skipsColdMetric_whenBackgroundedBeforeFirstFrame() throws Exception {
+        AppTracer tracer = AppTracer.getInstance();
+        tracer.setIsColdStart(true);
+        tracer.setProcessStartTime(100L);
+        tracer.setFirstDrawTime(1600L);
+        resetStatic("backgroundedBeforeFirstDraw", true);
+
+        AppApplicationLifeCycle.sampleColdStart();
+
+        Assert.assertFalse("AppLaunch/Cold must not be recorded when backgrounded before the first frame",
+                StatsEngine.get().getStatsMap().containsKey(MetricNames.APP_LAUNCH_COLD));
+    }
+
+    @Test
+    public void sampleColdStart_skipsColdMetric_whenNotColdStart() {
+        AppTracer tracer = AppTracer.getInstance();
+        tracer.setIsColdStart(false);
+        tracer.setProcessStartTime(100L);
+        tracer.setFirstDrawTime(1600L);
+
+        AppApplicationLifeCycle.sampleColdStart();
+
+        Assert.assertFalse("AppLaunch/Cold must not be recorded for a warm/hot start",
+                StatsEngine.get().getStatsMap().containsKey(MetricNames.APP_LAUNCH_COLD));
+    }
+
+    // --- backgrounded-before-first-frame flag ---
+
+    @Test
+    public void backgroundedBeforeFirstDraw_setWhenAppStopsBeforeFirstFrame() throws Exception {
+        Activity activity = activityNamed("SplashActivity");
+
+        lifecycle.onActivityStarted(activity);
+        lifecycle.onActivityStopped(activity); // activityReferences -> 0 while firstDrawInvoked is false
+
+        Assert.assertTrue("backgrounding before the first frame must invalidate the cold sample",
+                getStaticBoolean("backgroundedBeforeFirstDraw"));
+    }
+
+    @Test
+    public void backgroundedBeforeFirstDraw_notSetWhenAppStopsAfterFirstFrame() throws Exception {
+        resetStatic("firstDrawInvoked", true); // first frame already drawn
+        Activity activity = activityNamed("MainActivity");
+
+        lifecycle.onActivityStarted(activity);
+        lifecycle.onActivityStopped(activity);
+
+        Assert.assertFalse("stopping after the first frame is a normal background, not a cold-start invalidation",
+                getStaticBoolean("backgroundedBeforeFirstDraw"));
+    }
+
+    // --- hot start behavior (unchanged) ---
+
+    @Test
+    public void hotStartMetricRecorded_onReturnToForeground() {
+        Activity activity = activityNamed("MainActivity");
+
+        // Foreground, then background, then return to foreground.
+        lifecycle.onActivityStarted(activity);
+        lifecycle.onActivityStopped(activity);   // activityReferences -> 0, isBackgrounded = true
+        lifecycle.onActivityStarted(activity);   // background -> foreground: isForegrounded = true
+        lifecycle.onActivityResumed(activity);
+
+        Assert.assertTrue("AppLaunch/Hot should be recorded on return to foreground",
+                StatsEngine.get().getStatsMap().containsKey(MetricNames.APP_LAUNCH_HOT));
+    }
+}

--- a/agent/src/test/java/com/newrelic/agent/android/rum/AppStartUpMetricsTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/rum/AppStartUpMetricsTest.java
@@ -22,6 +22,7 @@ public class AppStartUpMetricsTest {
         Assert.assertNotNull(tracerInstance);
 
         tracerInstance.setContentProviderStartedTime(100L);
+        tracerInstance.setProcessStartTime(0L);
         tracerInstance.setAppOnCreateTime(200L);
         tracerInstance.setAppOnCreateEndTime(300L);
         tracerInstance.setFirstDrawTime(400L);
@@ -38,7 +39,9 @@ public class AppStartUpMetricsTest {
         Assert.assertEquals(100L, (long) metrics.getApplicationOnCreateTime());
         Assert.assertEquals(200L, (long) metrics.getAppOnCreateEndToFirstActivityCreate());
         Assert.assertEquals(200L, (long) metrics.getFirstActivityCreateToResume());
-        Assert.assertEquals(600L, (long) metrics.getColdStartTime());
+        // Cold start (TTID) = firstDrawTime(400) - processStartTime; processStartTime is unset here
+        // so it falls back to contentProviderStartedTime(100) => 300.
+        Assert.assertEquals(300L, (long) metrics.getColdStartTime());
         Assert.assertEquals(100L, (long) metrics.getHotStartTime());
     }
 
@@ -53,6 +56,26 @@ public class AppStartUpMetricsTest {
 
         Assert.assertEquals(0L, (long) metrics.getApplicationOnCreateTime());
         Assert.assertEquals(0L, (long) metrics.getAppOnCreateEndToFirstActivityCreate());
+    }
+
+    @Test
+    public void coldStartUsesProcessStartTimeWhenSet() {
+        tracerInstance.setProcessStartTime(50L);
+        tracerInstance.setFirstDrawTime(400L);
+
+        AppStartUpMetrics metrics = new AppStartUpMetrics();
+
+        // firstDrawTime(400) - processStartTime(50) = 350
+        Assert.assertEquals(350L, (long) metrics.getColdStartTime());
+    }
+
+    @Test
+    public void firstDrawTimeUnset_returnsZeroColdStart() {
+        tracerInstance.setFirstDrawTime(0L);
+
+        AppStartUpMetrics metrics = new AppStartUpMetrics();
+
+        Assert.assertEquals(0L, (long) metrics.getColdStartTime());
     }
 
     @Test


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-593759](https://newrelic.atlassian.net/browse/NR-593759)

## Jira
[NR-593759](https://new-relic.atlassian.net/browse/NR-593759)

## What & Why
`AppLaunch/Cold` was computed as `launch-activity first onResume − contentProviderStart`, gated on `withLaunchActivityName`. When the app was backgrounded before that activity's first `onResume()` (e.g. during a splash screen), the eventual resume was still treated as cold-start completion, so the metric included the entire backgrounded duration — reproduced at **16.77s**.

This adopts Google's **Time To Initial Display (TTID)** definition: cold start = process creation → first frame drawn.

- **Start anchor:** `Process.getStartUptimeMillis()` (API 24+), fallback to content-provider init time below API 24.
- **Endpoint:** a one-shot `ViewTreeObserver.OnDrawListener` on the first activity's decor view captures the first frame and samples `AppLaunch/Cold`. The `onDraw` body is guarded so it can never crash the render pass.
- **Guard:** the sample is invalidated if the app was backgrounded before the first frame (unambiguous — no activity handoff precedes the first frame).
- **Removed** the launch-activity-gated cold path. `withLaunchActivityName` no longer affects cold start (public API retained, effectively deprecated for app-start metrics).

Verified on-device: cold now reports an accurate first-frame value instead of the inflated 16.77s.

## Callouts
- ⚠️ **Metric semantics change:** `AppLaunch/Cold` now measures to first frame (TTID), not to the configured launch activity's resume. Historical values are **not comparable** to post-fix values — needs a release-note line and a heads-up to cold-start dashboard owners.
- Also raised in NR-593518: `percentile()`/`WHERE newrelic.timeslice.value` on `AppLaunch/Cold` is a timeslice-metric NRQL limitation, not an agent bug — out of scope here, worth documenting in release notes.
- The `OnDrawListener` is registered in `onActivityCreated` and relies on the floating-ViewTreeObserver merge on attach; confirmed working on-device.

## Test plan
- New `AppApplicationLifeCycleTest`: cold-start recording decision, sampling through `StatsEngine`, backgrounded-before-first-frame invalidation, hot-start behavior.
- `AppStartUpMetricsTest`: TTID formula (`firstDraw − processStart`), process-start-time precedence, unset-first-draw → 0.
- Manual: force-stop + launch (no backgrounding) → sane sub-second `AppLaunch/Cold`; background during splash then return → not inflated.

[NR-593759]: https://new-relic.atlassian.net/browse/NR-593759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-593759]: https://new-relic.atlassian.net/browse/NR-593759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ