### PR TITLE
Gradle Isolated Projects

### DIFF
--- a/plugins/gradle/src/main/groovy/com/newrelic/agent/android/BuildHelper.groovy
+++ b/plugins/gradle/src/main/groovy/com/newrelic/agent/android/BuildHelper.groovy
@@ -255,8 +255,17 @@ class BuildHelper {
         logger.warn("Set property '${PROP_HALT_ON_WARNING}=true' to treat warnings as fatal errors.")
     }
 
+    /**
+     * Read an optional Gradle property, falling back to defaultValue when it is not set.
+     *
+     * Resolved through the property provider rather than through rootProject: reaching into
+     * another project's model fails the build under Gradle's Isolated Projects, and a Gradle
+     * property resolves to the same value from any project in the build, so no cross-project
+     * access is needed to read one.
+     */
     def hasOptional(String key, Object defaultValue) {
-        project.rootProject.hasProperty(key) ? project.rootProject[key] : defaultValue
+        def provider = project.providers.gradleProperty(key)
+        provider.present ? provider.get() : defaultValue
     }
 
     def getBuildMetrics() {
@@ -345,7 +354,9 @@ class BuildHelper {
                 project.file("../../node_modules/react-native/react.gradle"),
                 project.file("../node_modules/react-native/react.gradle"),
                 project.file("node_modules/react-native/react.gradle"),
-                project.rootProject.file("node_modules/react-native/react.gradle"),
+                // rootDir, not rootProject.file(): reading another project's model fails the
+                // build under Isolated Projects, while rootDir is plain build layout.
+                new File(project.rootDir, "node_modules/react-native/react.gradle"),
         ]
 
         for (def reactGradle : reactGradlePaths) {


### PR DESCRIPTION
### Overview

`BuildHelper` reads another project's model in two places. Gradle's [Isolated Projects](https://docs.gradle.org/current/userguide/isolated_projects.html) turns that into a configuration failure rather than a warning, so applying the plugin takes the whole build down when the feature is enabled:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> Project ':app' cannot access 'Project.hasProperty' functionality on another project ':'
      at com.newrelic.agent.android.BuildHelper.hasOptional(BuildHelper.groovy:259)
```

Two changes, both in `plugins/gradle/src/main/groovy/com/newrelic/agent/android/BuildHelper.groovy`.

**1. `hasOptional` — the reported failure**

```groovy
- project.rootProject.hasProperty(key) ? project.rootProject[key] : defaultValue
+ def provider = project.providers.gradleProperty(key)
+ provider.present ? provider.get() : defaultValue
```

A Gradle property resolves to the same value from any project in the build, so reading one never requires reaching through `rootProject`. This uses the same provider API already present a few lines above in `configurationCacheEnabled()`.

**2. `checkReactNative` — a second, latent violation**

```groovy
- project.rootProject.file("node_modules/react-native/react.gradle"),
+ new File(project.rootDir, "node_modules/react-native/react.gradle"),
```

This one is on the always-path (`NewRelicGradlePlugin` calls `checkReactNative()` during apply, and the candidate-path list is built eagerly), so it is reached on every build regardless of React Native. It stayed hidden behind the first failure only because Gradle stops at the first violation.

`rootDir` is build layout rather than project model. Gradle's isolation wrapper `MutableStateAccessAwareProject` delegates `getRootDir()` and `getProjectDir()` straight through to the delegate, while `hasProperty()` and `getTasks()` route through `onMutableStateAccess` — which is what makes one legal and the others not.

I checked the rest of the plugin while I was in there: these are the only two `rootProject` accesses in `plugins/gradle/src/main`, there is no `allprojects`/`subprojects` usage, and every `afterEvaluate` is registered on the project's own instance, which Isolated Projects permits.

### Related Github Issue

https://github.com/newrelic/newrelic-android-agent/issues/617

### Testing

Verified against a real ~175-module Android application (Gradle 9.7.1, AGP 9.3.1, JDK 21) with `org.gradle.unsafe.isolated-projects=true` and the plugin applied, consuming a locally published build of this branch:

| | before | after |
|---|---|---|
| configuration | fails — `cannot access 'Project.hasProperty'` | succeeds, configuration cache entry stored |
| `:app:assembleQaDebug` | never reached | 3,003 tasks, 0 failures, APK produced |

The plugin is genuinely applied rather than skipped in the passing run — `:app:newrelicConfigQaDebug` and `:app:newrelicTransformClassesForQaDebug` are both in the task graph. And the `"may not be compatible with Android Gradle plugin version 9.3.1"` warning still fires, which is emitted from `validatePluginSettings` via `hasOptional(PROP_WARNING_AGP, true)` — so the rewritten method is on the executed path and returns its default, not merely uninvoked.

Existing coverage in `BuildHelperTest` asserts only `hasOptional`'s default-value branch, so it passes both before and after and would not have caught this.

**On adding a functional test:** I wrote a `PluginIsolatedProjectsSpec` (TestKit, Gradle 9.7.1 pin, modeled on `PluginAGP93CompatSpec`) and it does not pass yet — for a reason unrelated to this change. `samples/agent-test-app/build.gradle:76` has its own cross-project write:

```groovy
allprojects { ext.newrelic = rootProject.newrelic }
```

That block is load-bearing: `library/build.gradle` and `feature/build.gradle` both `apply from: "${rootDir}/android.gradle"`, and `android.gradle` reads `newrelic.deps.agent`, `newrelic.deps.ndk` and `newrelic.agent.version`. The usual replacement, `gradle.lifecycle.beforeProject`, needs Gradle 8.8+, and `PluginJDK11IntegrationSpec` runs that same sample on 7.6.1 — so the fixture needs each project to build its own config map instead, which is a change to a fixture eight specs share. I left it out of this PR rather than widen it, and I'm happy to open it separately or fold it in if you'd prefer the regression test land together with the fix.

Two incidental notes from that attempt, in case they're useful: the sample sets `org.gradle.unsafe.configuration-cache=false`, and Isolated Projects refuses to run without the configuration cache (`Configuration Cache cannot be disabled when Isolated Projects is enabled`), so such a test needs `--configuration-cache` on the command line. Gradle 9.7.1 accepts both `org.gradle.unsafe.isolated-projects` and `org.gradle.isolated-projects`.

I was not able to run the full existing suite locally: the repo wrapper is Gradle 8.1.1, which cannot run on JDK 21 (`Unsupported class file major version 65`), and no JDK ≤ 19 was available on my machine. I built and published with a local-only wrapper bump to 8.14.3, which is **not** part of this branch. CI should be the judge of the existing suite.

### Checks

- [x] **Are your contributions backwards compatible with relevant frameworks and APIs?** Yes. Both replacements stay within the plugin's declared floor of `minSupportedGradleVersion = '7.1'` — `Project.getRootDir()` and `ProviderFactory.gradleProperty(String)` both long predate it. Deliberately avoided `Project.isolated` (Gradle 8.8+) and `ProjectLayout.settingsDirectory` (8.13+) for that reason.

- [x] **Does your code contain any breaking changes? Please describe.** One narrowing worth a reviewer's attention. `rootProject.hasProperty(key)` also saw values set as extra/`ext` properties on the root project; `providers.gradleProperty(key)` sees Gradle properties only — `gradle.properties`, `-P`, and `ORG_GRADLE_PROJECT_*`. Both call sites take user-facing switches whose own warning text directs people to set them exactly that way (`newrelic.warning.agp`, `newrelic.halt-on-warning`), so the documented usage is unaffected. A consumer assigning them via `ext.'newrelic.warning.agp' = false` in a root `build.gradle` would no longer be picked up. That path is undocumented, but it is a real behavior change rather than a pure refactor, so I would rather name it than bury it.

- [x] **Does your code introduce any new dependencies? Please describe.** No. No new dependencies, no new plugin coordinates, no version changes.