### PR TITLE
fix(session-replay): confine Curtains access to the main thread

### DIFF
--- a/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
+++ b/agent/src/main/java/com/newrelic/agent/android/sessionReplay/SessionReplay.java
@@ -314,7 +314,20 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
             persistSrState(true, true);
         }
 
+        // curtains.Curtains is a main-thread-only, non-thread-safe API (NR-608999): every
+        // access must happen inside this single post() so the calling thread never races
+        // the main thread on Curtains' internal LazyThreadSafetyMode.NONE delegate. The
+        // listener must be registered before the decorViews.length == 0 early return,
+        // otherwise cold start (no root view yet) never registers a listener at all.
         uiThreadHandler.post(() -> {
+            Curtains.getOnRootViewsChangedListeners().add((view, added) -> {
+                if (added) {
+                    viewDrawInterceptor.Intercept(new View[]{view});
+                } else {
+                    viewDrawInterceptor.removeIntercept(new View[]{view});
+                }
+            });
+
             View[] decorViews = Curtains.getRootViews().toArray(new View[0]);//WindowManagerSpy.windowManagerMViewsArray();
 
             // Check if decorViews is not empty before accessing
@@ -326,24 +339,17 @@ public class SessionReplay implements OnFrameTakenListener, HarvestLifecycleAwar
             viewDrawInterceptor.Intercept(decorViews);
             sessionReplayActivityLifecycleCallbacks.setupTouchInterceptorForWindow(decorViews[0]);
         });
-
-        Curtains.getOnRootViewsChangedListeners().add((view, added) -> {
-            if (added) {
-                viewDrawInterceptor.Intercept(new View[]{view});
-            } else {
-                viewDrawInterceptor.removeIntercept(new View[]{view});
-            }
-        });
     }
 
 
     public static void stopRecording() {
-        if(viewDrawInterceptor != null) {
-            uiThreadHandler.post(() -> {
+        // See NR-608999: Curtains access must stay confined to the main thread.
+        uiThreadHandler.post(() -> {
+            if (viewDrawInterceptor != null) {
                 viewDrawInterceptor.stopIntercept();
-            });
-        }
-        Curtains.getOnRootViewsChangedListeners().clear();
+            }
+            Curtains.getOnRootViewsChangedListeners().clear();
+        });
     }
 
     @Override

--- a/agent/src/test/java/com/newrelic/agent/android/sessionReplay/SessionReplayCurtainsThreadingTest.java
+++ b/agent/src/test/java/com/newrelic/agent/android/sessionReplay/SessionReplayCurtainsThreadingTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026. New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.agent.android.sessionReplay;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowLooper;
+
+import java.lang.reflect.Field;
+
+import curtains.Curtains;
+import curtains.OnRootViewsChangedListener;
+
+/**
+ * Regression test for NR-608999: SessionReplay.startRecording()/stopRecording() used to
+ * touch curtains.Curtains from both the main thread (via a posted Runnable) and the
+ * caller's thread (via a synchronous call), racing on Curtains' internal
+ * LazyThreadSafetyMode.NONE delegate and crashing with an NPE from
+ * kotlin.UnsafeLazyImpl.getValue.
+ *
+ * These tests exercise the real (non-mocked) Curtains API from a background thread while
+ * the main Looper is paused, asserting that no Curtains mutation is visible until the
+ * paused main Looper is explicitly idled - i.e. that all Curtains access is confined to
+ * the main thread.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class SessionReplayCurtainsThreadingTest {
+
+    private ShadowLooper shadowLooper;
+    private OnRootViewsChangedListener marker;
+
+    @Before
+    public void setUp() throws Exception {
+        shadowLooper = Shadows.shadowOf(Looper.getMainLooper());
+        shadowLooper.pause();
+
+        setStaticField("uiThreadHandler", new Handler(Looper.getMainLooper()));
+        setStaticField("viewDrawInterceptor", null);
+
+        // Pre-warm Curtains' lazy on the main (test) thread first, same as the app-side
+        // workaround described in NR-608999, so the assertions below aren't themselves
+        // racing Curtains' one-time initialization.
+        marker = (view, added) -> { };
+        Curtains.getOnRootViewsChangedListeners().add(marker);
+        Curtains.getOnRootViewsChangedListeners().remove(marker);
+    }
+
+    @After
+    public void tearDown() {
+        Curtains.getOnRootViewsChangedListeners().clear();
+    }
+
+    @Test
+    public void stopRecording_clearsCurtainsListenersOnlyAfterMainThreadRuns() throws Exception {
+        Curtains.getOnRootViewsChangedListeners().add(marker);
+        Assert.assertEquals(1, Curtains.getOnRootViewsChangedListeners().size());
+
+        Thread backgroundCaller = new Thread(SessionReplay::stopRecording);
+        backgroundCaller.start();
+        backgroundCaller.join();
+
+        Assert.assertEquals(
+                "stopRecording() must not clear Curtains listeners on the caller's thread; "
+                        + "the clear() must be deferred to the main thread",
+                1, Curtains.getOnRootViewsChangedListeners().size());
+
+        shadowLooper.idle();
+
+        Assert.assertEquals(
+                "once the main thread processes the deferred work, listeners must be cleared",
+                0, Curtains.getOnRootViewsChangedListeners().size());
+    }
+
+    @Test
+    public void startRecording_registersCurtainsListenerOnlyAfterMainThreadRuns() throws Exception {
+        Assert.assertEquals(0, Curtains.getOnRootViewsChangedListeners().size());
+
+        Thread backgroundCaller = new Thread(() -> SessionReplay.startRecording(SessionReplayMode.ERROR));
+        backgroundCaller.start();
+        backgroundCaller.join();
+
+        Assert.assertEquals(
+                "startRecording() must not register the Curtains listener on the caller's thread; "
+                        + "the add() must be deferred to the main thread",
+                0, Curtains.getOnRootViewsChangedListeners().size());
+
+        shadowLooper.idle();
+
+        Assert.assertEquals(
+                "once the main thread processes the deferred work, the listener must be registered",
+                1, Curtains.getOnRootViewsChangedListeners().size());
+    }
+
+    private static void setStaticField(String name, Object value) throws Exception {
+        Field field = SessionReplay.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+}


### PR DESCRIPTION
## Jira
[NR-608999](https://new-relic.atlassian.net/browse/NR-608999)

## What & Why
`SessionReplay.startRecording()`/`stopRecording()` touched `curtains.Curtains` from two different threads at once:
- `startRecording()` posted `Curtains.getRootViews()` to the main thread via `uiThreadHandler.post{}`, but called `Curtains.getOnRootViewsChangedListeners().add(...)` synchronously on the caller's thread.
- `stopRecording()` had the same shape: `viewDrawInterceptor.stopIntercept()` was posted to the main thread, but `Curtains.getOnRootViewsChangedListeners().clear()` ran on the caller's thread immediately.

Both `getRootViews()` and `getOnRootViewsChangedListeners()` resolve the same `rootViewsSpy` delegate inside Curtains, which uses `LazyThreadSafetyMode.NONE` (compiles to `kotlin.UnsafeLazyImpl`, whose internal fields are not volatile). When `startRecording()` runs on an agent background thread (`NR_Harvester-1`, reached via `Harvester.execute()` → `AndroidAgentImpl` → `SessionReplay.startRecording()`), this two-thread access races on that lazy and crashes the host app with an NPE at `kotlin.UnsafeLazyImpl.getValue`. Curtains is a documented main-thread-only, non-thread-safe API.

## Fix
Fold every Curtains call into the existing `uiThreadHandler.post{}` block in both methods, so all access is confined to the main thread:
- `startRecording()`: listener registration moved inside the post block, ahead of the `decorViews.length == 0` early return (so cold start, with no root view yet, still registers the listener).
- `stopRecording()`: now unconditionally posts to the main thread; the `viewDrawInterceptor != null` guard moved inside the runnable so `Curtains.getOnRootViewsChangedListeners().clear()` always runs on the main thread.

## Callouts
- No callers depend on the previous synchronous listener add/clear behavior (checked all internal call sites in `SessionReplay.java` and `AndroidAgentImpl.java`).
- `startRecording()`/`stopRecording()` had zero prior unit test coverage.

## Test plan
- [Diff](https://github.com/newrelic/newrelic-android-agent/pull/new/NR-608999-curtains-threading-race)
- Added `SessionReplayCurtainsThreadingTest`: calls `startRecording()`/`stopRecording()` from a real background thread against a paused Robolectric main `Looper`, and asserts Curtains' listener list is unchanged immediately after the call returns, only mutating once the paused `Looper` is idled — i.e. all Curtains access is confined to the main thread. Against the pre-fix code this assertion fails (listener mutates immediately on the background thread).

[NR-608999]: https://new-relic.atlassian.net/browse/NR-608999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ