### PR TITLE
test(hybrid): assert isFatal argument overrides additionalAttributes (NR-590261)

### DIFF
--- a/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerAttributesTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/hybrid/JSErrorDataControllerAttributesTest.java
@@ -172,6 +172,23 @@ public class JSErrorDataControllerAttributesTest {
     }
 
     @Test
+    public void additionalAttributes_doNotOverrideIsFatal() throws Exception {
+        // isFatalError is set after the additionalAttributes merge, same as the
+        // other reserved wire keys, so a caller-supplied value under that key
+        // must be discarded in favor of the method's own isFatal argument.
+        Map<String, Object> extras = new HashMap<>();
+        extras.put(AnalyticsAttribute.JSERROR_ISFATAL, true);
+
+        JSErrorDataController.getInstance().sendJSErrorData(
+                "TypeError", "boom", "stack", false, extras);
+        Assert.assertTrue(store.latch.await(STORE_WAIT_SECONDS, TimeUnit.SECONDS));
+
+        JsonObject event = JsonParser.parseString(store.lastValue).getAsJsonObject();
+        Assert.assertFalse("method's isFatal argument must win over additionalAttributes",
+                event.get(AnalyticsAttribute.JSERROR_ISFATAL).getAsBoolean());
+    }
+
+    @Test
     public void nullMessage_isNormalizedToEmptyString() throws Exception {
         JSErrorDataController.getInstance().sendJSErrorData(
                 "TypeError", null, "stack", false, null);


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-590261](https://newrelic.atlassian.net/browse/NR-590261)

## Jira
[NR-590261](https://new-relic.atlassian.net/browse/NR-590261)

## What & Why
`JSErrorDataController.sendJSErrorData(...)` sets `isFatalError` **after** merging the caller-supplied `additionalAttributes` map, the same as the other reserved wire keys. This test locks in that precedence: a caller value under `JSERROR_ISFATAL` must be discarded in favor of the method's own `isFatal` argument.

Test-only; no production change.

## Test plan
- New `additionalAttributes_doNotOverrideIsFatal`: passes `isFatal=false` plus `additionalAttributes[JSERROR_ISFATAL]=true`, asserts the emitted event's `isFatalError` is `false`.

[NR-590261]: https://new-relic.atlassian.net/browse/NR-590261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ