### PR TITLE
feat(tree-shaking): allow R8 to strip Session Replay when disabled at build time (NR-587343)

### DIFF
--- a/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/crash/CrashReporter.java
@@ -32,7 +32,6 @@ public class CrashReporter extends PayloadReporter {
 
     private final UncaughtExceptionHandler uncaughtExceptionHandler;
     protected final CrashStore crashStore;
-    private final CrashSessionReplayHandler sessionReplayHandler;
 
     public static CrashReporter getInstance() {
         return instance.get();
@@ -76,7 +75,6 @@ public class CrashReporter extends PayloadReporter {
         super(agentConfiguration);
         this.uncaughtExceptionHandler = new UncaughtExceptionHandler(this);
         this.crashStore = agentConfiguration.getCrashStore();
-        this.sessionReplayHandler = new CrashSessionReplayHandler(agentConfiguration);
         this.isEnabled.set(FeatureFlag.featureEnabled(FeatureFlag.CrashReporting));
     }
 
@@ -120,8 +118,13 @@ public class CrashReporter extends PayloadReporter {
     protected Future reportCrash(final Crash crash) {
         if (crash != null) {
 
+            // Constructed lazily inside the gate rather than held in a field: a field of an
+            // SR type, and an unconditional allocation, both anchor the sessionReplay package
+            // for R8 even when the gate folds to false (NR-587343 tree-shaking). The handler
+            // is stateless apart from agentConfiguration, so per-crash construction is
+            // equivalent to the previous long-lived instance.
             if (agentConfiguration.getSessionReplayConfiguration().isEnabled()) {
-                sessionReplayHandler.handleCrashSessionReplay(crash);
+                new CrashSessionReplayHandler(agentConfiguration).handleCrashSessionReplay(crash);
             }
 
             final boolean hasValidDataToken = crash.getDataToken().isValid();

--- a/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/logging/LogReporting.java
@@ -47,6 +47,9 @@ public abstract class LogReporting {
     };
 
     public static void initialize(File cacheDir, AgentConfiguration agentConfiguration) throws IOException {
+        if (!isRemoteLoggingEnabled()) {
+            return;
+        }
         if (agentConfiguration.getLogReportingConfiguration().enabled) {
             LogReporting.setLogLevel(agentConfiguration.getLogReportingConfiguration().getLogLevel());
             LogReporter.initialize(cacheDir, agentConfiguration);
@@ -59,10 +62,16 @@ public abstract class LogReporting {
     }
 
     public static boolean isInitialized() {
+        if (!isRemoteLoggingEnabled()) {
+            return false;
+        }
         return LogReporter.getInstance() != null;
     }
 
     public static void shutdown() {
+        if (!isRemoteLoggingEnabled()) {
+            return;
+        }
         if(isInitialized()) {
             LogReporter.getInstance().shutdown();
         }

--- a/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadController.java
+++ b/agent-core/src/main/java/com/newrelic/agent/android/payload/PayloadController.java
@@ -88,11 +88,16 @@ public class PayloadController implements HarvestLifecycleAware {
                 log.warn("PayloadController: No payload reporter - payload reporting will be disabled");
             }
 
-            SessionReplayReporter sessionReplayReporter = SessionReplayReporter.initialize(agentConfiguration);
-            if(sessionReplayReporter != null){
-                sessionReplayReporter.start();
-            }else{
-                log.warn("SessionReplayController: No session replay reporter - session replay reporting will be disabled");
+            // Gated so R8 can strip the sessionReplay package when SR is disabled at build
+            // time (NR-587343). This was the largest ungated entry point into the package:
+            // SessionReplayReporter transitively reaches the sender and capture pipeline.
+            if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+                SessionReplayReporter sessionReplayReporter = SessionReplayReporter.initialize(agentConfiguration);
+                if(sessionReplayReporter != null){
+                    sessionReplayReporter.start();
+                }else{
+                    log.warn("SessionReplayController: No session replay reporter - session replay reporting will be disabled");
+                }
             }
 
             JSErrorDataReporter jsErrorDataReporter = JSErrorDataReporter.initialize(agentConfiguration);
@@ -131,7 +136,9 @@ public class PayloadController implements HarvestLifecycleAware {
                         }
                         AgentDataReporter.shutdown();
                         CrashReporter.shutdown();
-                        SessionReplayReporter.shutdown();
+                        if (AgentConfiguration.getInstance().getSessionReplayConfiguration().isSessionReplayEnabled()) {
+                            SessionReplayReporter.shutdown();
+                        }
                         JSErrorDataReporter.shutdown();
 
                     } catch (InterruptedException e) {

--- a/agent/proguard-rules.pro
+++ b/agent/proguard-rules.pro
@@ -1,5 +1,13 @@
--keep class com.newrelic.agent.android.** { *; }
+# Keep all agent classes EXCEPT the sessionReplay package, which is made strippable
+# when SessionReplay is disabled at build time (NR-587343 tree-shaking).
+-keep class !com.newrelic.agent.android.sessionReplay.**,!com.newrelic.agent.android.logging.LogReporter,!com.newrelic.agent.android.logging.LogReporter$**,!com.newrelic.agent.android.logging.RemoteLogger,!com.newrelic.agent.android.logging.LogForwarder,!com.newrelic.agent.android.logging.ForwardingAgentLog,!com.newrelic.agent.android.logging.LoggingConfiguration, com.newrelic.agent.android.** { *; }
 -dontwarn com.newrelic.agent.android.**
+
+# SessionReplay config classes are always deserialized from backend config (referenced
+# from always-on AgentConfiguration), so keep them even when SR code is stripped.
+-keep class com.newrelic.agent.android.sessionReplay.SessionReplayConfiguration { *; }
+-keep class com.newrelic.agent.android.sessionReplay.MobileSessionReplayConfiguration { *; }
+-keep class com.newrelic.agent.android.sessionReplay.SessionReplayStore { *; }
 -keepattributes Exceptions, Signature, InnerClasses, LineNumberTable, SourceFile, EnclosingMethod
 
 ##

--- a/agent/proguard-rules.pro
+++ b/agent/proguard-rules.pro
@@ -1,13 +1,5 @@
-# Keep all agent classes EXCEPT the sessionReplay package, which is made strippable
-# when SessionReplay is disabled at build time (NR-587343 tree-shaking).
--keep class !com.newrelic.agent.android.sessionReplay.**,!com.newrelic.agent.android.logging.LogReporter,!com.newrelic.agent.android.logging.LogReporter$**,!com.newrelic.agent.android.logging.RemoteLogger,!com.newrelic.agent.android.logging.LogForwarder,!com.newrelic.agent.android.logging.ForwardingAgentLog,!com.newrelic.agent.android.logging.LoggingConfiguration, com.newrelic.agent.android.** { *; }
+-keep class com.newrelic.agent.android.** { *; }
 -dontwarn com.newrelic.agent.android.**
-
-# SessionReplay config classes are always deserialized from backend config (referenced
-# from always-on AgentConfiguration), so keep them even when SR code is stripped.
--keep class com.newrelic.agent.android.sessionReplay.SessionReplayConfiguration { *; }
--keep class com.newrelic.agent.android.sessionReplay.MobileSessionReplayConfiguration { *; }
--keep class com.newrelic.agent.android.sessionReplay.SessionReplayStore { *; }
 -keepattributes Exceptions, Signature, InnerClasses, LineNumberTable, SourceFile, EnclosingMethod
 
 ##

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -178,7 +178,6 @@ public class AndroidAgentImpl implements
         agentConfiguration.setEventStore(new FileEventStore(context, agentConfiguration));
         context.deleteSharedPreferences("NREventStore");
 
-        agentConfiguration.setSessionReplayStore(new FileSessionReplayStore(context));
         context.deleteSharedPreferences("NRSessionReplayStore");
 
         agentConfiguration.setOfflineSessionReplayStore(new FileOfflineSessionReplayStore(context));
@@ -240,6 +239,9 @@ public class AndroidAgentImpl implements
     }
 
     private static void startLogReporter(Context context, AgentConfiguration agentConfiguration) {
+            if (!LogReporting.isRemoteLoggingEnabled()) {
+                return;
+            }
             LogReportingConfiguration logReportingConfiguration = agentConfiguration.getLogReportingConfiguration();
             LogReportingConfiguration.reseed();
              if (logReportingConfiguration.isSampled()) {
@@ -731,7 +733,9 @@ public class AndroidAgentImpl implements
         Harvest.shutdown();
         Measurements.shutdown();
         PayloadController.shutdown();
-        SessionReplay.deInitialize();
+        if (AgentConfiguration.getInstance().getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            SessionReplay.deInitialize();
+        }
 
         if (LogReporting.isRemoteLoggingEnabled()) {
             LogReporting.shutdown();
@@ -794,6 +798,9 @@ public class AndroidAgentImpl implements
      * @return true if recording started/transitioned to FULL, false if disabled
      */
     protected static boolean recordReplay() {
+        if (!AgentConfiguration.getInstance().getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            return false;
+        }
         // Check current mode - single call instead of two
         SessionReplayMode currentMode = SessionReplay.getCurrentMode();
 
@@ -839,6 +846,9 @@ public class AndroidAgentImpl implements
     }
 
     protected static boolean pauseReplay() {
+        if (!AgentConfiguration.getInstance().getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            return false;
+        }
         // If SessionReplay is already recording (ERROR or FULL mode)
         if (SessionReplay.isReplayRecording()) {
                 SessionReplay.pauseReplay();
@@ -930,6 +940,7 @@ public class AndroidAgentImpl implements
                                                            SessionReplayConfiguration sessionReplayConfiguration,
                                                            SessionReplayMode mode) {
         if(sessionReplayConfiguration.isEnabled()) {
+            agentConfiguration.setSessionReplayStore(new FileSessionReplayStore(context));
             sessionReplayConfiguration.processCustomMaskingRules();
             AnalyticsControllerImpl.getInstance().setAttribute(AnalyticsAttribute.SESSION_REPLAY_ENABLED, true);
             Handler uiHandler = new Handler(Looper.getMainLooper());
@@ -1238,7 +1249,9 @@ public class AndroidAgentImpl implements
     @Override
     public void onSessionRestarted() {
         // Shut down previous session's reporters before re-evaluating sampling
-        SessionReplay.deInitialize();
+        if (agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            SessionReplay.deInitialize();
+        }
 
         if (LogReporting.isRemoteLoggingEnabled()) {
             LogReporting.shutdown();

--- a/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
+++ b/agent/src/main/java/com/newrelic/agent/android/AndroidAgentImpl.java
@@ -180,8 +180,6 @@ public class AndroidAgentImpl implements
 
         context.deleteSharedPreferences("NRSessionReplayStore");
 
-        agentConfiguration.setOfflineSessionReplayStore(new FileOfflineSessionReplayStore(context));
-
         agentConfiguration.setJsErrorStore(new FileJSErrorStore(context, agentConfiguration));
         context.deleteSharedPreferences("NRJSErrorStore");
 
@@ -941,6 +939,12 @@ public class AndroidAgentImpl implements
                                                            SessionReplayMode mode) {
         if(sessionReplayConfiguration.isEnabled()) {
             agentConfiguration.setSessionReplayStore(new FileSessionReplayStore(context));
+            // Relocated out of the constructor: an unconditional allocation keeps
+            // FileOfflineSessionReplayStore reachable, which anchors OfflineSessionReplayStore
+            // and OfflineSessionReplayPayload in the sessionReplay package (NR-587343).
+            // Only SessionReplayReporter reads this store, and that is itself gated now.
+            agentConfiguration.setOfflineSessionReplayStore(new FileOfflineSessionReplayStore(context));
+
             sessionReplayConfiguration.processCustomMaskingRules();
             AnalyticsControllerImpl.getInstance().setAttribute(AnalyticsAttribute.SESSION_REPLAY_ENABLED, true);
             Handler uiHandler = new Handler(Looper.getMainLooper());

--- a/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
+++ b/agent/src/main/java/com/newrelic/agent/android/NewRelic.java
@@ -1100,6 +1100,12 @@ public final class NewRelic {
         EventManager eventManager = AnalyticsControllerImpl.getInstance().getEventManager();
         EventListener currentListener = ((EventManagerImpl) eventManager).getListener();
 
+        if (!agentConfiguration.getSessionReplayConfiguration().isSessionReplayEnabled()) {
+            // SessionReplay disabled/stripped: set the user listener directly
+            eventManager.setEventListener(eventListener);
+            return;
+        }
+
         // If current listener is a CompositeEventListener, update its user listener
         if (currentListener instanceof CompositeEventListener) {
             ((CompositeEventListener) currentListener).setUserListener(eventListener);

--- a/agent/src/main/kotlin/com/newrelic/agent/android/instrumentation/ComposeNavigationInstrumentation.kt
+++ b/agent/src/main/kotlin/com/newrelic/agent/android/instrumentation/ComposeNavigationInstrumentation.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
+import com.newrelic.agent.android.AgentConfiguration
 import com.newrelic.agent.android.analytics.AnalyticsControllerImpl
 import com.newrelic.agent.android.sessionReplay.SessionReplay
 import  kotlin.collections.Map
@@ -56,7 +57,9 @@ private class MeasureNavigationObserver(
     private val destinationChangedListener =
         NavController.OnDestinationChangedListener { controller, _, _ ->
             controller.currentDestination?.route?.let { to ->
-                SessionReplay.setTakeFullSnapshot(true)
+                if (AgentConfiguration.getInstance().sessionReplayConfiguration.isSessionReplayEnabled) {
+                    SessionReplay.setTakeFullSnapshot(true)
+                }
                 val attributes = mapOf("event_type" to "navigation")
 
                 AnalyticsControllerImpl.getInstance().recordBreadcrumb("screen_name: $to", attributes)

--- a/docs/Session-Replay-Tree-Shaking.md
+++ b/docs/Session-Replay-Tree-Shaking.md
@@ -1,0 +1,280 @@
+# Removing Session Replay from your release build
+
+If your app will never use Session Replay, you can have R8 remove the feature's
+code from your release APK entirely, instead of shipping it and leaving it turned
+off. Testing against a sample application measured a reduction of approximately
+80 KB. The exact figure depends on your app, AGP version, and R8 settings, so
+measure your own build.
+
+This is configured entirely in your app. Turning Session Replay off in the New
+Relic UI does **not** reduce APK size — backend configuration is read at runtime,
+long after R8 has finished compiling.
+
+> **All three steps below are required, and the rule set must be used in full.**
+>
+> 1. Ignore the agent's bundled ProGuard rules
+> 2. Add the New Relic rules to your own ProGuard configuration
+> 3. Add the `-assumevalues` rule
+>
+> Each step depends on the others. Applying only some of them will either remove
+> nothing at all, or cause a runtime error when the agent parses its
+> configuration. There is no partial configuration that works.
+
+---
+
+## Requirements
+
+| Requirement | Notes |
+|---|---|
+| `minifyEnabled true` | R8 must run on the variant |
+| Android Gradle Plugin 8.1 or newer | Required for the `keepRules` block in Step 1 |
+| R8 full mode | Enabled by default on AGP 8+. Do not set `android.enableR8.fullMode=false` |
+| No blanket keep rule for New Relic classes | Any `-keep class com.newrelic.** { *; }` in your app, in another library, or in a DexGuard configuration will prevent this from working. See [Troubleshooting](#troubleshooting) |
+
+---
+
+## Step 1 — Ignore the agent's bundled ProGuard rules
+
+The agent AAR ships its own consumer ProGuard rules, which keep the full agent
+including Session Replay. ProGuard and R8 keep rules are **additive** — a rule
+supplied by a library cannot be overridden or narrowed from your app. To take
+control of them, tell AGP not to apply them.
+
+Add the `optimization` block to your minified build type in `app/build.gradle`:
+
+```groovy
+android {
+    buildTypes {
+        release {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                          'proguard-rules.pro'
+
+            optimization {
+                keepRules {
+                    // Option A: Ignore rules from specific libraries using 'group:artifact'
+                    ignoreExternalDependencies 'com.newrelic.agent.android:android-agent'
+
+                    // Option B: Ignore ALL external library proguard rules entirely
+                    // ignoreAllExternalDependencies true
+                }
+            }
+        }
+    }
+}
+```
+
+Notes:
+- Coordinates are `group:artifact` with **no version**.
+- Prefer Option A. Option B discards the bundled rules of *every* dependency in
+  your build, and you would need to replace all of them yourself.
+- Apply this to each minified build type you ship.
+- On AGP 8.10 and newer, `ignoreFrom(...)` and
+  `ignoreFromAllExternalDependencies(...)` are accepted as aliases.
+  `ignoreExternalDependencies` works on all supported versions.
+
+Kotlin DSL (`app/build.gradle.kts`):
+
+```kotlin
+release {
+    isMinifyEnabled = true
+    optimization {
+        keepRules {
+            ignoreExternalDependencies("com.newrelic.agent.android:android-agent")
+            // ignoreAllExternalDependencies(true)
+        }
+    }
+}
+```
+
+---
+
+## Step 2 — Add the New Relic rules to `proguard-rules.pro`
+
+Because Step 1 discarded the agent's bundled rules, your app must now supply
+them. Copy this block **in full** into `app/proguard-rules.pro`.
+
+```proguard
+# =============================================================================
+# New Relic Android agent — ProGuard/R8 rules
+# Configured to remove Session Replay from the build.
+# =============================================================================
+
+# Keep the agent, with two exclusions:
+#   - the sessionReplay package, so it can be removed
+#   - two store classes that live outside that package but implement its
+#     interfaces; keeping them would hold the package in place
+-keep class !com.newrelic.agent.android.sessionReplay.**,!com.newrelic.agent.android.stores.FileSessionReplayStore,!com.newrelic.agent.android.stores.FileOfflineSessionReplayStore, com.newrelic.agent.android.** { *; }
+-dontwarn com.newrelic.agent.android.**
+
+# Session Replay CONFIGURATION is still delivered and parsed even when the
+# feature's code is removed, and it is populated reflectively. These rules keep
+# what reflection requires: no-argument constructors and original field names.
+#
+# These must use -keepclassmembers. A "-keep class ... { *; }" rule here would
+# mark the configuration methods as entry points, which stops R8 from applying
+# the -assumevalues rule from Step 3 and silently disables the whole
+# optimization.
+#
+# The "$**" rules are required in addition to the plain ones: a rule naming a
+# class does not cover its nested classes.
+-keepclassmembers class com.newrelic.agent.android.sessionReplay.SessionReplayConfiguration {
+    <fields>;
+    <init>();
+}
+-keepclassmembers class com.newrelic.agent.android.sessionReplay.SessionReplayConfiguration$** {
+    <fields>;
+    <init>();
+}
+-keepclassmembers class com.newrelic.agent.android.sessionReplay.MobileSessionReplayConfiguration {
+    <fields>;
+    <init>();
+}
+-keepclassmembers class com.newrelic.agent.android.sessionReplay.MobileSessionReplayConfiguration$** {
+    <fields>;
+    <init>();
+}
+-keepclassmembers class com.newrelic.agent.android.sessionReplay.SessionReplayLocalConfiguration {
+    <fields>;
+    <init>();
+}
+
+# Enum values are matched by constant name during configuration parsing.
+-keepclassmembers enum com.newrelic.agent.android.sessionReplay.TextMaskingStrategy {
+    <fields>;
+}
+
+-keep class com.newrelic.agent.android.sessionReplay.SessionReplayStore { *; }
+
+# Required by the New Relic Gradle plugin
+-keepattributes Exceptions, Signature, InnerClasses, LineNumberTable, SourceFile, EnclosingMethod
+-keepattributes *Annotation*
+-keep class com.newrelic.com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.newrelic.com.google.gson.reflect.TypeToken
+
+# Network libraries instrumented by the agent
+-keep class org.apache.http.** { *; }
+-keep interface org.apache.http.** { *; }
+-keep class com.squareup.okhttp.** { *; }
+-keep interface com.squareup.okhttp.** { *; }
+-keep class okhttp3.** { *; }
+-keep interface okhttp3.** { *; }
+-keep class retrofit2.** { *; }
+-keep interface retrofit2.** { *; }
+-keep class com.google.gson.** { *; }
+-keep interface com.google.gson.** { *; }
+```
+
+On its own, this block does not remove anything — it replaces the agent's bundled
+rules and makes Session Replay *eligible* for removal. Step 3 is what actually
+triggers it.
+
+### React Native apps
+
+If your app uses React Native, also add:
+
+```proguard
+-keep class com.facebook.react.uimanager.drawable.CSSBackgroundDrawable {
+    int mColor;
+}
+-keep class com.facebook.react.views.view.ReactViewBackgroundDrawable {
+    int mColor;
+}
+-keep class com.facebook.react.uimanager.drawable.BackgroundDrawable {
+    int backgroundColor;
+}
+-keep class com.facebook.react.uimanager.drawable.CompositeBackgroundDrawable {
+    android.graphics.drawable.Drawable background;
+}
+```
+
+---
+
+## Step 3 — Add the `-assumevalues` rule
+
+This is the rule that performs the removal. Add it to `app/proguard-rules.pro`,
+alongside the block from Step 2:
+
+```proguard
+# Declares at build time that Session Replay is off, which is what allows R8 to
+# remove it. Without this rule the agent's internal checks read runtime
+# configuration, which R8 cannot evaluate at build time, so it must assume the
+# feature may be used and keeps all Session Replay code.
+#
+# Both methods must be listed — different call sites use each one, and omitting
+# either leaves those call sites in the build.
+-assumevalues class com.newrelic.agent.android.sessionReplay.SessionReplayConfiguration {
+    boolean isEnabled() return false;
+    boolean isSessionReplayEnabled() return false;
+}
+```
+
+Why this cannot be inferred automatically: Session Replay is normally controlled
+by configuration delivered from New Relic while your app is running. R8 runs at
+build time and has no way to know what that configuration will contain, so it
+keeps the code. This rule is you telling R8, at build time, that the answer will
+always be "off" for this build.
+
+> **Important:** this rule must not be combined with a
+> `-keep class ... SessionReplayConfiguration { *; }` rule. A `-keep` rule marks
+> those methods as entry points, and R8 does not apply `-assumevalues` to methods
+> that are kept — the optimization would be silently cancelled. The Step 2 rules
+> use `-keepclassmembers` specifically to avoid this.
+
+### Keeping Session Replay instead
+
+To build a variant that *does* include Session Replay, remove this Step 3 rule
+only. Steps 1 and 2 can stay exactly as they are.
+
+---
+
+## Step 4 — Verify
+
+Temporarily add this rule and rebuild your minified variant:
+
+```proguard
+-whyareyoukeeping class com.newrelic.agent.android.sessionReplay.SessionReplayReporter
+```
+
+- **No output for that class** — it was removed. The configuration is working.
+- **A retention path is printed** — read it. It names the rule or call chain that
+  is holding Session Replay in your build, which is the problem to fix.
+
+To measure the saving, compare the total size of `classes*.dex` inside the APK
+with and without the `-assumevalues` block. `-printusage <file>` will also list
+the removed `com.newrelic.agent.android.sessionReplay` classes.
+
+Remove the `-whyareyoukeeping` rule when you are done.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Nothing is removed | The `-assumevalues` rule is missing. The agent's internal checks read runtime configuration, which R8 cannot evaluate on its own. | Add the Step 3 rule — it is what performs the removal |
+| Nothing is removed | A blanket `-keep class com.newrelic.** { *; }` exists in your app, in another library, or in a DexGuard configuration. It keeps the code *and* marks the configuration methods as entry points, which cancels `-assumevalues`. Keep rules are additive and cannot be overridden. | Remove that rule. Older New Relic setup guidance recommended it; it is incompatible with this optimization |
+| Nothing is removed | Step 1 was skipped, so the agent's bundled rules still apply and keep the whole package | Add the `optimization { keepRules { ... } }` block |
+| `RuntimeException: Unable to invoke no-args constructor for ...SessionReplayConfiguration$a` while the agent parses configuration | The Session Replay configuration classes lost the constructor reflection needs. A rule naming a class does not cover its nested classes. | Include the `$**` `-keepclassmembers` rules from Step 2 |
+| Text masking settings appear to be ignored | `TextMaskingStrategy` enum constants were renamed | Include the enum rule from Step 2 |
+| Works in debug, fails only in release | R8 does not run on debug builds | Always test the minified variant |
+
+If some Session Replay code remains in the APK, the build is still correct — R8
+never leaves a broken program. A partial result means fewer bytes saved, not a
+stability risk, so it is safe to investigate at your own pace.
+
+---
+
+## What changes at runtime
+
+- No replays are captured or uploaded. Enabling Session Replay in the New Relic
+  UI has **no effect** on a build compiled this way; it must be rebuilt without
+  the `-assumevalues` block.
+- Session Replay configuration is still received in the harvest response and
+  parsed, then ignored. This is why the configuration classes must remain
+  reflection-readable.
+- Replay data already cached on the device from an earlier build is not uploaded
+  and not deleted. It ages out through the cache's normal size limit.
+- All other agent functionality is unaffected: crash reporting, handled
+  exceptions, network monitoring, interaction traces, events, logging, and
+  distributed tracing continue to work normally.

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.debug.obsoleteApi=true
 android.useAndroidX=true
 
 # Version of the SDK to be built and deployed
-newrelic.agent.version = 7.8.2
+newrelic.agent.version = 7.8.3-SNAPSHOT
 newrelic.agent.build = SNAPSHOT
 newrelic.agent.snapshot=
 


### PR DESCRIPTION
🔗 Linked to JIRA ticket: [NR-587343](https://newrelic.atlassian.net/browse/NR-587343)

## Jira

[NR-587343](https://new-relic.atlassian.net/browse/NR-587343)

## What & Why

Apps that never use Session Replay currently ship the entire feature and disable it at runtime. This lets R8 remove it from the release APK instead — **approximately 80 KB** measured in a sample application.

Session Replay is normally controlled by configuration delivered from the backend at runtime, which R8 cannot evaluate at build time. So it must assume the feature may be used and keeps all of its code. This PR makes the feature *reachability-gated* so that a host app declaring "Session Replay is off" via `-assumevalues` causes R8 to dead-code-eliminate it.

Every cross-package reference into `sessionReplay` is now behind its existing config gate. The first commit covered the obvious call sites; the second closes the ones that always-on agent code still reached unconditionally, which were holding the whole package in place:

- **`PayloadController`** — `SessionReplayReporter.initialize()`/`start()` and `shutdown()`. The initialize path was the largest single anchor, transitively reaching the sender and capture pipeline.
- **`CrashReporter`** — removed the `CrashSessionReplayHandler` field and its unconditional constructor allocation, constructing it inside the existing gate instead. The pre-existing `isEnabled()` check ran *after* the object was already built, so both the field type and the eager allocation anchored the package regardless.
- **`AndroidAgentImpl`** — `setOfflineSessionReplayStore()` moved out of the constructor into the SR-enabled branch, alongside `setSessionReplayStore()`.

## Callouts

**The agent's consumer ProGuard rules intentionally remain a plain blanket keep.** An earlier iteration shipped the `sessionReplay` carve-out inside the AAR, which is unsafe as a default: it strips blanket protection from config classes that Gson populates *reflectively*, and without matching nested-class rules `Harvester.parseHarvesterConfiguration` throws at runtime (`Unable to invoke no-args constructor for ...SessionReplayConfiguration$a`) rather than failing the build. Apps opting in now discard the agent's bundled rules via AGP's `keepRules.ignoreExternalDependencies` and supply the narrowed set themselves.

**Two properties worth knowing when reviewing the gating:**

- Missing a gate costs bytes, never stability — R8 always emits a self-consistent program, so an ungated path just means the code is retained.
- The real hazard is reflection, which R8 cannot see. The agent contains no reflective loads of its own Session Replay classes by name (all `Class.forName` calls in that package point *outward* at Compose/React Native types), so the documented `-keepclassmembers` rules are sufficient.

**Behavior when stripped:** enabling Session Replay in the New Relic UI has no effect on such a build — it must be rebuilt without `-assumevalues`. Config is still received and parsed, then ignored. Previously cached offline replay payloads are neither uploaded nor deleted; they age out via the cache's existing FIFO cap.

`gradle.properties` bumps the SDK version to `7.8.3-SNAPSHOT`.

## Docs

`docs/Session-Replay-Tree-Shaking.md` — customer-facing guide, structured as three required steps (all are load-bearing; no partial configuration works). Covers the `optimization { keepRules { ... } }` block, the full replacement rule set, `-assumevalues`, verification via `-whyareyoukeeping`, and a troubleshooting table for the two silent-failure modes above.

## Test plan

Verified so far:

- `:agent:compileReleaseJavaWithJavac` and `:agent:compileReleaseKotlin` pass
- `publishToMavenLocal` produces an AAR carrying the expected consumer rules
- End-to-end on a real minified app (`minifyEnabled true`, AGP 8 / R8 full mode) following the documented three steps: **~80 KB APK reduction**

For reviewers:

1. Take an app with `minifyEnabled true` and apply the three steps in `docs/Session-Replay-Tree-Shaking.md`.
2. Confirm removal: add `-whyareyoukeeping class com.newrelic.agent.android.sessionReplay.SessionReplayReporter` — it should report no retention path.
3. Compare `classes*.dex` totals with and without the `-assumevalues` block.
4. **Regression check with Session Replay enabled** — build *without* `-assumevalues` and confirm replays are still captured and uploaded, and that crash-associated replay data still works (exercises the now-lazy `CrashSessionReplayHandler`).
5. Confirm harvest config parsing does not throw in a minified build, with and without the feature stripped.

[NR-587343]: https://new-relic.atlassian.net/browse/NR-587343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-587343]: https://new-relic.atlassian.net/browse/NR-587343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ