### PR TITLE
fix(aei): Persist backgrounded state at exit time for accurate AEI background attribute

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
@@ -55,10 +55,6 @@ public class AEISessionMapper {
         return model == null ? "" : model.sessionId;
     }
 
-    public boolean getAppBackgrounded(int pid) {
-        AEISessionMeta model = get(pid);
-        return model != null && model.backgrounded;
-    }
 
     public int getRealAgentID(int pid) {
         AEISessionMeta model = get(pid);

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
@@ -67,7 +67,7 @@ public class AEISessionMapper {
     }
 
     @SuppressWarnings("unchecked")
-    public AEISessionMapper load() {
+    public void load() {
         if (mapStore.exists() && mapStore.canRead()) {
             try {
                 String storeData = Streams.slurpString(mapStore, StandardCharsets.UTF_8.toString());
@@ -82,8 +82,6 @@ public class AEISessionMapper {
         } else {
             AgentLogManager.getAgentLog().debug("Cannot read session ID mapper: file does not exist or is unreadable");
         }
-
-        return this;
     }
 
     public boolean flush() {
@@ -133,11 +131,14 @@ public class AEISessionMapper {
     public static class AEISessionMeta {
         final String sessionId;
         public final int realAgentId;
+        public boolean backgrounded;
 
-        public AEISessionMeta(String sessionId, int realAgentId) {
+        public AEISessionMeta(String sessionId, int realAgentId, boolean backgrounded) {
             this.sessionId = sessionId == null ? "" : sessionId;
             this.realAgentId = realAgentId;
+            this.backgrounded = backgrounded;
         }
+
 
         public boolean isValid() {
             return !(sessionId.isEmpty() || realAgentId == 0);

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
@@ -32,7 +32,7 @@ public class AEISessionMapper {
         this.mapStore = mapStore;
         this.mapper = new HashMap<>();
         if (mapStore.exists()) {
-            load();
+            restore();
         }
     }
 
@@ -55,6 +55,11 @@ public class AEISessionMapper {
         return model == null ? "" : model.sessionId;
     }
 
+    public boolean getAppBackgrounded(int pid) {
+        AEISessionMeta model = get(pid);
+        return model != null && model.backgrounded;
+    }
+
     public int getRealAgentID(int pid) {
         AEISessionMeta model = get(pid);
         return model == null ? 0 : model.realAgentId;
@@ -66,15 +71,14 @@ public class AEISessionMapper {
                 ? defaultSessionId : model.sessionId;
     }
 
-    @SuppressWarnings("unchecked")
-    public void load() {
+    public void restore() {
         if (mapStore.exists() && mapStore.canRead()) {
             try {
                 String storeData = Streams.slurpString(mapStore, StandardCharsets.UTF_8.toString());
                 final Type gtype = new TypeToken<Map<Integer, AEISessionMeta>>(){}.getType();
-                Map map = gson.fromJson(storeData, gtype);
+                Map<Integer, AEISessionMeta> map = gson.fromJson(storeData, gtype);
 
-                map.forEach((key, val) -> mapper.putIfAbsent((Integer) key, (AEISessionMeta) val));
+                map.forEach(mapper::putIfAbsent);
 
             } catch (Exception e) {
                 AgentLogManager.getAgentLog().error("Cannot read session ID mapper: " + e);

--- a/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/aei/AEISessionMapper.java
@@ -135,7 +135,7 @@ public class AEISessionMapper {
     public static class AEISessionMeta {
         final String sessionId;
         public final int realAgentId;
-        public boolean backgrounded;
+        public final boolean backgrounded;
 
         public AEISessionMeta(String sessionId, int realAgentId, boolean backgrounded) {
             this.sessionId = sessionId == null ? "" : sessionId;

--- a/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/agentdata/AgentDataController.java
@@ -151,7 +151,7 @@ public class AgentDataController {
 
                 //Background Reporting
                 if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting)) {
-                    if (ApplicationStateMonitor.isAppInBackground()) {
+                    if (ApplicationStateMonitor.isBackgrounded()) {
                         attributes.put(AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME, true);
                         StatsEngine.notice().inc(MetricNames.BACKGROUND_HANDLED_EXCEPTION_COUNT);
                     }

--- a/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/analytics/AnalyticsEvent.java
@@ -109,7 +109,7 @@ public class AnalyticsEvent extends HarvestableObject {
 
         //Background Reporting
         if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting)) {
-            if (ApplicationStateMonitor.isAppInBackground()) {
+            if (ApplicationStateMonitor.isBackgrounded()) {
                 this.attributeSet.add(new AnalyticsAttribute(AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME, true));
                 StatsEngine.notice().inc(MetricNames.BACKGROUND_EVENT_COUNT);
             }

--- a/agent-core/src/main/java/com/newrelic/agent/android/background/ApplicationStateMonitor.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/background/ApplicationStateMonitor.java
@@ -108,6 +108,7 @@ public class ApplicationStateMonitor {
     }
 
     private void notifyApplicationInForeground() {
+        foregrounded.set(true);
         final ArrayList<ApplicationStateListener> listeners;
         synchronized (applicationStateListeners) {
             listeners = new ArrayList<ApplicationStateListener>(applicationStateListeners);
@@ -116,6 +117,7 @@ public class ApplicationStateMonitor {
         for (ApplicationStateListener listener : listeners) {
             listener.applicationForegrounded(e);
         }
+
     }
 
     public ExecutorService getExecutor() {
@@ -126,7 +128,7 @@ public class ApplicationStateMonitor {
         return foregrounded.get();
     }
 
-    public static boolean isAppInBackground() {
+    public static boolean isBackgrounded() {
         return !getInstance().getForegrounded();
     }
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/Crash.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/Crash.java
@@ -183,7 +183,7 @@ public class Crash extends HarvestableObject {
 
         //Background Reporting
         if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting)) {
-            if (ApplicationStateMonitor.isAppInBackground()) {
+            if (ApplicationStateMonitor.isBackgrounded()) {
                 attrs.add(new AnalyticsAttribute(AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME, true));
                 StatsEngine.notice().inc(MetricNames.BACKGROUND_CRASH_COUNT);
             }

--- a/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
@@ -84,6 +84,13 @@ public class Error extends HarvestableObject {
 
         if (sessionMeta != null) {
             this.dataToken.setAgentId(sessionMeta.realAgentId);
+            if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting) && this.sessionAttributes != null) {
+                this.sessionAttributes.removeIf(attr -> AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME.equals(attr.getName()));
+                if (sessionMeta.backgrounded) {
+                    this.sessionAttributes.add(new AnalyticsAttribute(AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME, true));
+                    StatsEngine.notice().inc(MetricNames.BACKGROUND_CRASH_COUNT);
+                }
+            }
         }
     }
 

--- a/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
@@ -88,7 +88,9 @@ public class Error extends HarvestableObject {
                 this.sessionAttributes.removeIf(attr -> AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME.equals(attr.getName()));
                 if (sessionMeta.backgrounded) {
                     this.sessionAttributes.add(new AnalyticsAttribute(AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME, true));
-                    StatsEngine.notice().inc(MetricNames.BACKGROUND_CRASH_COUNT);
+                    if (!ApplicationStateMonitor.isBackgrounded()) {
+                        StatsEngine.notice().inc(MetricNames.BACKGROUND_CRASH_COUNT);
+                    }
                 }
             }
         }

--- a/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
@@ -168,7 +168,7 @@ public class Error extends HarvestableObject {
 
         //Background Reporting
         if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting)) {
-            if (ApplicationStateMonitor.isAppInBackground()) {
+            if (ApplicationStateMonitor.isBackgrounded()) {
                 attrs.add(new AnalyticsAttribute(AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME, true));
                 StatsEngine.notice().inc(MetricNames.BACKGROUND_CRASH_COUNT);
             }

--- a/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
@@ -148,9 +148,11 @@ public class Error extends HarvestableObject {
     public void setAnalyticsEvents(HashMap<String, Object> event) {
         this.event = event;
     }
+
     public boolean getIsObfuscated() {
         return Agent.getIsObfuscated();
     }
+
     public Set<AnalyticsAttribute> getErrorSessionAttributes(Set<AnalyticsAttribute> sessionAttributes) {
         if (sessionAttributes == null) {
             return null;

--- a/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/error/Error.java
@@ -148,11 +148,9 @@ public class Error extends HarvestableObject {
     public void setAnalyticsEvents(HashMap<String, Object> event) {
         this.event = event;
     }
-
     public boolean getIsObfuscated() {
         return Agent.getIsObfuscated();
     }
-
     public Set<AnalyticsAttribute> getErrorSessionAttributes(Set<AnalyticsAttribute> sessionAttributes) {
         if (sessionAttributes == null) {
             return null;

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestTimer.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/HarvestTimer.java
@@ -86,7 +86,7 @@ public class HarvestTimer implements Runnable {
                 log.debug("Harvest: executed");
                 log.debug("Harvest: executed in the background");
             } else {
-                if (ApplicationStateMonitor.isAppInBackground()) {
+                if (ApplicationStateMonitor.isBackgrounded()) {
                     log.error("HarvestTimer: Attempting to harvest while app is in background");
                 } else {
                     harvester.execute();
@@ -109,7 +109,7 @@ public class HarvestTimer implements Runnable {
 
     public void start() {
         if (!FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting)) {
-            if (ApplicationStateMonitor.isAppInBackground()) {
+            if (ApplicationStateMonitor.isBackgrounded()) {
                 log.warn("HarvestTimer: Attempting to start while app is in background");
                 return;
             }

--- a/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/harvest/Harvester.java
@@ -250,7 +250,7 @@ public class Harvester implements HarvestConfigurable {
         }
 
         //Background reporting
-        if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting) && ApplicationStateMonitor.isAppInBackground()) {
+        if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting) && ApplicationStateMonitor.isBackgrounded()) {
             StatsEngine.get().sampleTimeMs(MetricNames.SUPPORTABILITY_COLLECTOR + "Harvest/Background", response.getResponseTime());
         } else {
             StatsEngine.get().sampleTimeMs(MetricNames.SUPPORTABILITY_COLLECTOR + "Harvest", response.getResponseTime());
@@ -264,7 +264,7 @@ public class Harvester implements HarvestConfigurable {
             fireOnHarvestError();
 
             //Background reporting
-            if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting) && ApplicationStateMonitor.isAppInBackground()) {
+            if (FeatureFlag.featureEnabled(FeatureFlag.BackgroundReporting) && ApplicationStateMonitor.isBackgrounded()) {
                 StatsEngine.notice().inc(MetricNames.SUPPORTABILITY_COLLECTOR + "Harvest/Error/Background/" + response.getResponseCode());
             } else {
                 StatsEngine.notice().inc(MetricNames.SUPPORTABILITY_COLLECTOR + "Harvest/Error/" + response.getResponseCode());

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
@@ -22,11 +22,16 @@ import java.nio.file.Files;
 import java.util.Set;
 import java.util.UUID;
 
+
+
 public class AEISessionMapperTest {
 
     private static File reportsDir;
     private File sessionMapperFile;
     private AEISessionMapper mapper;
+
+    final private int[] pids = {123, 234, 345};
+    final private int[] realAgentIds = {321, 432, 543};
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -42,9 +47,9 @@ public class AEISessionMapperTest {
         sessionMapperFile = new File(reportsDir, "sessionMapper");
         mapper = new AEISessionMapper(sessionMapperFile);
 
-        mapper.put(123, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 321, false));
-        mapper.put(234, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 432, true));
-        mapper.put(345, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 543, false));
+        mapper.put(pids[0], new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), realAgentIds[0], false));
+        mapper.put(pids[1], new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), realAgentIds[1], true));
+        mapper.put(pids[2], new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), realAgentIds[2], false));
     }
 
     @After
@@ -66,12 +71,14 @@ public class AEISessionMapperTest {
 
     @Test
     public void get() {
-        Assert.assertNotNull(mapper.get(232));
+
+        Assert.assertNotNull(mapper.get(pids[1]));
         Assert.assertNull(mapper.get(456));
     }
+
     @Test
     public void getAppBackgrounded() {
-        Assert.assertTrue(mapper.getAppBackgrounded(432));
+        Assert.assertTrue(mapper.getAppBackgrounded(pids[1]));
         Assert.assertFalse(mapper.getAppBackgrounded(456));
     }
 
@@ -115,17 +122,17 @@ public class AEISessionMapperTest {
 
     @Test
     public void erase() {
-        Assert.assertNotNull(mapper.get(123));
-        Assert.assertNotNull(mapper.get(234));
-        Assert.assertNotNull(mapper.get(345));
+        Assert.assertNotNull(mapper.get(pids[0]));
+        Assert.assertNotNull(mapper.get(pids[1]));
+        Assert.assertNotNull(mapper.get(pids[2]));
         Assert.assertNull(mapper.get(456));
 
-        Set<Integer> pidSet = Set.of(123, 234, 456);
+        Set<Integer> pidSet = Set.of(pids[0], pids[1], 456);
         mapper.erase(pidSet);
 
-        Assert.assertNotNull(mapper.get(123));
-        Assert.assertNotNull(mapper.get(234));
-        Assert.assertNull(mapper.get(345));
+        Assert.assertNotNull(mapper.get(pids[0]));
+        Assert.assertNotNull(mapper.get(pids[1]));
+        Assert.assertNull(mapper.get(pids[2]));
 
         mapper.put(456, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 654, false));
         mapper.erase(pidSet);

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
@@ -77,12 +77,6 @@ public class AEISessionMapperTest {
     }
 
     @Test
-    public void getAppBackgrounded() {
-        Assert.assertTrue(mapper.getAppBackgrounded(pids[1]));
-        Assert.assertFalse(mapper.getAppBackgrounded(456));
-    }
-
-    @Test
     public void getOrDefault() {
         Assert.assertNotNull(mapper.getOrDefault(456, UUID.randomUUID().toString()));
     }

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
@@ -43,9 +43,9 @@ public class AEISessionMapperTest {
         sessionMapperFile = new File(reportsDir, "sessionMapper");
         mapper = new AEISessionMapper(sessionMapperFile);
 
-        mapper.put(123, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 321));
-        mapper.put(234, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 432));
-        mapper.put(345, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 543));
+        mapper.put(123, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 321, false));
+        mapper.put(234, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 432, true));
+        mapper.put(345, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 543, false));
     }
 
     @After
@@ -60,7 +60,7 @@ public class AEISessionMapperTest {
 
     @Test
     public void put() {
-        mapper.put(6661, new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), 1666));
+        mapper.put(6661, new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), 1666, false));
         Assert.assertEquals(AgentConfiguration.getInstance().getSessionID(), mapper.getSessionId(6661));
         Assert.assertEquals(1666, mapper.getRealAgentID(6661));
     }
@@ -123,7 +123,7 @@ public class AEISessionMapperTest {
         Assert.assertNotNull(mapper.get(234));
         Assert.assertNull(mapper.get(345));
 
-        mapper.put(456, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 654));
+        mapper.put(456, new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 654, false));
         mapper.erase(pidSet);
         Assert.assertNotNull(mapper.get(456));
     }

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
@@ -66,7 +66,7 @@ public class AEISessionMapperTest {
 
     @Test
     public void get() {
-        Assert.assertNotNull(mapper.get(234));
+        Assert.assertNotNull(mapper.get(232));
         Assert.assertNull(mapper.get(456));
     }
     @Test

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/AEISessionMapperTest.java
@@ -6,7 +6,6 @@
 package com.newrelic.agent.android.aei;
 
 import com.newrelic.agent.android.AgentConfiguration;
-import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.logging.ConsoleAgentLog;
@@ -70,6 +69,11 @@ public class AEISessionMapperTest {
         Assert.assertNotNull(mapper.get(234));
         Assert.assertNull(mapper.get(456));
     }
+    @Test
+    public void getAppBackgrounded() {
+        Assert.assertTrue(mapper.getAppBackgrounded(432));
+        Assert.assertFalse(mapper.getAppBackgrounded(456));
+    }
 
     @Test
     public void getOrDefault() {
@@ -77,13 +81,13 @@ public class AEISessionMapperTest {
     }
 
     @Test
-    public void load() {
+    public void restore() {
         Assert.assertEquals(0, sessionMapperFile.length());
         mapper.flush();
         Assert.assertNotEquals(0, sessionMapperFile.length());
         mapper.clear();
         Assert.assertTrue(mapper.mapper.isEmpty());
-        mapper.load();
+        mapper.restore();
         Assert.assertFalse(mapper.mapper.isEmpty());
     }
 

--- a/agent-core/src/test/java/com/newrelic/agent/android/aei/ErrorTests.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/aei/ErrorTests.java
@@ -4,29 +4,34 @@ package com.newrelic.agent.android.aei;
 import com.google.gson.JsonObject;
 import com.newrelic.agent.android.Agent;
 import com.newrelic.agent.android.AgentConfiguration;
+import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.NewRelicConfig;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.analytics.AnalyticsEvent;
 import com.newrelic.agent.android.analytics.SessionEvent;
-
+import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.crash.CrashTests;
 import com.newrelic.agent.android.harvest.ApplicationInformation;
 import com.newrelic.agent.android.logging.AgentLogManager;
 import com.newrelic.agent.android.logging.ConsoleAgentLog;
+import com.newrelic.agent.android.metric.MetricNames;
+import com.newrelic.agent.android.stats.StatsEngine;
 import com.newrelic.agent.android.test.stub.StubAgentImpl;
 import com.newrelic.agent.android.test.stub.StubAnalyticsAttributeStore;
 import com.newrelic.agent.android.error.Error;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.*;
 
@@ -167,6 +172,93 @@ public class ErrorTests {
         assertFalse(safeBuildId.isEmpty());
     }
 
+    @After
+    public void tearDown() {
+        FeatureFlag.disableFeature(FeatureFlag.BackgroundReporting);
+        setAppInBackground(false);
+    }
+
+    @Test
+    public void backgroundedTrueAddsAttributeWhenFeatureEnabled() {
+        FeatureFlag.enableFeature(FeatureFlag.BackgroundReporting);
+        AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("session-bg", 42, true);
+
+        Error error = new Error(AnalyticsControllerImpl.getInstance().getSessionAttributes(), getApplicationExitInfoEvent(), meta);
+
+        assertTrue("background attribute should reflect persisted backgrounded=true",
+                error.getSessionAttributes().stream()
+                        .anyMatch(a -> AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME.equals(a.getName()) && a.getBooleanValue()));
+    }
+
+    @Test
+    public void backgroundedFalseOmitsAttributeWhenFeatureEnabled() {
+        FeatureFlag.enableFeature(FeatureFlag.BackgroundReporting);
+        AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("session-fg", 42, false);
+
+        Error error = new Error(AnalyticsControllerImpl.getInstance().getSessionAttributes(), getApplicationExitInfoEvent(), meta);
+
+        assertFalse("background attribute should not be present when persisted backgrounded=false",
+                error.getSessionAttributes().stream()
+                        .anyMatch(a -> AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME.equals(a.getName())));
+    }
+
+    @Test
+    public void backgroundedTrueWithFeatureDisabledOmitsAttribute() {
+        FeatureFlag.disableFeature(FeatureFlag.BackgroundReporting);
+        AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("session-bg", 42, true);
+
+        Error error = new Error(AnalyticsControllerImpl.getInstance().getSessionAttributes(), getApplicationExitInfoEvent(), meta);
+
+        assertFalse("background attribute should not be set when BackgroundReporting is disabled",
+                error.getSessionAttributes().stream()
+                        .anyMatch(a -> AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME.equals(a.getName())));
+    }
+
+    @Test
+    public void backgroundedTrueIncrementsMetric() {
+        FeatureFlag.enableFeature(FeatureFlag.BackgroundReporting);
+        StatsEngine.notice().getStatsMap().clear();
+        AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("session-bg", 42, true);
+
+        new Error(AnalyticsControllerImpl.getInstance().getSessionAttributes(), getApplicationExitInfoEvent(), meta);
+
+        assertTrue("BACKGROUND_CRASH_COUNT metric should be incremented",
+                StatsEngine.notice().getStatsMap().containsKey(MetricNames.BACKGROUND_CRASH_COUNT));
+    }
+
+    @Test
+    public void backgroundedFalseOverridesLiveBackgroundState() {
+        FeatureFlag.enableFeature(FeatureFlag.BackgroundReporting);
+        setAppInBackground(true); // live state says background, but persisted session was foreground
+        AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("session-fg", 42, false);
+
+        Error error = new Error(AnalyticsControllerImpl.getInstance().getSessionAttributes(), getApplicationExitInfoEvent(), meta);
+
+        assertFalse("persisted backgrounded=false should override live background state",
+                error.getSessionAttributes().stream()
+                        .anyMatch(a -> AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME.equals(a.getName())));
+    }
+
+    @Test
+    public void nullSessionMetaLeavesBackgroundAttributeUnchanged() {
+        FeatureFlag.enableFeature(FeatureFlag.BackgroundReporting);
+        // With null sessionMeta and app in foreground (default), no background attr expected
+        Error error = new Error(AnalyticsControllerImpl.getInstance().getSessionAttributes(), getApplicationExitInfoEvent(), null);
+
+        assertFalse("no background attribute when app is in foreground and sessionMeta is null",
+                error.getSessionAttributes().stream()
+                        .anyMatch(a -> AnalyticsAttribute.BACKGROUND_ATTRIBUTE_NAME.equals(a.getName())));
+    }
+
+    private static void setAppInBackground(boolean background) {
+        try {
+            Field foregrounded = ApplicationStateMonitor.class.getDeclaredField("foregrounded");
+            foregrounded.setAccessible(true);
+            ((AtomicBoolean) foregrounded.get(ApplicationStateMonitor.getInstance())).set(!background);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not set ApplicationStateMonitor background state", e);
+        }
+    }
 
     private static class TestStubAgentImpl extends StubAgentImpl {
         public static StubAgentImpl install() {

--- a/agent-core/src/test/java/com/newrelic/agent/android/payload/PayloadControllerTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/payload/PayloadControllerTest.java
@@ -55,8 +55,8 @@ public class PayloadControllerTest {
     private PayloadController payloadController;
     private Payload payload;
     private PayloadSender payloadSender;
-    private boolean radioEnabled = false;
-    private boolean opportunisticUploads = false;
+    private final boolean radioEnabled;
+    private final boolean opportunisticUploads;
 
     @Parameterized.Parameters
     public static Collection networkState() {
@@ -79,7 +79,9 @@ public class PayloadControllerTest {
         AgentLogManager.getAgentLog().setLevel(AgentLog.AUDIT);
     }
 
+
     @Before
+    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         agentConfiguration = Mockito.spy(new AgentConfiguration());
         agentConfiguration.setApplicationToken(CrashReporterTest.class.getSimpleName());
@@ -174,7 +176,7 @@ public class PayloadControllerTest {
         Future future = PayloadController.submitPayload(payloadSender, new PayloadSender.CompletionHandler() {
             @Override
             public void onResponse(PayloadSender payloadSender) {
-                Assert.assertEquals(payloadSender.getResponseCode(), 200);
+                Assert.assertEquals(200, payloadSender.getResponseCode());
             }
 
             @Override
@@ -193,7 +195,7 @@ public class PayloadControllerTest {
         future = PayloadController.submitPayload(payloadSender, new PayloadSender.CompletionHandler() {
             @Override
             public void onResponse(PayloadSender payloadSender) {
-                Assert.assertEquals(payloadSender.getResponseCode(), 666);
+                Assert.assertEquals(666, payloadSender.getResponseCode());
                 throw new RuntimeException("Response exception");
             }
 
@@ -299,10 +301,10 @@ public class PayloadControllerTest {
         payloadReaperQueue.add(new PayloadReaper(providePayloadSender("Payload #1".getBytes()), null));
         payloadReaperQueue.add(new PayloadReaper(providePayloadSender("Payload #2".getBytes()), null));
         payloadReaperQueue.add(new PayloadReaper(providePayloadSender("Payload #3".getBytes()), null));
-        Assert.assertEquals(payloadReaperQueue.size(), 3);
+        Assert.assertEquals(3, payloadReaperQueue.size());
         PayloadController.dequeueRunnable.run();
         Mockito.verify(queueExecutor, Mockito.times(3)).submit(Mockito.any(PayloadReaper.class));
-        Assert.assertEquals(payloadReaperQueue.size(), 0);
+        Assert.assertEquals(0, payloadReaperQueue.size());
     }
 
     @Test
@@ -310,10 +312,10 @@ public class PayloadControllerTest {
         payloadReaperRetryQueue.add(new PayloadReaper(providePayloadSender("Payload #1".getBytes()), null));
         payloadReaperRetryQueue.add(new PayloadReaper(providePayloadSender("Payload #2".getBytes()), null));
         payloadReaperRetryQueue.add(new PayloadReaper(providePayloadSender("Payload #3".getBytes()), null));
-        Assert.assertEquals(payloadReaperRetryQueue.size(), 3);
+        Assert.assertEquals(3, payloadReaperRetryQueue.size());
         PayloadController.requeueRunnable.run();
         Mockito.verify(queueExecutor, Mockito.atLeastOnce()).submit(Mockito.any(PayloadReaper.class));
-        Assert.assertEquals(payloadReaperRetryQueue.size(), 0);
+        Assert.assertEquals(0, payloadReaperRetryQueue.size());
     }
 
     @Test
@@ -321,13 +323,13 @@ public class PayloadControllerTest {
         payloadReaperRetryQueue.add(new PayloadReaper(new AgentDataSender("Payload #1".getBytes(), agentConfiguration), null));
         payloadReaperRetryQueue.add(new PayloadReaper(new AgentDataSender("Payload #2".getBytes(), agentConfiguration), null));
         payloadReaperRetryQueue.add(new PayloadReaper(new AgentDataSender("Payload #3".getBytes(), agentConfiguration), null));
-        Assert.assertEquals(payloadReaperRetryQueue.size(), 3);
+        Assert.assertEquals(3, payloadReaperRetryQueue.size());
         Mockito.doReturn(1).when(agentConfiguration).getPayloadTTL();
         Thread.sleep(100);
         PayloadController.requeueRunnable.run();
         Mockito.verify(payloadReaperQueue, Mockito.never()).offer(Mockito.any(PayloadReaper.class));
-        Assert.assertEquals(payloadReaperQueue.size(), 0);
-        Assert.assertEquals(payloadReaperRetryQueue.size(), 0);
+        Assert.assertEquals(0, payloadReaperQueue.size());
+        Assert.assertEquals(0, payloadReaperRetryQueue.size());
     }
 
     @Test
@@ -346,7 +348,7 @@ public class PayloadControllerTest {
         } else {
             for (int i = 0; i < limit; i++) {
                 PayloadController.submitPayload(payloadSender);
-                Assert.assertEquals(PayloadController.payloadReaperQueue.size(), 1);
+                Assert.assertEquals(1, PayloadController.payloadReaperQueue.size());
             }
 
             Mockito.verify(PayloadController.queueExecutor, Mockito.times(0)).submit(Mockito.any(PayloadReaper.class));

--- a/agent-core/src/test/java/com/newrelic/agent/android/sessionReplay/SessionReplayReporterTest.java
+++ b/agent-core/src/test/java/com/newrelic/agent/android/sessionReplay/SessionReplayReporterTest.java
@@ -46,6 +46,7 @@ public class SessionReplayReporterTest {
     }
 
     @Before
+    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         StatsEngine.reset();
 

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -248,12 +248,10 @@ public class ApplicationExitMonitor {
             }
 
             log.debug("AEI: inspected [" + applicationExitInfoList.size() + "] records: new[" + recordsVisited.get() + "] existing [" + recordsSkipped.get() + "] dropped[" + recordsDropped.get() + "]");
-
-            if (sessionMeta != null) {
-                AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId(), sessionMeta.backgrounded);
-                sessionMapper.put(getCurrentProcessId(), model);
-                sessionMapper.flush();
-            }
+            boolean isBackgrounded = ApplicationStateMonitor.isAppInBackground();
+            AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId(), isBackgrounded);
+            sessionMapper.put(getCurrentProcessId(), model);
+            sessionMapper.flush();
 
             // sync the cache dir and session mapper
             reconcileMetadata(applicationExitInfoList);

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -205,6 +205,9 @@ public class ApplicationExitMonitor {
 
                 // try to map the AEI with the session it occurred in
                 sessionMeta = sessionMapper.get(exitInfo.getPid());
+                if (sessionMeta != null) {
+                    sessionMeta = new AEISessionMapper.AEISessionMeta(sessionMeta.sessionId, sessionMeta.realAgentId, isExitBackgrounded(exitInfo.getImportance()));
+                }
 
                 // we are not dropping it if the session is not found, we will still report it
 //                if (sessionMeta == null || !sessionMeta.isValid() || sessionMeta.sessionId.equals(AgentConfiguration.getInstance().getSessionID())) {
@@ -248,8 +251,7 @@ public class ApplicationExitMonitor {
             }
 
             log.debug("AEI: inspected [" + applicationExitInfoList.size() + "] records: new[" + recordsVisited.get() + "] existing [" + recordsSkipped.get() + "] dropped[" + recordsDropped.get() + "]");
-            boolean isBackgrounded = ApplicationStateMonitor.isAppInBackground();
-            AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId(), isBackgrounded);
+            AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId(), ApplicationStateMonitor.isBackgrounded());
             sessionMapper.put(getCurrentProcessId(), model);
             sessionMapper.flush();
 
@@ -321,18 +323,8 @@ public class ApplicationExitMonitor {
         eventAttributes.put(AnalyticsAttribute.EVENT_TYPE_ATTRIBUTE, AnalyticsEvent.EVENT_TYPE_MOBILE_APPLICATION_EXIT);
 
         // Add fg/bg flag based on inferred importance:
-        switch (exitInfo.getImportance()) {
-            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND:
-            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE:
-            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE:
-            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE:
-            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING:
-                eventAttributes.put(AnalyticsAttribute.APP_EXIT_APP_STATE_ATTRIBUTE, "foreground");
-                break;
-            default:
-                eventAttributes.put(AnalyticsAttribute.APP_EXIT_APP_STATE_ATTRIBUTE, "background");
-                break;
-        }
+        eventAttributes.put(AnalyticsAttribute.APP_EXIT_APP_STATE_ATTRIBUTE,
+                isExitBackgrounded(exitInfo.getImportance()) ? "background" : "foreground");
 
         // Add the reason for the exit
         if (exitInfo.getReason() == ApplicationExitInfo.REASON_ANR) {
@@ -384,6 +376,19 @@ public class ApplicationExitMonitor {
 
     protected String toValidAttributeValue(String attributeValue) {
         return (null == attributeValue ? "null" : attributeValue.substring(0, Math.min(attributeValue.length(), AnalyticsAttribute.ATTRIBUTE_VALUE_MAX_LENGTH - 1)));
+    }
+
+    boolean isExitBackgrounded(int importance) {
+        switch (importance) {
+            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND:
+            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE:
+            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE:
+            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE:
+            case ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING:
+                return false;
+            default:
+                return true;
+        }
     }
 
     protected String getReasonAsString(int reason) {

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -153,7 +153,6 @@ public class ApplicationExitMonitor {
                     am.getHistoricalProcessExitReasons(packageName, 0, 0);
 
             // the set may contain more than one report for this package name
-            AEISessionMapper.AEISessionMeta sessionMeta = null;
             for (ApplicationExitInfo exitInfo : applicationExitInfoList) {
                 File artifact = new File(reportsDir, String.format(Locale.getDefault(), ARTIFACT_NAME,
                         exitInfo.getPid()));
@@ -204,7 +203,7 @@ public class ApplicationExitMonitor {
                 }
 
                 // try to map the AEI with the session it occurred in
-                sessionMeta = sessionMapper.get(exitInfo.getPid());
+                AEISessionMapper.AEISessionMeta sessionMeta = sessionMapper.get(exitInfo.getPid());
                 if (sessionMeta != null) {
                     sessionMeta = new AEISessionMapper.AEISessionMeta(sessionMeta.sessionId, sessionMeta.realAgentId, isExitBackgrounded(exitInfo.getImportance()));
                 }

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -245,7 +245,7 @@ public class ApplicationExitMonitor {
             }
             log.debug("AEI: inspected [" + applicationExitInfoList.size() + "] records: new[" + recordsVisited.get() + "] existing [" + recordsSkipped.get() + "] dropped[" + recordsDropped.get() + "]");
 
-            AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId());
+            AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId(), false);
             sessionMapper.put(getCurrentProcessId(), model);
             sessionMapper.flush();
 

--- a/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
+++ b/agent/src/main/java/com/newrelic/agent/android/aei/ApplicationExitMonitor.java
@@ -19,6 +19,7 @@ import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
 import com.newrelic.agent.android.analytics.AnalyticsEvent;
+import com.newrelic.agent.android.background.ApplicationStateMonitor;
 import com.newrelic.agent.android.harvest.Harvest;
 import com.newrelic.agent.android.logging.AgentLog;
 import com.newrelic.agent.android.logging.AgentLogManager;
@@ -134,7 +135,7 @@ public class ApplicationExitMonitor {
     @SuppressLint("SwitchIntDef")
     @SuppressWarnings("deprecation")
     public void harvestApplicationExitInfo() {
-        sessionMapper.load();
+        sessionMapper.restore();
 
         // Only supported in Android 11+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -142,7 +143,7 @@ public class ApplicationExitMonitor {
             AtomicInteger recordsSkipped = new AtomicInteger(0);
             AtomicInteger recordsDropped = new AtomicInteger(0);
 
-            if (null == am) {
+            if (am == null) {
                 log.error("harvestApplicationExitInfo: ActivityManager is null! Cannot record ApplicationExitInfo data.");
                 return;
             }
@@ -152,6 +153,7 @@ public class ApplicationExitMonitor {
                     am.getHistoricalProcessExitReasons(packageName, 0, 0);
 
             // the set may contain more than one report for this package name
+            AEISessionMapper.AEISessionMeta sessionMeta = null;
             for (ApplicationExitInfo exitInfo : applicationExitInfoList) {
                 File artifact = new File(reportsDir, String.format(Locale.getDefault(), ARTIFACT_NAME,
                         exitInfo.getPid()));
@@ -166,6 +168,7 @@ public class ApplicationExitMonitor {
 
                 // try to map the AEI with the session it occurred in
                 String aeiSessionId = sessionMapper.getSessionId(exitInfo.getPid());
+
                 if (!(aeiSessionId == null || aeiSessionId.isEmpty() || aeiSessionId.equals(AgentConfiguration.getInstance().getSessionID()))) {
                     // found a prior session ID
                     log.debug("ApplicationExitMonitor: Found session id [" + aeiSessionId + "] for AEI pid[" + exitInfo.getPid() + "]");
@@ -201,7 +204,7 @@ public class ApplicationExitMonitor {
                 }
 
                 // try to map the AEI with the session it occurred in
-                AEISessionMapper.AEISessionMeta sessionMeta = sessionMapper.get(exitInfo.getPid());
+                sessionMeta = sessionMapper.get(exitInfo.getPid());
 
                 // we are not dropping it if the session is not found, we will still report it
 //                if (sessionMeta == null || !sessionMeta.isValid() || sessionMeta.sessionId.equals(AgentConfiguration.getInstance().getSessionID())) {
@@ -243,11 +246,14 @@ public class ApplicationExitMonitor {
 
                 traceReporter.reportAEITrace(error.asJsonObject().toString(), exitInfo.getPid());
             }
+
             log.debug("AEI: inspected [" + applicationExitInfoList.size() + "] records: new[" + recordsVisited.get() + "] existing [" + recordsSkipped.get() + "] dropped[" + recordsDropped.get() + "]");
 
-            AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId(), false);
-            sessionMapper.put(getCurrentProcessId(), model);
-            sessionMapper.flush();
+            if (sessionMeta != null) {
+                AEISessionMapper.AEISessionMeta model = new AEISessionMapper.AEISessionMeta(AgentConfiguration.getInstance().getSessionID(), Harvest.getHarvestConfiguration().getDataToken().getAgentId(), sessionMeta.backgrounded);
+                sessionMapper.put(getCurrentProcessId(), model);
+                sessionMapper.flush();
+            }
 
             // sync the cache dir and session mapper
             reconcileMetadata(applicationExitInfoList);

--- a/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/AndroidAgentImplTest.java
@@ -276,11 +276,11 @@ public class AndroidAgentImplTest {
 
         ApplicationStateMonitor.getInstance().activityStopped();
         Thread.sleep(1000);
-        Assert.assertTrue("Agent should be in background", ApplicationStateMonitor.isAppInBackground());
+        Assert.assertTrue("Agent should be in background", ApplicationStateMonitor.isBackgrounded());
 
         ApplicationStateMonitor.getInstance().activityStarted();
         Thread.sleep(1000);
-        Assert.assertFalse("Agent should be in foreground", ApplicationStateMonitor.isAppInBackground());
+        Assert.assertFalse("Agent should be in foreground", ApplicationStateMonitor.isBackgrounded());
 
         Assert.assertNotEquals("Agent should provide new session ID when foregrounded", sessionId, agentConfig.getSessionID());
     }

--- a/agent/src/test/java/com/newrelic/agent/android/MonoAndroidAgentImplTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/MonoAndroidAgentImplTest.java
@@ -74,15 +74,15 @@ public class MonoAndroidAgentImplTest {
             setUpAgent();
             try {
                 ApplicationStateMonitor asm = ApplicationStateMonitor.getInstance();
-                Assert.assertFalse("Should be foregrounded on start", ApplicationStateMonitor.isAppInBackground());
+                Assert.assertFalse("Should be foregrounded on start", ApplicationStateMonitor.isBackgrounded());
                 asm.activityStopped();
                 Thread.sleep(5000);
-                Assert.assertTrue("Should be backgrounded on stop", ApplicationStateMonitor.isAppInBackground());
+                Assert.assertTrue("Should be backgrounded on stop", ApplicationStateMonitor.isBackgrounded());
                 asm.activityStarted();
                 Thread.sleep(5000);
                 asm.activityStopped();
                 Thread.sleep(5000);
-                Assert.assertTrue("Should be backgrounded after restart", ApplicationStateMonitor.isAppInBackground());
+                Assert.assertTrue("Should be backgrounded after restart", ApplicationStateMonitor.isBackgrounded());
             } catch (Exception e) {
                 Assert.fail("Should not throw exception on mono agent impl");
             }
@@ -98,16 +98,16 @@ public class MonoAndroidAgentImplTest {
             setUpAgent();
             try {
                 ApplicationStateMonitor asm = ApplicationStateMonitor.getInstance();
-                Assert.assertFalse("Should be foregrounded on start", ApplicationStateMonitor.isAppInBackground());
+                Assert.assertFalse("Should be foregrounded on start", ApplicationStateMonitor.isBackgrounded());
                 asm.activityStopped();
                 Thread.sleep(5000);
-                Assert.assertTrue("Should be backgrounded on stop", ApplicationStateMonitor.isAppInBackground());
+                Assert.assertTrue("Should be backgrounded on stop", ApplicationStateMonitor.isBackgrounded());
                 asm.activityStarted();
                 Thread.sleep(5000);
-                Assert.assertFalse("Should be foregrounded on start after being backgrounded", ApplicationStateMonitor.isAppInBackground());
+                Assert.assertFalse("Should be foregrounded on start after being backgrounded", ApplicationStateMonitor.isBackgrounded());
                 asm.activityStopped();
                 Thread.sleep(5000);
-                Assert.assertTrue("Should be backgrounded after restart", ApplicationStateMonitor.isAppInBackground());
+                Assert.assertTrue("Should be backgrounded after restart", ApplicationStateMonitor.isBackgrounded());
             } catch (Exception e) {
                 Assert.fail("Should not throw exception on mono agent impl");
             }

--- a/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 
 import android.app.ActivityManager;
 import android.app.ApplicationExitInfo;
@@ -20,8 +19,6 @@ import android.os.Build;
 import com.newrelic.agent.android.AgentConfiguration;
 import com.newrelic.agent.android.FeatureFlag;
 import com.newrelic.agent.android.NewRelic;
-import com.newrelic.agent.android.NewRelicTest;
-import com.newrelic.agent.android.NullAgentImpl;
 import com.newrelic.agent.android.SpyContext;
 import com.newrelic.agent.android.analytics.AnalyticsAttribute;
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl;
@@ -58,21 +55,15 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 @RunWith(RobolectricTestRunner.class)
 public class ApplicationExitMonitorTest {
@@ -95,6 +86,7 @@ public class ApplicationExitMonitorTest {
     public void setUp() throws Exception {
         logger = Mockito.spy(new ConsoleAgentLog());
         logger.setLevel(AgentLog.DEBUG);
+        random = new Random();
         AgentLogManager.setAgentLog(logger);
 
         spyContext = new SpyContext();
@@ -648,7 +640,6 @@ public class ApplicationExitMonitorTest {
 
     void loadSessionMapper() {
         // seed the session mapper
-        random = new Random();
         applicationExitInfoList.forEach(aei ->
                 applicationExitMonitor.sessionMapper.mapper.putIfAbsent(aei.getPid(),
                         new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, random.nextBoolean()))

--- a/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
@@ -493,7 +493,7 @@ public class ApplicationExitMonitorTest {
             frozen.add(new AnalyticsAttribute("checkout_step", "review"));
             store.upsert(new SessionManifest("S_PRIOR", 1234, 0L, 1L, frozen));
 
-            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_PRIOR", 1234);
+            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_PRIOR", 1234, false);
             Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(meta);
 
             Assert.assertEquals(1, resolved.size());
@@ -512,7 +512,7 @@ public class ApplicationExitMonitorTest {
         AgentConfiguration.getInstance().setSessionContextStore(store);
         StatsEngine.SUPPORTABILITY.getStatsMap().clear();
         try {
-            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_UNKNOWN", 1234);
+            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_UNKNOWN", 1234, false);
             Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(meta);
 
             // No manifest (e.g. prior session ran under a pre-upgrade agent) → transitional
@@ -594,7 +594,7 @@ public class ApplicationExitMonitorTest {
     public void testGetEventAttributesForANR() throws IOException {
 
 
-        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234);
+        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, false);
         ApplicationExitInfo exitInfo = provideApplicationExitInfo(ApplicationExitInfo.REASON_ANR);
 
         HashMap<String, Object> eventAttributes = applicationExitMonitor.getEventAttributesForAEI(exitInfo,sessionMeta, Objects.requireNonNull(exitInfo.getTraceInputStream()).toString());
@@ -618,7 +618,7 @@ public class ApplicationExitMonitorTest {
     public void testGetEventAttributesForNonANRAEI() throws IOException {
 
 
-        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234);
+        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, false);
         ApplicationExitInfo exitInfo = provideApplicationExitInfo(ApplicationExitInfo.REASON_CRASH);
 
         HashMap<String, Object> eventAttributes = applicationExitMonitor.getEventAttributesForAEI(exitInfo,sessionMeta, Objects.requireNonNull(exitInfo.getTraceInputStream()).toString());
@@ -648,7 +648,7 @@ public class ApplicationExitMonitorTest {
         // seed the session mapper
         applicationExitInfoList.forEach(aei ->
                 applicationExitMonitor.sessionMapper.mapper.putIfAbsent(aei.getPid(),
-                        new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234))
+                        new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, false))
         );
         applicationExitMonitor.sessionMapper.flush();
     }

--- a/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/aei/ApplicationExitMonitorTest.java
@@ -68,6 +68,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -77,6 +78,7 @@ import java.util.stream.Collectors;
 public class ApplicationExitMonitorTest {
     private AgentLog logger;
     private SpyContext spyContext;
+    private Random random;
 
     ApplicationExitMonitor applicationExitMonitor;
     ArrayList<ApplicationExitInfo> applicationExitInfoList;
@@ -493,7 +495,7 @@ public class ApplicationExitMonitorTest {
             frozen.add(new AnalyticsAttribute("checkout_step", "review"));
             store.upsert(new SessionManifest("S_PRIOR", 1234, 0L, 1L, frozen));
 
-            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_PRIOR", 1234, false);
+            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_PRIOR", 1234, random.nextBoolean());
             Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(meta);
 
             Assert.assertEquals(1, resolved.size());
@@ -512,7 +514,7 @@ public class ApplicationExitMonitorTest {
         AgentConfiguration.getInstance().setSessionContextStore(store);
         StatsEngine.SUPPORTABILITY.getStatsMap().clear();
         try {
-            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_UNKNOWN", 1234, false);
+            AEISessionMapper.AEISessionMeta meta = new AEISessionMapper.AEISessionMeta("S_UNKNOWN", 1234, random.nextBoolean());
             Set<AnalyticsAttribute> resolved = applicationExitMonitor.resolveSessionAttributes(meta);
 
             // No manifest (e.g. prior session ran under a pre-upgrade agent) → transitional
@@ -594,7 +596,7 @@ public class ApplicationExitMonitorTest {
     public void testGetEventAttributesForANR() throws IOException {
 
 
-        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, false);
+        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, random.nextBoolean());
         ApplicationExitInfo exitInfo = provideApplicationExitInfo(ApplicationExitInfo.REASON_ANR);
 
         HashMap<String, Object> eventAttributes = applicationExitMonitor.getEventAttributesForAEI(exitInfo,sessionMeta, Objects.requireNonNull(exitInfo.getTraceInputStream()).toString());
@@ -618,7 +620,7 @@ public class ApplicationExitMonitorTest {
     public void testGetEventAttributesForNonANRAEI() throws IOException {
 
 
-        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, false);
+        AEISessionMapper.AEISessionMeta sessionMeta = new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234,  random.nextBoolean());
         ApplicationExitInfo exitInfo = provideApplicationExitInfo(ApplicationExitInfo.REASON_CRASH);
 
         HashMap<String, Object> eventAttributes = applicationExitMonitor.getEventAttributesForAEI(exitInfo,sessionMeta, Objects.requireNonNull(exitInfo.getTraceInputStream()).toString());
@@ -646,9 +648,10 @@ public class ApplicationExitMonitorTest {
 
     void loadSessionMapper() {
         // seed the session mapper
+        random = new Random();
         applicationExitInfoList.forEach(aei ->
                 applicationExitMonitor.sessionMapper.mapper.putIfAbsent(aei.getPid(),
-                        new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, false))
+                        new AEISessionMapper.AEISessionMeta(UUID.randomUUID().toString(), 1234, random.nextBoolean()))
         );
         applicationExitMonitor.sessionMapper.flush();
     }

--- a/agent/src/test/java/com/newrelic/agent/android/util/ActivityLifecycleBackgroundListenerTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/util/ActivityLifecycleBackgroundListenerTest.java
@@ -52,21 +52,21 @@ public class ActivityLifecycleBackgroundListenerTest {
     @Test
     public void ensureTrivialUsageWorks() throws Exception {
 
-        assertFalse(ApplicationStateMonitorTest.isAppInBackground());
+        assertFalse(ApplicationStateMonitorTest.isBackgrounded());
 
         albl.onActivityPaused(null);
         albl.onTrimMemory(20);
         albl.onActivityStopped(null);
 
         Thread.sleep(750);
-        assertTrue(ApplicationStateMonitorTest.isAppInBackground());
+        assertTrue(ApplicationStateMonitorTest.isBackgrounded());
 
         albl.onActivityStarted(null);
         albl.onActivityResumed(null);
         Thread.sleep(750);
         asm.shutdownExecutor();
 
-        assertFalse(ApplicationStateMonitorTest.isAppInBackground());
+        assertFalse(ApplicationStateMonitorTest.isBackgrounded());
 
         assertEquals(2, listener.getEvents().size());
         assertEquals("background", listener.getEvents().get(0));
@@ -100,7 +100,7 @@ public class ActivityLifecycleBackgroundListenerTest {
         asm.activityStopped(true);
         asm.getExecutor().submit(() -> {}).get();
         asm.getForegroundState().set(false);
-        assertTrue(ApplicationStateMonitorTest.isAppInBackground());
+        assertTrue(ApplicationStateMonitorTest.isBackgrounded());
 
         // Restarting an activity (count 0 -> 1 while backgrounded) foregrounds the app,
         // emitting exactly one foreground event.
@@ -114,7 +114,7 @@ public class ActivityLifecycleBackgroundListenerTest {
     @Test
     public void rotationDoesNotEmitBackgroundOrForegroundEvents() throws Exception {
         // Initial: foregrounded=true
-        assertFalse(ApplicationStateMonitorTest.isAppInBackground());
+        assertFalse(ApplicationStateMonitorTest.isBackgrounded());
 
         Activity oldActivity = Mockito.mock(Activity.class);
         Mockito.when(oldActivity.isChangingConfigurations()).thenReturn(true);
@@ -135,7 +135,7 @@ public class ActivityLifecycleBackgroundListenerTest {
 
         assertEquals("No state events should fire during rotation", 0, listener.getEvents().size());
         assertFalse("App should still be foregrounded after rotation",
-                ApplicationStateMonitorTest.isAppInBackground());
+                ApplicationStateMonitorTest.isBackgrounded());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ActivityLifecycleBackgroundListenerTest {
         albl.onActivityPaused(activity);
         albl.onActivityStopped(activity);
         Thread.sleep(750);
-        assertTrue(ApplicationStateMonitorTest.isAppInBackground());
+        assertTrue(ApplicationStateMonitorTest.isBackgrounded());
 
         albl.onActivityStarted(activity);
         albl.onActivityResumed(activity);


### PR DESCRIPTION
## Summary

Fixes a bug where AEI (ApplicationExitInfo) derived errors — native crashes, ANRs, OS-initiated kills — were systematically missing the `background=true` attribute even when the original exit occurred while the app was backgrounded.

**Root cause:** `Error.getErrorSessionAttributes()` was calling `ApplicationStateMonitor.isAppInBackground()` at the moment the `Error` object was constructed. That construction happens inside `harvestApplicationExitInfo()`, which runs on the *next* app launch — at which point the app has just foregrounded, so `isAppInBackground()` is almost always `false` regardless of the historical exit state. `AEISessionMeta` had no way to recover the correct value because it only stored `sessionId` and `realAgentId`.

**Fix:** Persist the app's actual foreground/background state at exit time into `AEISessionMeta.backgrounded`, and use that persisted value in `Error` when stamping the attribute — instead of live `ApplicationStateMonitor` state. The `BackgroundReporting` feature flag still gates the behavior.

## Changes

- **`AEISessionMeta`** — adds a `backgrounded` boolean field; all construction sites updated
- **`AEISessionMapper`** — adds `getAppBackgrounded(int pid)`; renames `load()` → `restore()` for clarity; fixes the raw-type cast in the Gson deserialization path; changes return type of `restore()` to `void`
- **`Error`** — replaces the live `ApplicationStateMonitor.isAppInBackground()` check with `sessionMeta.backgrounded` when `BackgroundReporting` is enabled; also increments `BACKGROUND_CRASH_COUNT` metric on background exits
- **`ApplicationExitMonitor`** — calls `restore()` instead of `load()`; moves `sessionMeta` declaration outside the loop so flush uses the correct value
- **Tests** — adds `getAppBackgrounded` test; renames `load` test to `restore`; adds 6 new `ErrorTests` covering: backgrounded=true adds attribute, backgrounded=false omits attribute, feature-flag disabled suppresses attribute, metric increment, persisted state overrides live state, null meta leaves attribute unchanged

## Test plan

- [ ] Run `./gradlew :agent-core:test :agent:test` — all new and existing AEI/Error tests pass
- [ ] Verify `background=true` appears on AEI error events for exits that occurred while backgrounded
- [ ] Verify `background` attribute is absent when `BackgroundReporting` feature flag is disabled
- [ ] Verify no regression on live (non-AEI) crash/handled-exception background attribute stamping

Fixes [NR-596838](https://new-relic.atlassian.net/browse/NR-596838)

[NR-596838]: https://new-relic.atlassian.net/browse/NR-596838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ